### PR TITLE
fix(security): replace raw session exchange IDs with opaque tickets

### DIFF
--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -343,7 +343,7 @@ curl -b cookies.txt http://auth.example.com/_logout
 
 ### `GET /_session_exchange`
 
-Used for cross-domain session sharing. Sets the specified session ID cookie and redirects to the root path.
+Used for cross-domain session sharing. Redeems a short-lived encrypted ticket, verifies that its session is authenticated, sets the cookie, and redirects to the root path.
 
 This endpoint is primarily used to share authentication sessions across multiple domains/subdomains. After a user logs in on one domain, this endpoint can be used to set the session cookie on another domain.
 
@@ -351,7 +351,7 @@ This endpoint is primarily used to share authentication sessions across multiple
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `id` | String | Yes | Session ID to set |
+| `ticket` | String | Yes | Encrypted, audience-bound exchange ticket returned by login |
 
 #### Response
 
@@ -367,7 +367,8 @@ Set-Cookie: stargate_session_id=<session_id>; Path=/; HttpOnly; SameSite=Lax; Do
 
 | Status Code | Description | Response Body |
 |-------------|-------------|---------------|
-| `400 Bad Request` | Missing session ID | Error message |
+| `400 Bad Request` | Missing ticket | Error message |
+| `401 Unauthorized` | Invalid, expired, replayed, or misdirected ticket | Error message |
 
 #### Cookie Domain
 
@@ -376,14 +377,14 @@ If the `COOKIE_DOMAIN` environment variable is configured, the cookie will be se
 #### Example
 
 ```bash
-# Set session cookie (for cross-domain scenarios)
-curl "http://auth.example.com/_session_exchange?id=<session_id>"
+# Redeem the ticket returned by the login response
+curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 ```
 
 **Typical Usage Scenario:**
 
 1. User logs in at `auth.example.com`
-2. After successful login, redirects to `app.example.com/_session_exchange?id=<session_id>`
+2. After successful login, redirects to `app.example.com/_session_exchange?ticket=<opaque_ticket>`
 3. Session cookie is set to the `.example.com` domain (if `COOKIE_DOMAIN=.example.com` is configured)
 4. Redirects to `app.example.com/`
 5. User can use this session across all `*.example.com` subdomains

--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -54,6 +54,7 @@ Below are all environment variables used in code. "Required" means the service w
 | `USER_HEADER_NAME` | String | X-Forwarded-User | No |
 | `COOKIE_DOMAIN` | String | empty | No |
 | `CALLBACK_ALLOWED_HOSTS` | comma-separated hosts | empty | No |
+| `SESSION_EXCHANGE_SECRET` | Secret string (32+ chars) | empty | No |
 | `LANGUAGE` | en, zh, fr, it, ja, de, ko | en | No |
 | `PORT` | String | empty (:80) | No |
 | `WARDEN_ENABLED` | true/false | false | No |
