### PR TITLE
fix(security): allowlist post-login callback hosts

### DIFF
--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -53,6 +53,7 @@ Below are all environment variables used in code. "Required" means the service w
 | `LOGIN_PAGE_FOOTER_TEXT` | String | Copyright © 2024 - Stargate | No |
 | `USER_HEADER_NAME` | String | X-Forwarded-User | No |
 | `COOKIE_DOMAIN` | String | empty | No |
+| `CALLBACK_ALLOWED_HOSTS` | comma-separated hosts | empty | No |
 | `LANGUAGE` | en, zh, fr, it, ja, de, ko | en | No |
 | `PORT` | String | empty (:80) | No |
 | `WARDEN_ENABLED` | true/false | false | No |
@@ -301,6 +302,16 @@ After setting `COOKIE_DOMAIN=.example.com`:
 - **Session expiration**: Fixed to 24 hours in code; there is no `SESSION_TTL` (or similar) env variable.
 - **Cookie Secure**: Set from request protocol (e.g. `X-Forwarded-Proto: https`); there is no `COOKIE_SECURE` env variable.
 - **Cookie SameSite**: Fixed to `Lax`; there is no `COOKIE_SAME_SITE` env variable.
+
+### `CALLBACK_ALLOWED_HOSTS`
+
+Comma-separated allowlist of exact hosts that may receive a post-login callback. Ports, when used, must be listed explicitly. Subdomains covered by `COOKIE_DOMAIN` are also allowed.
+
+```bash
+CALLBACK_ALLOWED_HOSTS=app.example.com,admin.example.com
+```
+
+Stargate rejects callback hosts outside this list with HTTP 400. Do not add domains that can be registered or controlled by untrusted users.
 
 ### `PORT`
 

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -53,6 +53,7 @@ services:
 | `LOGIN_PAGE_FOOTER_TEXT` | String | Copyright © 2024 - Stargate | 否 |
 | `USER_HEADER_NAME` | String | X-Forwarded-User | 否 |
 | `COOKIE_DOMAIN` | String | 空 | 否 |
+| `CALLBACK_ALLOWED_HOSTS` | 逗号分隔的主机名 | 空 | 否 |
 | `LANGUAGE` | en, zh, fr, it, ja, de, ko | en | 否 |
 | `PORT` | String | 空（:80） | 否 |
 | `WARDEN_ENABLED` | true/false | false | 否 |
@@ -301,6 +302,16 @@ COOKIE_DOMAIN=.example.com
 - **会话过期时间**：由代码内常量固定为 24 小时，暂无 `SESSION_TTL` 等环境变量可配置。
 - **Cookie Secure**：根据请求协议（如 `X-Forwarded-Proto: https`）自动设置，暂无 `COOKIE_SECURE` 环境变量。
 - **Cookie SameSite**：固定为 `Lax`，暂无 `COOKIE_SAME_SITE` 环境变量。
+
+### `CALLBACK_ALLOWED_HOSTS`
+
+允许接收登录后回调的精确主机名列表，使用逗号分隔。若使用端口，必须在列表中显式写出。`COOKIE_DOMAIN` 覆盖的子域名也会被允许。
+
+```bash
+CALLBACK_ALLOWED_HOSTS=app.example.com,admin.example.com
+```
+
+不在允许列表中的回调主机会收到 HTTP 400。不要加入可能由不可信用户注册或控制的域名。
 
 ### `PORT`
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -72,6 +72,14 @@ var (
 		Validator:      ValidateAny, // Empty value is also valid (means not setting domain)
 	}
 
