### PR TITLE
fix(security): authenticate proxy identity headers

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -123,6 +123,31 @@ var (
 		Validator:      ValidateCaseInsensitivePossibleValues,
 	}
 
+	HeaderAuthEnabled = EnvVariable{
+		Name:           "HEADER_AUTH_ENABLED",
+		Required:       false,
+		DefaultValue:   "false",
+		PossibleValues: []string{"true", "false"},
+		Validator:      ValidateCaseInsensitivePossibleValues,
+	}
+
+	HeaderAuthSharedSecret = EnvVariable{
+		Name:           "HEADER_AUTH_SHARED_SECRET",
+		Required:       false,
+		DefaultValue:   "",
+		PossibleValues: []string{"*"},
+		Validator:      ValidateAny,
+		Sensitive:      true,
+	}
+
+	HeaderAuthSecretHeader = EnvVariable{
+		Name:           "HEADER_AUTH_SECRET_HEADER",
+		Required:       false,
+		DefaultValue:   "X-Stargate-Header-Auth",
+		PossibleValues: []string{"*"},
+		Validator:      ValidateNotEmptyString,
+	}
+
 	WardenCacheTTL = EnvVariable{
 		Name:           "WARDEN_CACHE_TTL",
 		Required:       false,
@@ -376,7 +401,7 @@ func Initialize(l *logger.Logger) error {
 	}
 
 	// Then validate all other configuration variables
-	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &CookieDomain, &CallbackAllowedHosts, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenEnabled, &WardenCacheTTL, &WardenOTPEnabled, &WardenOTPSecretKey, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
+	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &CookieDomain, &CallbackAllowedHosts, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &WardenOTPEnabled, &WardenOTPSecretKey, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
 
 	for _, variable := range envVariables {
 		err := variable.Validate()
@@ -400,6 +425,15 @@ func Initialize(l *logger.Logger) error {
 	}
 	if StepUpEnabled.ToBool() && Passwords.Value == "" {
 		return NewValidationError(StepUpEnabled.Name, "requires PASSWORDS for re-authentication", StepUpEnabled.PossibleValues)
+	}
+
+	if HeaderAuthEnabled.ToBool() {
+		if !WardenEnabled.ToBool() {
+			return NewValidationError(HeaderAuthEnabled.Name, "requires WARDEN_ENABLED=true", HeaderAuthEnabled.PossibleValues)
+		}
+		if strings.TrimSpace(HeaderAuthSharedSecret.Value) == "" {
+			return NewValidationError(HeaderAuthSharedSecret.Name, i18n.TStatic("error.config_required_not_set"), HeaderAuthSharedSecret.PossibleValues)
+		}
 	}
 
 	// Log language setting

--- a/src/internal/handlers/check.go
+++ b/src/internal/handlers/check.go
@@ -2,14 +2,37 @@ package handlers
 
 import (
 	"context"
+	"crypto/subtle"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/session"
 	forwardauth "github.com/soulteary/forwardauth-kit"
+	"github.com/soulteary/stargate/src/internal/config"
 	"github.com/soulteary/stargate/src/internal/i18n"
 	"github.com/soulteary/tracing-kit"
 	"go.opentelemetry.io/otel/attribute"
 )
+
+func allowTrustedHeaderAuth(ctx *fiber.Ctx) bool {
+	if !config.HeaderAuthEnabled.ToBool() {
+		return false
+	}
+	expected := config.HeaderAuthSharedSecret.String()
+	provided := ctx.Get(config.HeaderAuthSecretHeader.String())
+	if expected == "" || len(expected) != len(provided) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(provided)) == 1
+}
+
+func sanitizeTrustedIdentityHeaders(ctx *fiber.Ctx) {
+	if !allowTrustedHeaderAuth(ctx) {
+		ctx.Request().Header.Del("X-User-Phone")
+		ctx.Request().Header.Del("X-User-Mail")
+	}
+	// The proxy credential is only for Stargate and must never be propagated.
+	ctx.Request().Header.Del(config.HeaderAuthSecretHeader.String())
+}
 
 // SessionStoreForCheck is the minimal interface required by CheckRoute to get session.
 // *session.Store implements it; tests can pass a mock to simulate store.Get failure.
@@ -38,6 +61,7 @@ func CheckRoute(store SessionStoreForCheck) func(c *fiber.Ctx) error {
 	}
 
 	return func(ctx *fiber.Ctx) error {
+		sanitizeTrustedIdentityHeaders(ctx)
 		// Get trace context from middleware
 		traceCtx := ctx.Locals("trace_context")
 		if traceCtx == nil {

--- a/src/internal/handlers/check_headers_test.go
+++ b/src/internal/handlers/check_headers_test.go
@@ -30,6 +30,51 @@ func setupCheckHeaderConfig(t *testing.T) {
 	InitForwardAuthHandler(testLogger)
 }
 
+func setTrustedHeaderAuthConfig(t *testing.T) {
+	t.Helper()
+	originalEnabled := config.HeaderAuthEnabled.Value
+	originalSecret := config.HeaderAuthSharedSecret.Value
+	originalHeader := config.HeaderAuthSecretHeader.Value
+	t.Cleanup(func() {
+		config.HeaderAuthEnabled.Value = originalEnabled
+		config.HeaderAuthSharedSecret.Value = originalSecret
+		config.HeaderAuthSecretHeader.Value = originalHeader
+	})
+	config.HeaderAuthEnabled.Value = "true"
+	config.HeaderAuthSharedSecret.Value = "trusted-proxy-secret"
+	config.HeaderAuthSecretHeader.Value = "X-Stargate-Header-Auth"
+}
+
+func TestSanitizeTrustedIdentityHeadersRejectsUnsignedHeaders(t *testing.T) {
+	setTrustedHeaderAuthConfig(t)
+
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{
+		"X-User-Phone": "13800138000",
+		"X-User-Mail":  "user@example.com",
+	}, "")
+	defer app.ReleaseCtx(ctx)
+
+	sanitizeTrustedIdentityHeaders(ctx)
+
+	testza.AssertEqual(t, "", ctx.Get("X-User-Phone"))
+	testza.AssertEqual(t, "", ctx.Get("X-User-Mail"))
+}
+
+func TestSanitizeTrustedIdentityHeadersAcceptsProxyCredential(t *testing.T) {
+	setTrustedHeaderAuthConfig(t)
+
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{
+		"X-User-Phone":           "13800138000",
+		"X-Stargate-Header-Auth": "trusted-proxy-secret",
+	}, "")
+	defer app.ReleaseCtx(ctx)
+
+	sanitizeTrustedIdentityHeaders(ctx)
+
+	testza.AssertEqual(t, "13800138000", ctx.Get("X-User-Phone"))
+	testza.AssertEqual(t, "", ctx.Get("X-Stargate-Header-Auth"))
+}
+
 func TestCheckRoute_SetsAuthHeadersFromSession(t *testing.T) {
 	setupCheckHeaderConfig(t)
 

--- a/src/internal/handlers/forwardauth.go
+++ b/src/internal/handlers/forwardauth.go
@@ -92,7 +92,7 @@ func InitForwardAuthHandler(l *logger.Logger) {
 		},
 
 		// Header-based authentication (Warden)
-		HeaderAuthEnabled:   config.WardenEnabled.ToBool(),
+		HeaderAuthEnabled:   config.HeaderAuthEnabled.ToBool(),
 		HeaderAuthUserPhone: "X-User-Phone",
 		HeaderAuthUserMail:  "X-User-Mail",
 		HeaderAuthCheckFunc: func(phone, mail string) bool {

--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -165,6 +165,12 @@ func TestCheckRoute_HeaderAuth_Invalid(t *testing.T) {
 	testza.AssertEqual(t, fiber.StatusUnauthorized, ctx.Response().StatusCode())
 }
 
+func enableTrustedHeaderAuth(t *testing.T) {
+	t.Helper()
+	t.Setenv("HEADER_AUTH_ENABLED", "true")
+	t.Setenv("HEADER_AUTH_SHARED_SECRET", "trusted-proxy-secret")
+}
+
 func TestLoginAPI_ValidPassword(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
@@ -1572,6 +1578,7 @@ func TestLoginRoute_SessionStoreError(t *testing.T) {
 
 // TestCheckRoute_WardenAuth_ValidPhone tests Warden authentication with valid phone
 func TestCheckRoute_WardenAuth_ValidPhone(t *testing.T) {
+	enableTrustedHeaderAuth(t)
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("WARDEN_ENABLED", "true")
@@ -1649,7 +1656,8 @@ func TestCheckRoute_WardenAuth_ValidPhone(t *testing.T) {
 	handler := CheckRoute(store)
 
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
-		"X-User-Phone": "13800138000",
+		"X-User-Phone":           "13800138000",
+		"X-Stargate-Header-Auth": "trusted-proxy-secret",
 	}, "")
 	defer app.ReleaseCtx(ctx)
 
@@ -1664,6 +1672,7 @@ func TestCheckRoute_WardenAuth_ValidPhone(t *testing.T) {
 
 // TestCheckRoute_WardenAuth_ValidMail tests Warden authentication with valid email
 func TestCheckRoute_WardenAuth_ValidMail(t *testing.T) {
+	enableTrustedHeaderAuth(t)
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("WARDEN_ENABLED", "true")
@@ -1747,7 +1756,8 @@ func TestCheckRoute_WardenAuth_ValidMail(t *testing.T) {
 	handler := CheckRoute(store)
 
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
-		"X-User-Mail": "user2@example.com",
+		"X-User-Mail":            "user2@example.com",
+		"X-Stargate-Header-Auth": "trusted-proxy-secret",
 	}, "")
 	defer app.ReleaseCtx(ctx)
 
@@ -1762,6 +1772,7 @@ func TestCheckRoute_WardenAuth_ValidMail(t *testing.T) {
 
 // TestCheckRoute_WardenAuth_InvalidUser tests Warden authentication with invalid user
 func TestCheckRoute_WardenAuth_InvalidUser(t *testing.T) {
+	enableTrustedHeaderAuth(t)
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("WARDEN_ENABLED", "true")
@@ -1817,7 +1828,8 @@ func TestCheckRoute_WardenAuth_InvalidUser(t *testing.T) {
 	handler := CheckRoute(store)
 
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
-		"X-User-Phone": "99999999999", // Not in list
+		"X-User-Phone":           "99999999999", // Not in list
+		"X-Stargate-Header-Auth": "trusted-proxy-secret",
 	}, "")
 	defer app.ReleaseCtx(ctx)
 
@@ -1832,6 +1844,7 @@ func TestCheckRoute_WardenAuth_InvalidUser(t *testing.T) {
 
 // TestCheckRoute_WardenAuth_EmptyHeaders tests Warden authentication with empty headers
 func TestCheckRoute_WardenAuth_EmptyHeaders(t *testing.T) {
+	enableTrustedHeaderAuth(t)
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("WARDEN_ENABLED", "true")
@@ -1858,6 +1871,7 @@ func TestCheckRoute_WardenAuth_EmptyHeaders(t *testing.T) {
 
 // TestCheckRoute_WardenAuth_WithBothHeaders tests Warden authentication with both phone and mail headers
 func TestCheckRoute_WardenAuth_WithBothHeaders(t *testing.T) {
+	enableTrustedHeaderAuth(t)
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("WARDEN_ENABLED", "true")
@@ -1941,8 +1955,9 @@ func TestCheckRoute_WardenAuth_WithBothHeaders(t *testing.T) {
 	handler := CheckRoute(store)
 
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
-		"X-User-Phone": "13800138000",
-		"X-User-Mail":  "user1@example.com",
+		"X-User-Phone":           "13800138000",
+		"X-User-Mail":            "user1@example.com",
+		"X-Stargate-Header-Auth": "trusted-proxy-secret",
 	}, "")
 	defer app.ReleaseCtx(ctx)
 
@@ -1957,6 +1972,7 @@ func TestCheckRoute_WardenAuth_WithBothHeaders(t *testing.T) {
 
 // TestCheckRoute_WardenAuth_WithCustomUserHeader tests Warden authentication with custom user header name
 func TestCheckRoute_WardenAuth_WithCustomUserHeader(t *testing.T) {
+	enableTrustedHeaderAuth(t)
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("WARDEN_ENABLED", "true")
@@ -2026,7 +2042,8 @@ func TestCheckRoute_WardenAuth_WithCustomUserHeader(t *testing.T) {
 	handler := CheckRoute(store)
 
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
-		"X-User-Phone": "13800138000",
+		"X-User-Phone":           "13800138000",
+		"X-Stargate-Header-Auth": "trusted-proxy-secret",
 	}, "")
 	defer app.ReleaseCtx(ctx)
 


### PR DESCRIPTION
## Summary

- disable Warden header authentication by default instead of enabling it implicitly
- require an explicit `HEADER_AUTH_ENABLED=true` opt-in and a shared proxy credential
- compare the proxy credential in constant time
- strip unsigned identity headers and remove the proxy credential before request processing continues
- add regression tests for signed and unsigned header assertions

## Security impact

Previously, any client able to reach `/_auth` could send `X-User-Phone` or `X-User-Mail` and be authenticated when that identity existed in Warden. This change only accepts those headers when a trusted reverse proxy supplies the configured credential.

The reverse proxy must remove client-supplied `X-User-Phone`, `X-User-Mail`, and the configured secret header before injecting its own values.

## Validation

- `git diff --check`
- targeted regression tests added
- full Go CI will run in GitHub Actions (the local environment does not include Go)

## Dependency note

This branch includes the two missing `go.yaml.in/yaml/v3` checksums from #38 so CI can run before that baseline fix merges.