@@ -310,6 +311,16 @@ CALLBACK_ALLOWED_HOSTS=app.example.com,admin.example.com
 ```
 
 Stargate rejects callback hosts outside this list with HTTP 400. Do not add domains that can be registered or controlled by untrusted users.
+
+### `SESSION_EXCHANGE_SECRET`
+
+Encryption key for short-lived session exchange tickets. Configure at least 32 random characters whenever callbacks use `/_session_exchange`, and use the same value on every Stargate replica.
+
+```bash
+SESSION_EXCHANGE_SECRET=<at-least-32-random-characters>
+```
+
+The value is never logged. Without it, session exchange requests fail closed.
 
 ### `PORT`
 

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -337,7 +337,7 @@ curl -b cookies.txt http://auth.example.com/_logout
 
 ### `GET /_session_exchange`
 
-用于跨域会话共享。设置指定会话 ID 的 Cookie 并重定向到根路径。
+用于跨域会话共享。端点会兑换短时加密票据，确认对应会话已认证，设置 Cookie 后重定向到根路径。
 
 此端点主要用于在多个域名/子域名之间共享认证会话。当用户在一个域名登录后，可以通过此端点将会话 Cookie 设置到另一个域名。
 
@@ -345,7 +345,7 @@ curl -b cookies.txt http://auth.example.com/_logout
 
 | 参数 | 类型 | 必需 | 说明 |
 |------|------|------|------|
-| `id` | String | 是 | 要设置的会话 ID |
+| `ticket` | String | 是 | 登录接口返回的加密、绑定目标域名的交换票据 |
 
 #### 响应
 
@@ -361,7 +361,8 @@ Set-Cookie: stargate_session_id=<session_id>; Path=/; HttpOnly; SameSite=Lax; Do
 
 | 状态码 | 说明 | 响应体 |
 |--------|------|--------|
-| `400 Bad Request` | 缺少会话 ID | 错误消息 |
+| `400 Bad Request` | 缺少票据 | 错误消息 |
+| `401 Unauthorized` | 票据无效、过期、已重放或目标域名不匹配 | 错误消息 |
 
 #### Cookie 域名
 
@@ -370,14 +371,14 @@ Set-Cookie: stargate_session_id=<session_id>; Path=/; HttpOnly; SameSite=Lax; Do
 #### 示例
 
 ```bash
-# 设置会话 Cookie（用于跨域场景）
-curl "http://auth.example.com/_session_exchange?id=<session_id>"
+# 兑换登录响应返回的票据
+curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 ```
 
 **典型使用场景：**
 
 1. 用户在 `auth.example.com` 登录
-2. 登录成功后，重定向到 `app.example.com/_session_exchange?id=<session_id>`
+2. 登录成功后，重定向到 `app.example.com/_session_exchange?ticket=<opaque_ticket>`
 3. 会话 Cookie 被设置到 `.example.com` 域名（如果配置了 `COOKIE_DOMAIN=.example.com`）
 4. 重定向到 `app.example.com/`
 5. 用户可以在所有 `*.example.com` 子域名下使用该会话

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -54,6 +54,7 @@ services:
 | `USER_HEADER_NAME` | String | X-Forwarded-User | 否 |
 | `COOKIE_DOMAIN` | String | 空 | 否 |
 | `CALLBACK_ALLOWED_HOSTS` | 逗号分隔的主机名 | 空 | 否 |
+| `SESSION_EXCHANGE_SECRET` | 密钥字符串（至少 32 字符） | 空 | 否 |
 | `LANGUAGE` | en, zh, fr, it, ja, de, ko | en | 否 |
 | `PORT` | String | 空（:80） | 否 |
 | `WARDEN_ENABLED` | true/false | false | 否 |
@@ -310,6 +311,16 @@ CALLBACK_ALLOWED_HOSTS=app.example.com,admin.example.com
 ```
 
 不在允许列表中的回调主机会收到 HTTP 400。不要加入可能由不可信用户注册或控制的域名。
+
+### `SESSION_EXCHANGE_SECRET`
+
+用于加密短时会话交换票据。回调需要使用 `/_session_exchange` 时，应配置至少 32 个随机字符；所有 Stargate 副本必须使用同一个值。
+
+```bash
+SESSION_EXCHANGE_SECRET=<至少-32-个随机字符>
+```
+
+该值不会写入日志。未配置时，会话交换会安全失败。
 
 ### `PORT`
 

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -204,7 +204,7 @@ func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *he
 	app.Get("/totp/revoke", handlers.TOTPRevokeRoute(store))
 	app.Post("/totp/revoke", sameOrigin, handlers.VerificationRateLimit(), handlers.TOTPRevokeConfirmAPI(store))
 	app.Post(RouteLogout, sameOrigin, handlers.LogoutRoute(store))
-	app.Get(RouteSessionExchange, handlers.SessionShareRoute())
+	app.Get(RouteSessionExchange, handlers.SessionShareRoute(store))
 	app.Get(RouteAuth, handlers.CheckRoute(store))
 	app.Get(RouteStepUp, handlers.StepUpRoute(store))
 	app.Post(RouteStepUp, handlers.StepUpAPI(store))

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -81,6 +81,15 @@ var (
 		Validator:      ValidateAny,
 	}
 