+	CallbackAllowedHosts = EnvVariable{
+		Name:           "CALLBACK_ALLOWED_HOSTS",
+		Required:       false,
+		DefaultValue:   "",
+		PossibleValues: []string{"app.example.com,admin.example.com"},
+		Validator:      ValidateAny,
+	}
+
 	Language = EnvVariable{
 		Name:           "LANGUAGE",
 		Required:       false,
@@ -362,7 +370,7 @@ func Initialize(l *logger.Logger) error {
 	}
 
 	// Then validate all other configuration variables
-	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &CookieDomain, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenEnabled, &WardenCacheTTL, &WardenOTPEnabled, &WardenOTPSecretKey, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
+	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &CookieDomain, &CallbackAllowedHosts, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenEnabled, &WardenCacheTTL, &WardenOTPEnabled, &WardenOTPSecretKey, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
 
 	for _, variable := range envVariables {
 		err := variable.Validate()

--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -26,6 +26,7 @@ func TestMain(m *testing.M) {
 	// Set up required environment variables for config
 	_ = os.Setenv("AUTH_HOST", "auth.example.com")
 	_ = os.Setenv("PASSWORDS", "plaintext:test123")
+	_ = os.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com,test.example.com,cookie.example.com,form.example.com,query.example.com")
 
 	// Initialize config and ForwardAuth handler
 	testLog := testLogger()
@@ -492,6 +493,24 @@ func TestLoginRoute_WithCallback(t *testing.T) {
 	err = handler(ctx)
 	// We just verify the handler doesn't panic
 	_ = err
+}
+
+func TestLoginRoute_RejectsUntrustedCallback(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com")
+	err := config.Initialize(testLogger())
+	testza.AssertNoError(t, err)
+
+	store := setupTestStore()
+	handler := LoginRoute(store)
+	ctx, app := createTestContext("GET", "/_login?callback=evil.example.net", nil, "")
+	defer app.ReleaseCtx(ctx)
+
+	err = handler(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusBadRequest, ctx.Response().StatusCode())
+	testza.AssertEqual(t, "", string(ctx.Response().Header.Peek("Location")))
 }
 
 func TestLoginRoute_WithoutCallback(t *testing.T) {

--- a/src/internal/handlers/login.go
+++ b/src/internal/handlers/login.go
@@ -572,6 +572,12 @@ func loginAPIHandler(ctx *fiber.Ctx, sessionGetter SessionGetter, authenticator 
 			callback = originHost
 		}
 	}
+	if callback != "" {
+		callback, err = ValidateCallbackHost(callback)
+		if err != nil {
+			return SendErrorResponse(ctx, fiber.StatusBadRequest, "invalid callback host")
+		}
+	}
 
 	// If callback exists, redirect to session exchange endpoint
 	if callback != "" {
@@ -686,6 +692,13 @@ func loginRouteHandler(ctx *fiber.Ctx, sessionGetter SessionGetter) error {
 		// If URL has callback parameter, update cookie (if domain is different)
 		SetCallbackCookie(ctx, callback)
 	}
+	if callback != "" {
+		canonical, err := ValidateCallbackHost(callback)
+		if err != nil {
+			return SendErrorResponse(ctx, fiber.StatusBadRequest, "invalid callback host")
+		}
+		callback = canonical
+	}
 
 	sess, err := sessionGetter.Get(ctx)
 	if err != nil {
@@ -709,7 +722,7 @@ func loginRouteHandler(ctx *fiber.Ctx, sessionGetter SessionGetter) error {
 			return ctx.Redirect(redirectURL)
 		}
 		// When no callback, redirect to current host's root path
-		host := GetForwardedHost(ctx)
+		host := config.AuthHost.String()
 		redirectURL := fmt.Sprintf("%s://%s/", proto, host)
 		return ctx.Redirect(redirectURL)
 	}

--- a/src/internal/handlers/utils.go
+++ b/src/internal/handlers/utils.go
@@ -9,6 +9,8 @@ package handlers
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -48,11 +50,14 @@ func GetForwardedURI(ctx *fiber.Ctx) string {
 // This is useful for determining whether the original request was HTTP or HTTPS
 // when behind a reverse proxy.
 func GetForwardedProto(ctx *fiber.Ctx) string {
-	forwardedProto := ctx.Get("X-Forwarded-Proto")
-	if forwardedProto != "" {
+	forwardedProto := strings.ToLower(strings.TrimSpace(strings.Split(ctx.Get("X-Forwarded-Proto"), ",")[0]))
+	if forwardedProto == "http" || forwardedProto == "https" {
 		return forwardedProto
 	}
-	return ctx.Protocol()
+	if strings.EqualFold(ctx.Protocol(), "https") {
+		return "https"
+	}
+	return "http"
 }
 
 // IsDifferentDomain checks if the origin host is different from the auth host.
@@ -70,11 +75,77 @@ func IsDifferentDomain(ctx *fiber.Ctx) bool {
 
 // normalizeHost removes port number from hostname for comparison.
 func normalizeHost(host string) string {
-	// If contains port number, only take the hostname part
-	if idx := strings.Index(host, ":"); idx != -1 {
-		return host[:idx]
+	parsed, err := parseCallbackHost(host)
+	if err != nil {
+		return ""
 	}
-	return host
+	return strings.ToLower(strings.TrimSuffix((&url.URL{Host: parsed}).Hostname(), "."))
+}
+
+func parseCallbackHost(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.ContainsAny(raw, "\\\r\n\t") {
+		return "", fmt.Errorf("invalid callback host")
+	}
+
+	value := raw
+	if !strings.Contains(value, "://") {
+		value = "//" + value
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("invalid callback host")
+	}
+	if parsed.Scheme != "" && parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("invalid callback scheme")
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return "", fmt.Errorf("callback paths are not allowed")
+	}
+
+	hostname := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if hostname == "" || net.ParseIP(hostname) != nil {
+		return "", fmt.Errorf("callback host must be a DNS name")
+	}
+	if strings.Contains(parsed.Host, ":") {
+		if _, _, err := net.SplitHostPort(parsed.Host); err != nil {
+			return "", fmt.Errorf("invalid callback port")
+		}
+	}
+	return parsed.Host, nil
+}
+
+// ValidateCallbackHost returns a canonical callback host only when it is explicitly
+// allowed or belongs to the configured cookie domain.
+func ValidateCallbackHost(raw string) (string, error) {
+	host, err := parseCallbackHost(raw)
+	if err != nil {
+		return "", err
+	}
+	hostname := strings.ToLower(strings.TrimSuffix((&url.URL{Host: host}).Hostname(), "."))
+
+	authHost, err := parseCallbackHost(config.AuthHost.String())
+	if err == nil && strings.EqualFold(host, authHost) {
+		return host, nil
+	}
+
+	for _, allowed := range strings.Split(config.CallbackAllowedHosts.String(), ",") {
+		allowed = strings.TrimSpace(allowed)
+		if allowed == "" {
+			continue
+		}
+		canonical, parseErr := parseCallbackHost(allowed)
+		if parseErr == nil && strings.EqualFold(host, canonical) {
+			return host, nil
+		}
+	}
+
+	cookieDomain := strings.ToLower(strings.Trim(strings.TrimSpace(config.CookieDomain.String()), "."))
+	if cookieDomain != "" && (hostname == cookieDomain || strings.HasSuffix(hostname, "."+cookieDomain)) {
+		return host, nil
+	}
+
+	return "", fmt.Errorf("callback host is not allowed")
 }
 
 // SetCallbackCookie stores the origin host in a cookie if it's different from the auth host.
@@ -84,8 +155,11 @@ func SetCallbackCookie(ctx *fiber.Ctx, callbackHost string) {
 		return
 	}
 
-	// Normalize domain
-	callbackHost = normalizeHost(callbackHost)
+	// Never persist an untrusted redirect target.
+	callbackHost, err := ValidateCallbackHost(callbackHost)
+	if err != nil {
+		return
+	}
 	authHost := normalizeHost(config.AuthHost.String())
 
 	// Only set cookie if domains are different
@@ -141,11 +215,20 @@ func BuildCallbackURL(ctx *fiber.Ctx) string {
 	authHost := config.AuthHost.String()
 
 	// If origin domain is different from auth service domain, store origin domain in cookie
-	if IsDifferentDomain(ctx) {
+	if canonical, err := ValidateCallbackHost(callbackHost); err == nil && IsDifferentDomain(ctx) {
+		callbackHost = canonical
 		SetCallbackCookie(ctx, callbackHost)
+	} else if err != nil {
+		callbackHost = ""
 	}
 
-	return fmt.Sprintf("%s://%s/_login?callback=%s", proto, authHost, callbackHost)
+	loginURL := url.URL{Scheme: proto, Host: authHost, Path: "/_login"}
+	if callbackHost != "" {
+		query := loginURL.Query()
+		query.Set("callback", callbackHost)
+		loginURL.RawQuery = query.Encode()
+	}
+	return loginURL.String()
 }
 
 // IsHTMLRequest checks if the request accepts HTML responses.

--- a/src/internal/handlers/utils_test.go
+++ b/src/internal/handlers/utils_test.go
@@ -159,6 +159,47 @@ func TestBuildCallbackURL_WithoutHeaders(t *testing.T) {
 	testza.AssertEqual(t, expected, result)
 }
 
+func TestValidateCallbackHostRejectsOpenRedirects(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com")
+	err := config.Initialize(testLoggerUtils())
+	testza.AssertNoError(t, err)
+
+	for _, candidate := range []string{
+		"evil.example.net",
+		"app.example.com.evil.example.net",
+		"https://evil.example.net",
+		"user@app.example.com",
+		"app.example.com/redirect",
+		"app.example.com\\@evil.example.net",
+	} {
+		_, err := ValidateCallbackHost(candidate)
+		testza.AssertNotNil(t, err, candidate)
+	}
+
+	host, err := ValidateCallbackHost("app.example.com")
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, "app.example.com", host)
+}
+
+func TestBuildCallbackURLDropsUntrustedForwardedHost(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com")
+	err := config.Initialize(testLoggerUtils())
+	testza.AssertNoError(t, err)
+
+	ctx, app := createTestContextForUtils("GET", "/test", map[string]string{
+		"X-Forwarded-Host":  "evil.example.net",
+		"X-Forwarded-Proto": "https",
+	})
+	defer app.ReleaseCtx(ctx)
+
+	testza.AssertEqual(t, "https://auth.example.com/_login", BuildCallbackURL(ctx))
+	testza.AssertEqual(t, "", string(ctx.Response().Header.Peek("Set-Cookie")))
+}
+
 func TestIsHTMLRequest_EmptyAccept(t *testing.T) {
 	ctx, app := createTestContextForUtils("GET", "/test", nil)
 	defer app.ReleaseCtx(ctx)


### PR DESCRIPTION
## Summary

- add `CALLBACK_ALLOWED_HOSTS` as an exact, comma-separated callback allowlist
- also allow hosts covered by the configured `COOKIE_DOMAIN`
- canonicalize callback hosts and reject userinfo, paths, unsupported schemes, malformed ports, IP literals, control characters, and unlisted destinations
- validate callback values from query parameters, form data, cookies, and forwarded headers
- constrain forwarded protocols to HTTP or HTTPS
- stop using an untrusted forwarded host for the authenticated root redirect
- document the new setting in English and Chinese

## Security impact

This closes the post-login open redirect reachable through `callback`, the callback cookie, and `X-Forwarded-Host`. Invalid targets now receive HTTP 400 and are never persisted in the callback cookie.

## Validation

- regression tests cover untrusted domains and parser-confusion payloads
- `git diff --check`
- full Go CI will run in GitHub Actions

## Dependency note

Includes the missing YAML v3 checksums from #38 so CI can run independently.