### PR TITLE
fix(security): redact secrets from configuration logs

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -54,6 +54,7 @@ var (
 		DefaultValue:   "",
 		PossibleValues: []string{"algorithm:pass1|pass2|pass3"},
 		Validator:      ValidatePasswordsOrEmpty,
+		Sensitive:      true,
 	}
 
 	UserHeaderName = EnvVariable{
@@ -103,6 +104,7 @@ var (
 		DefaultValue:   "",
 		PossibleValues: []string{"*"},
 		Validator:      ValidateAny,
+		Sensitive:      true,
 	}
 
 	WardenEnabled = EnvVariable{
@@ -137,6 +139,7 @@ var (
 		DefaultValue:   "",
 		PossibleValues: []string{"*"},
 		Validator:      ValidateAny,
+		Sensitive:      true,
 	}
 
 	HeraldURL = EnvVariable{
@@ -153,6 +156,7 @@ var (
 		DefaultValue:   "",
 		PossibleValues: []string{"*"},
 		Validator:      ValidateAny,
+		Sensitive:      true,
 	}
 
 	HeraldEnabled = EnvVariable{
@@ -169,6 +173,7 @@ var (
 		DefaultValue:   "",
 		PossibleValues: []string{"*"},
 		Validator:      ValidateAny, // Empty value is also valid (means using API key instead)
+		Sensitive:      true,
 	}
 
 	HeraldTLSCACertFile = EnvVariable{
@@ -234,6 +239,7 @@ var (
 		DefaultValue:   "",
 		PossibleValues: []string{"*"},
 		Validator:      ValidateAny,
+		Sensitive:      true,
 	}
 
 	SessionStorageRedisDB = EnvVariable{
@@ -372,7 +378,11 @@ func Initialize(l *logger.Logger) error {
 
 		// Only log non-empty configuration items
 		if variable.Value != "" {
-			log.Info().Str("name", variable.Name).Str("value", variable.Value).Msg("Config loaded")
+			if variable.Sensitive {
+				log.Info().Str("name", variable.Name).Bool("configured", true).Msg("Config loaded")
+			} else {
+				log.Info().Str("name", variable.Name).Str("value", variable.Value).Msg("Config loaded")
+			}
 		}
 	}
 

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -25,6 +25,29 @@ func TestEnvVariable_String(t *testing.T) {
 	testza.AssertEqual(t, "test-value", v.String())
 }
 
+func TestEnvVariable_SafeValue_RedactsSensitiveValues(t *testing.T) {
+	v := EnvVariable{Value: "super-secret", Sensitive: true}
+	testza.AssertEqual(t, redactedValue, v.SafeValue())
+
+	v.Sensitive = false
+	testza.AssertEqual(t, "super-secret", v.SafeValue())
+}
+
+func TestEnvVariable_Validate_RedactsSensitiveInvalidValue(t *testing.T) {
+	t.Setenv("SECRET_CONFIG", "invalid-secret")
+	v := EnvVariable{
+		Name:           "SECRET_CONFIG",
+		Sensitive:      true,
+		PossibleValues: []string{"valid"},
+		Validator:      ValidateStrictPossibleValues,
+	}
+
+	err := v.Validate()
+	testza.AssertNotNil(t, err)
+	testza.AssertEqual(t, redactedValue, err.(*ValidationError).ProvidedValue)
+	testza.AssertNotContains(t, err.Error(), "invalid-secret")
+}
+
 func TestEnvVariable_ToDuration(t *testing.T) {
 	tests := []struct {
 		value    string

--- a/src/internal/config/validation.go
+++ b/src/internal/config/validation.go
@@ -18,6 +18,17 @@ type EnvVariable struct {
 	PossibleValues []string
 	Validator      func(v EnvVariable) bool
 	Trimmed        bool // If true, use env.GetTrimmed instead of env.Get
+	Sensitive      bool // If true, never expose the value in logs or validation errors
+}
+
+const redactedValue = "[REDACTED]"
+
+// SafeValue returns a representation suitable for logs and errors.
+func (v EnvVariable) SafeValue() string {
+	if v.Sensitive && v.Value != "" {
+		return redactedValue
+	}
+	return v.Value
 }
 
 func (v *EnvVariable) String() string {
@@ -53,7 +64,7 @@ func (v *EnvVariable) Validate() error {
 	}
 
 	if !v.Validator(*v) {
-		return NewValidationError(v.Name, v.Value, v.PossibleValues)
+		return NewValidationError(v.Name, v.SafeValue(), v.PossibleValues)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- mark password, API key, HMAC, OTP, and Redis password settings as sensitive
- log only whether a sensitive setting is configured, never its value
- redact sensitive values from validation errors
- add regression tests for log/error-safe representations
- include the checksum repair from #38 so this branch can pass CI before #38 merges

## Security impact

Stargate currently writes `PASSWORDS`, service API keys, HMAC secrets, the legacy OTP secret, and the Redis password to startup logs. This change removes those plaintext disclosures.

## Tests

- sensitive values return `[REDACTED]` for error-safe formatting
- validation errors do not contain the submitted secret

Depends on the small CI baseline fix in #38; the duplicated `go.sum` lines disappear automatically after #38 merges.