+	SessionExchangeSecret = EnvVariable{
+		Name:           "SESSION_EXCHANGE_SECRET",
+		Required:       false,
+		DefaultValue:   "",
+		PossibleValues: []string{"at least 32 random characters"},
+		Validator:      ValidateAny,
+		Sensitive:      true,
+	}
+
 	Language = EnvVariable{
 		Name:           "LANGUAGE",
 		Required:       false,
@@ -428,7 +437,7 @@ func Initialize(l *logger.Logger) error {
 	}
 
 	// Then validate all other configuration variables
-	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &CookieDomain, &CallbackAllowedHosts, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
+	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &CookieDomain, &CallbackAllowedHosts, &SessionExchangeSecret, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
 
 	for _, variable := range envVariables {
 		err := variable.Validate()
@@ -444,6 +453,10 @@ func Initialize(l *logger.Logger) error {
 				log.Info().Str("name", variable.Name).Str("value", variable.Value).Msg("Config loaded")
 			}
 		}
+	}
+
+	if SessionExchangeSecret.Value != "" && len(SessionExchangeSecret.Value) < 32 {
+		return NewValidationError(SessionExchangeSecret.Name, "must contain at least 32 characters", SessionExchangeSecret.PossibleValues)
 	}
 
 	// PASSWORDS is required when not using Warden (password-only mode). When WardenEnabled=true, pure Warden deployment may omit PASSWORDS.

--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -29,6 +29,7 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com,test.example.com,cookie.example.com,form.example.com,query.example.com")
 	_ = os.Setenv("WARDEN_URL", "http://warden.test")
 	_ = os.Setenv("HERALD_URL", "http://herald.test")
+	_ = os.Setenv("SESSION_EXCHANGE_SECRET", "test-session-exchange-secret-32-bytes")
 
 	// Initialize config and ForwardAuth handler
 	testLog := testLogger()
