### PR TITLE
fix(ci): isolate pull requests from persistent runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master, develop ]
 
+permissions:
+  contents: read
+
 env:
   DOCKER_BUILDKIT: 1
 
@@ -13,7 +16,7 @@ jobs:
   # 代码格式检查
   fmt:
     name: 代码格式检查
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: 检出代码
         uses: actions/checkout@v6
@@ -34,7 +37,7 @@ jobs:
   # 代码静态检查
   vet:
     name: 代码静态检查
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: 检出代码
         uses: actions/checkout@v6
@@ -63,7 +66,7 @@ jobs:
   # 代码测试
   test:
     name: 代码测试
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: 检出代码
         uses: actions/checkout@v6
@@ -131,7 +134,7 @@ jobs:
   # 代码质量检查（使用 golangci-lint）
   lint:
     name: 代码质量检查
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: 检出代码
         uses: actions/checkout@v6
@@ -151,7 +154,7 @@ jobs:
   # 依赖项安全扫描
   security-scan:
     name: 依赖项安全扫描
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: 检出代码
         uses: actions/checkout@v6
@@ -183,7 +186,7 @@ jobs:
   # 完整构建检查
   build:
     name: 构建检查
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: 检出代码
         uses: actions/checkout@v6
@@ -241,7 +244,7 @@ jobs:
   # Docker 构建
   docker-build:
     name: Docker 构建
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [test]
     steps:
       - name: 检出代码

--- a/go.sum
+++ b/go.sum
@@ -586,6 +586,8 @@ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9i
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
## Summary

- run every CI job on ephemeral GitHub-hosted runners
- give the workflow read-only repository permissions
- keep push and pull-request validation behavior otherwise unchanged

## Security impact

The repository accepts public pull requests. Running attacker-controlled workflow code on a persistent self-hosted runner can expose runner state, credentials, network access, and later jobs. Ephemeral hosted runners remove that persistence boundary from PR validation.

## Validation

- verified all seven jobs use `ubuntu-latest`
- `git diff --check`

## Dependency note

This branch includes the missing YAML v3 checksums from #38 so the workflow can reach its actual checks before that PR merges.