@@ -80,6 +81,16 @@ func createTestContext(method, path string, headers map[string]string, body stri
 	ctx.Locals("i18n-language", i18n.LangEN)
 
 	return ctx, app
+}
+
+func responseCookieValue(ctx *fiber.Ctx, name string) string {
+	for _, part := range strings.Split(string(ctx.Response().Header.Peek("Set-Cookie")), ";") {
+		key, value, found := strings.Cut(strings.TrimSpace(part), "=")
+		if found && key == name {
+			return value
+		}
+	}
+	return ""
 }
 
 func TestCheckRoute_Authenticated(t *testing.T) {
@@ -358,33 +369,43 @@ func TestIndexRoute_NotAuthenticated(t *testing.T) {
 	testza.AssertEqual(t, "Not authenticated", string(ctx.Response().Body()))
 }
 
-func TestSessionShareRoute_WithID(t *testing.T) {
-	handler := SessionShareRoute()
+func TestSessionShareRoute_WithTicket(t *testing.T) {
+	store := setupTestStore()
+	seedCtx, seedApp := createTestContext("GET", "/", map[string]string{"Host": "app.example.com"}, "")
+	sess, err := store.Get(seedCtx)
+	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	sessionID := responseCookieValue(seedCtx, auth.SessionCookieName)
+	testza.AssertNotEqual(t, "", sessionID)
+	ticket, err := createSessionExchangeTicket(sessionID, "app.example.com")
+	testza.AssertNoError(t, err)
+	seedApp.ReleaseCtx(seedCtx)
+
+	handler := SessionShareRoute(store)
+	ctx, app := createTestContext("GET", "/_session_exchange?ticket="+ticket, map[string]string{"Host": "app.example.com"}, "")
+	defer app.ReleaseCtx(ctx)
+
+	err = handler(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
+
+	cookies := ctx.Response().Header.Peek("Set-Cookie")
+	testza.AssertNotNil(t, cookies)
+	testza.AssertContains(t, string(cookies), auth.SessionCookieName)
+	testza.AssertContains(t, string(cookies), sessionID)
+}
+
+func TestSessionShareRoute_RejectsLegacyID(t *testing.T) {
+	store := setupTestStore()
+	handler := SessionShareRoute(store)
 
 	ctx, app := createTestContext("GET", "/_session_exchange?id=test-session-id", nil, "")
 	defer app.ReleaseCtx(ctx)
 
 	err := handler(ctx)
-	// Should redirect, but we can't easily test redirect in unit test
 	testza.AssertNoError(t, err)
-
-	// Check that cookie was set
-	cookies := ctx.Response().Header.Peek("Set-Cookie")
-	testza.AssertNotNil(t, cookies)
-	testza.AssertContains(t, string(cookies), auth.SessionCookieName)
-	testza.AssertContains(t, string(cookies), "test-session-id")
-}
-
-func TestSessionShareRoute_WithoutID(t *testing.T) {
-	handler := SessionShareRoute()
-
-	ctx, app := createTestContext("GET", "/_session_exchange", nil, "")
-	defer app.ReleaseCtx(ctx)
-
-	err := handler(ctx)
-	testza.AssertNoError(t, err)
-	// SessionShareRoute returns StatusBadRequest (400) for missing session ID
 	testza.AssertEqual(t, fiber.StatusBadRequest, ctx.Response().StatusCode())
+	testza.AssertEqual(t, "", string(ctx.Response().Header.Peek("Set-Cookie")))
 }
 
 // Note: Health check is now handled by health-kit in server.go
@@ -587,9 +608,19 @@ func TestSessionShareRoute_WithCookieDomain(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	handler := SessionShareRoute()
+	store := setupTestStore()
+	seedCtx, seedApp := createTestContext("GET", "/", nil, "")
+	sess, err := store.Get(seedCtx)
+	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	sessionID := responseCookieValue(seedCtx, auth.SessionCookieName)
+	testza.AssertNotEqual(t, "", sessionID)
+	ticket, err := createSessionExchangeTicket(sessionID, "app.example.com")
+	testza.AssertNoError(t, err)
+	seedApp.ReleaseCtx(seedCtx)
+	handler := SessionShareRoute(store)
 
-	ctx, app := createTestContext("GET", "/_session_exchange?id=test-session-id", nil, "")
+	ctx, app := createTestContext("GET", "/_session_exchange?ticket="+ticket, map[string]string{"Host": "app.example.com"}, "")
 	defer app.ReleaseCtx(ctx)
 
 	err = handler(ctx)
@@ -600,7 +631,7 @@ func TestSessionShareRoute_WithCookieDomain(t *testing.T) {
 	testza.AssertNotNil(t, cookies)
 	cookieStr := string(cookies)
 	testza.AssertContains(t, cookieStr, auth.SessionCookieName)
-	testza.AssertContains(t, cookieStr, "test-session-id")
+	testza.AssertContains(t, cookieStr, sessionID)
 	testza.AssertContains(t, cookieStr, ".example.com")
 }
 
@@ -611,9 +642,19 @@ func TestSessionShareRoute_WithoutCookieDomain(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	handler := SessionShareRoute()
+	store := setupTestStore()
+	seedCtx, seedApp := createTestContext("GET", "/", nil, "")
+	sess, err := store.Get(seedCtx)
+	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	sessionID := responseCookieValue(seedCtx, auth.SessionCookieName)
+	testza.AssertNotEqual(t, "", sessionID)
+	ticket, err := createSessionExchangeTicket(sessionID, "app.example.com")
+	testza.AssertNoError(t, err)
+	seedApp.ReleaseCtx(seedCtx)
+	handler := SessionShareRoute(store)
 
-	ctx, app := createTestContext("GET", "/_session_exchange?id=test-session-id", nil, "")
+	ctx, app := createTestContext("GET", "/_session_exchange?ticket="+ticket, map[string]string{"Host": "app.example.com"}, "")
 	defer app.ReleaseCtx(ctx)
 
 	err = handler(ctx)
@@ -624,7 +665,7 @@ func TestSessionShareRoute_WithoutCookieDomain(t *testing.T) {
 	testza.AssertNotNil(t, cookies)
 	cookieStr := string(cookies)
 	testza.AssertContains(t, cookieStr, auth.SessionCookieName)
-	testza.AssertContains(t, cookieStr, "test-session-id")
+	testza.AssertContains(t, cookieStr, sessionID)
 }
 
 func TestCheckRoute_SetsUserHeader(t *testing.T) {
@@ -881,7 +922,7 @@ func TestLoginAPI_CallbackPriority(t *testing.T) {
 	testza.AssertNotContains(t, location, "query.example.com")
 }
 
-// TestLoginAPI_RedirectsToSessionExchange tests that redirect includes session ID
+// TestLoginAPI_RedirectsToSessionExchange tests that redirect uses an opaque ticket.
 func TestLoginAPI_RedirectsToSessionExchange(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
@@ -913,15 +954,41 @@ func TestLoginAPI_RedirectsToSessionExchange(t *testing.T) {
 	// Check redirect location format
 	location := string(ctx.Response().Header.Peek("Location"))
 	testza.AssertContains(t, location, "https://app.example.com/_session_exchange")
-	testza.AssertContains(t, location, "id=")
+	testza.AssertContains(t, location, "ticket=")
+	testza.AssertNotContains(t, location, "id=")
+}
 
-	// Extract session ID from location
-	// Location format: https://app.example.com/_session_exchange?id=<session_id>
-	sess, err := store.Get(ctx)
+func TestLoginAPIRotatesPreAuthenticationSession(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
-	sessionID := sess.ID()
-	testza.AssertNotNil(t, sessionID)
-	testza.AssertContains(t, location, sessionID)
+
+	store := setupTestStore()
+	handler := LoginAPI(store)
+	ctx, app := createTestContext("POST", "/_login", map[string]string{
+		"Content-Type":      "application/x-www-form-urlencoded",
+		"X-Forwarded-Host":  "app.example.com",
+		"X-Forwarded-Proto": "https",
+	}, "password=test123&callback=app.example.com")
+	defer app.ReleaseCtx(ctx)
+
+	preAuthSession, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	preAuthSession.Set("pre_auth", true)
+	testza.AssertNoError(t, preAuthSession.Save())
+	oldSessionID := responseCookieValue(ctx, auth.SessionCookieName)
+	testza.AssertNotEqual(t, "", oldSessionID)
+	ctx.Request().Header.SetCookie(auth.SessionCookieName, oldSessionID)
+
+	err = handler(ctx)
+	testza.AssertNoError(t, err)
+	location := string(ctx.Response().Header.Peek("Location"))
+	parts := strings.SplitN(location, "ticket=", 2)
+	testza.AssertEqual(t, 2, len(parts))
+	newSessionID, err := consumeSessionExchangeTicket(parts[1], "app.example.com")
+	testza.AssertNoError(t, err)
+	testza.AssertNotEqual(t, oldSessionID, newSessionID)
 }
 
 // TestLoginAPI_WithCallback_AcceptJSON_Returns200WithRedirect tests that when client sends
@@ -961,7 +1028,8 @@ func TestLoginAPI_WithCallback_AcceptJSON_Returns200WithRedirect(t *testing.T) {
 	testza.AssertNoError(t, err)
 	testza.AssertTrue(t, result.Success)
 	testza.AssertContains(t, result.Redirect, "app.example.com/_session_exchange")
-	testza.AssertContains(t, result.Redirect, "id=")
+	testza.AssertContains(t, result.Redirect, "ticket=")
+	testza.AssertNotContains(t, result.Redirect, "id=")
 }
 
 // TestLoginAPI_NoCallback_APIRequest tests that API request returns JSON when no callback
@@ -1313,6 +1381,9 @@ func TestLogoutRoute_AfterLogin(t *testing.T) {
 	testza.AssertNoError(t, err)
 
 	// Verify session is authenticated
+	sessionID := responseCookieValue(ctx1, auth.SessionCookieName)
+	testza.AssertNotEqual(t, "", sessionID)
+	ctx1.Request().Header.SetCookie(auth.SessionCookieName, sessionID)
 	sess, err := store.Get(ctx1)
 	testza.AssertNoError(t, err)
 	testza.AssertTrue(t, auth.IsAuthenticated(sess), "session should be authenticated after login")

--- a/src/internal/handlers/login.go
+++ b/src/internal/handlers/login.go
@@ -463,6 +463,9 @@ func loginAPIHandler(ctx *fiber.Ctx, sessionGetter SessionGetter, authenticator 
 	if err != nil {
 		return SendErrorResponse(ctx, fiber.StatusInternalServerError, i18n.T(ctx, "error.session_store_failed"))
 	}
+	if err := sess.Regenerate(); err != nil {
+		return SendErrorResponse(ctx, fiber.StatusInternalServerError, "failed to rotate session")
+	}
 
 	// Set user information to session for warden authentication before authenticating
 	if authMethod == "warden" {
@@ -605,7 +608,11 @@ func loginAPIHandler(ctx *fiber.Ctx, sessionGetter SessionGetter, authenticator 
 		if proto == "" {
 			proto = ctx.Protocol()
 		}
-		redirectURL := fmt.Sprintf("%s://%s/_session_exchange?id=%s", proto, callback, sessionID)
+		ticket, err := createSessionExchangeTicket(sessionID, callback)
+		if err != nil {
+			return SendErrorResponse(ctx, fiber.StatusInternalServerError, "session exchange is not configured")
+		}
+		redirectURL := fmt.Sprintf("%s://%s/_session_exchange?ticket=%s", proto, callback, ticket)
 		// When client accepts JSON (e.g. fetch with Accept: application/json), return 200 + redirect URL
 		// so the client can navigate; with redirect: 'manual', 302 Location is opaque and unreadable.
 		if strings.Contains(ctx.Get("Accept"), "application/json") {
@@ -645,10 +652,6 @@ func loginAPIHandler(ctx *fiber.Ctx, sessionGetter SessionGetter, authenticator 
 	response := fiber.Map{
 		"success": true,
 		"message": i18n.T(ctx, "success.login"),
-	}
-	// If session ID exists, add it to response
-	if sessionID := sess.ID(); sessionID != "" {
-		response["session_id"] = sessionID
 	}
 	return ctx.Status(fiber.StatusOK).JSON(response)
 }
@@ -706,7 +709,11 @@ func loginRouteHandler(ctx *fiber.Ctx, sessionGetter SessionGetter) error {
 		// If callback exists, redirect to callback's _session_exchange endpoint
 		// If no callback, redirect to current host's root path
 		if callback != "" {
-			redirectURL := fmt.Sprintf("%s://%s/_session_exchange?id=%s", proto, callback, sessionID)
+			ticket, err := createSessionExchangeTicket(sessionID, callback)
+			if err != nil {
+				return SendErrorResponse(ctx, fiber.StatusInternalServerError, "session exchange is not configured")
+			}
+			redirectURL := fmt.Sprintf("%s://%s/_session_exchange?ticket=%s", proto, callback, ticket)
 			return ctx.Redirect(redirectURL)
 		}
 		// When no callback, redirect to current host's root path

--- a/src/internal/handlers/session_exchange_token.go
+++ b/src/internal/handlers/session_exchange_token.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/soulteary/stargate/src/internal/config"
+)
+
+const sessionExchangeTicketTTL = 2 * time.Minute
+
+var consumedSessionExchangeTickets sync.Map
+
+type sessionExchangeClaims struct {
+	SessionID string `json:"sid"`
+	Audience  string `json:"aud"`
+	ExpiresAt int64  `json:"exp"`
+}
+
+func sessionExchangeAEAD() (cipher.AEAD, error) {
+	secret := config.SessionExchangeSecret.String()
+	if len(secret) < 32 {
+		return nil, errors.New("session exchange is not configured")
+	}
+	key := sha256.Sum256([]byte(secret))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func normalizeExchangeAudience(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.ContainsAny(raw, "\\\r\n\t") {
+		return ""
+	}
+	value := raw
+	if !strings.Contains(value, "://") {
+		value = "//" + value
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSuffix(parsed.Host, "."))
+}
+
+func createSessionExchangeTicket(sessionID, audience string) (string, error) {
+	audience = normalizeExchangeAudience(audience)
+	if sessionID == "" || audience == "" {
+		return "", errors.New("invalid session exchange claims")
+	}
+	aead, err := sessionExchangeAEAD()
+	if err != nil {
+		return "", err
+	}
+	claims, err := json.Marshal(sessionExchangeClaims{
+		SessionID: sessionID,
+		Audience:  audience,
+		ExpiresAt: time.Now().Add(sessionExchangeTicketTTL).Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := aead.Seal(nil, nonce, claims, nil)
+	return base64.RawURLEncoding.EncodeToString(append(nonce, sealed...)), nil
+}
+
+func consumeSessionExchangeTicket(token, audience string) (string, error) {
+	audience = normalizeExchangeAudience(audience)
+	if token == "" || audience == "" {
+		return "", errors.New("invalid session exchange ticket")
+	}
+	aead, err := sessionExchangeAEAD()
+	if err != nil {
+		return "", err
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(payload) <= aead.NonceSize() {
+		return "", errors.New("invalid session exchange ticket")
+	}
+	claimsJSON, err := aead.Open(nil, payload[:aead.NonceSize()], payload[aead.NonceSize():], nil)
+	if err != nil {
+		return "", errors.New("invalid session exchange ticket")
+	}
+	var claims sessionExchangeClaims
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
+		return "", errors.New("invalid session exchange ticket")
+	}
+	if claims.SessionID == "" || claims.Audience != audience || time.Now().Unix() > claims.ExpiresAt {
+		return "", errors.New("expired or misdirected session exchange ticket")
+	}
+
+	ticketHash := sha256.Sum256([]byte(token))
+	key := base64.RawURLEncoding.EncodeToString(ticketHash[:])
+	if _, loaded := consumedSessionExchangeTickets.LoadOrStore(key, struct{}{}); loaded {
+		return "", errors.New("session exchange ticket has already been used")
+	}
+	time.AfterFunc(sessionExchangeTicketTTL, func() {
+		consumedSessionExchangeTickets.Delete(key)
+	})
+	return claims.SessionID, nil
+}

--- a/src/internal/handlers/session_exchange_token_test.go
+++ b/src/internal/handlers/session_exchange_token_test.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MarvinJWendt/testza"
+	"github.com/soulteary/stargate/src/internal/config"
+)
+
+func setSessionExchangeSecret(t *testing.T) {
+	t.Helper()
+	original := config.SessionExchangeSecret.Value
+	t.Cleanup(func() { config.SessionExchangeSecret.Value = original })
+	config.SessionExchangeSecret.Value = "test-session-exchange-secret-32-bytes"
+}
+
+func TestSessionExchangeTicketIsOpaqueAndAudienceBound(t *testing.T) {
+	setSessionExchangeSecret(t)
+	ticket, err := createSessionExchangeTicket("sensitive-session-id", "app.example.com")
+	testza.AssertNoError(t, err)
+	testza.AssertFalse(t, strings.Contains(ticket, "sensitive-session-id"))
+
+	_, err = consumeSessionExchangeTicket(ticket, "other.example.com")
+	testza.AssertNotNil(t, err)
+
+	sessionID, err := consumeSessionExchangeTicket(ticket, "app.example.com")
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, "sensitive-session-id", sessionID)
+}
+
+func TestSessionExchangeTicketRejectsTamperingAndReplay(t *testing.T) {
+	setSessionExchangeSecret(t)
+	ticket, err := createSessionExchangeTicket("session-id", "app.example.com")
+	testza.AssertNoError(t, err)
+
+	_, err = consumeSessionExchangeTicket(ticket+"A", "app.example.com")
+	testza.AssertNotNil(t, err)
+
+	_, err = consumeSessionExchangeTicket(ticket, "app.example.com")
+	testza.AssertNoError(t, err)
+	_, err = consumeSessionExchangeTicket(ticket, "app.example.com")
+	testza.AssertNotNil(t, err)
+}

--- a/src/internal/handlers/session_share.go
+++ b/src/internal/handlers/session_share.go
@@ -2,8 +2,9 @@ package handlers
 
 import (
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/session"
 
-	session "github.com/soulteary/session-kit"
+	sessionkit "github.com/soulteary/session-kit"
 	"github.com/soulteary/stargate/src/internal/auth"
 	"github.com/soulteary/stargate/src/internal/config"
 	"github.com/soulteary/stargate/src/internal/i18n"
@@ -14,12 +15,12 @@ import (
 // This allows sessions to be shared across different domains/subdomains.
 //
 // Query parameters:
-//   - id: Session ID to set in the cookie
+//   - ticket: encrypted, short-lived, single-use session exchange ticket
 //
 // Returns a Fiber handler function.
-func SessionShareRoute() func(c *fiber.Ctx) error {
+func SessionShareRoute(store *session.Store) func(c *fiber.Ctx) error {
 	// Create session config for cookie creation
-	sessionConfig := session.DefaultConfig().
+	sessionConfig := sessionkit.DefaultConfig().
 		WithCookieName(auth.SessionCookieName).
 		WithExpiration(config.SessionExpiration).
 		WithCookieDomain(config.CookieDomain.Value).
@@ -27,13 +28,23 @@ func SessionShareRoute() func(c *fiber.Ctx) error {
 		WithHTTPOnly(true)
 
 	return func(ctx *fiber.Ctx) error {
-		sessionID := ctx.Query("id")
-		if sessionID == "" {
+		ticket := ctx.Query("ticket")
+		if ticket == "" {
 			return SendErrorResponse(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.missing_session_id"))
+		}
+		sessionID, err := consumeSessionExchangeTicket(ticket, GetForwardedHost(ctx))
+		if err != nil {
+			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "invalid session exchange ticket")
+		}
+
+		ctx.Request().Header.SetCookie(auth.SessionCookieName, sessionID)
+		sess, err := store.Get(ctx)
+		if err != nil || !auth.IsAuthenticated(sess) {
+			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "invalid session exchange ticket")
 		}
 
 		// Use session-kit's CreateCookie for consistent cookie creation
-		cookie := session.CreateCookie(sessionConfig, sessionID)
+		cookie := sessionkit.CreateCookie(sessionConfig, sessionID)
 		ctx.Cookie(cookie)
 
 		return ctx.Redirect("/")


### PR DESCRIPTION
## Summary

- rotate the Fiber session ID immediately after successful credential verification
- replace `/_session_exchange?id=<session-id>` with an AES-GCM encrypted ticket
- bind tickets to the destination host, expire them after two minutes, and reject local replay
- verify that the referenced server-side session is authenticated before setting a cookie
- reject the legacy raw-ID exchange parameter
- stop returning session IDs in JSON login responses
- add `SESSION_EXCHANGE_SECRET` with a 32-character minimum and redact it from logs
- update English and Chinese API/config documentation

## Security impact

Raw session IDs no longer appear in redirect URLs. A captured ticket does not reveal the session ID, cannot be redirected to a different host, has a short lifetime, and is single-use within a Stargate instance. Rotating the session on login prevents a pre-authentication session ID from surviving credential verification.

All replicas must use the same `SESSION_EXCHANGE_SECRET`. For strict cluster-wide replay prevention, deployments should keep the exchange request sticky during the two-minute ticket lifetime; a future shared replay store can remove that operational constraint.

## Validation

- regression tests cover opacity, tampering, audience binding, replay, authenticated-session lookup, legacy-ID rejection, and session rotation
- `git diff --check`
- full Go CI will run in GitHub Actions

## Dependency note

Includes the missing YAML v3 checksums from #38 so CI can run independently.