### PR TITLE
fix(auth): preserve password and bcrypt hash semantics

### DIFF
--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -143,8 +143,6 @@ PASSWORDS=plaintext:test123|admin456|user789
 # BCrypt hash
 PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
 
-# SHA512 hash
-PASSWORDS=sha512:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
 ```
 
 ## Optional Configuration
@@ -838,7 +836,7 @@ Refresh interval (Go duration, e.g. `5m`, `1h`).
 
 ## Password Configuration
 
-Stargate supports multiple password encryption algorithms. Password configuration format: `algorithm:password1|password2|password3`
+Stargate supports plaintext (development only) and bcrypt password verification. Password configuration format: `algorithm:password1|password2|password3`. Password bytes are case-sensitive and whitespace is significant.
 
 ### Supported Algorithms
 
@@ -879,51 +877,7 @@ go run -c 'golang.org/x/crypto/bcrypt' <<< 'password'
 PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
 ```
 
-#### `md5` - MD5 Hash
-
-**Description:**
-
-- Uses MD5 algorithm for hashing
-- Lower security, not recommended for production
-- Password must use MD5 hash value (32-character hexadecimal string)
-
-**Generate MD5 Hash:**
-
-```bash
-# Linux/macOS
-echo -n "password" | md5sum
-
-# Or use online tools
-```
-
-**Example:**
-
-```bash
-PASSWORDS=md5:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
-```
-
-#### `sha512` - SHA512 Hash
-
-**Description:**
-
-- Uses SHA512 algorithm for hashing
-- High security, recommended for production
-- Password must use SHA512 hash value (128-character hexadecimal string)
-
-**Generate SHA512 Hash:**
-
-```bash
-# Linux/macOS
-echo -n "password" | shasum -a 512
-
-# Or use online tools
-```
-
-**Example:**
-
-```bash
-PASSWORDS=sha512:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
-```
+MD5 and unsalted SHA-512 password hashes are rejected because they are fast, unsalted primitives and are not password hashing functions.
 
 ### Password Verification Rules
 
@@ -1164,7 +1118,7 @@ Error: Configuration error: invalid value for environment variable 'PASSWORDS': 
 ## Configuration Best Practices
 
 1. **Production Security**:
-   - Use `bcrypt` or `sha512` algorithms, avoid `plaintext`
+   - Use `bcrypt`; avoid `plaintext`
    - Set `DEBUG=false`
    - Use strong passwords (password authentication mode)
    - Or use Warden + Herald OTP authentication (recommended)

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -143,8 +143,6 @@ PASSWORDS=plaintext:test123|admin456|user789
 # BCrypt 哈希
 PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
 
-# SHA512 哈希
-PASSWORDS=sha512:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
 ```
 
 ## 可选配置
@@ -852,7 +850,7 @@ OTLP 采集端地址（如 Jaeger/OTLP Collector）。
 
 ## 密码配置
 
-Stargate 支持多种密码加密算法。密码配置格式为：`算法:密码1|密码2|密码3`
+Stargate 支持明文（仅开发环境）和 bcrypt 密码验证。配置格式为：`算法:密码1|密码2|密码3`。密码区分大小写，空白字符具有实际意义。
 
 ### 支持的算法
 
@@ -893,55 +891,11 @@ go run -c 'golang.org/x/crypto/bcrypt' <<< 'password'
 PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
 ```
 
-#### `md5` - MD5 哈希
-
-**说明：**
-
-- 使用 MD5 算法进行哈希
-- 安全性较低，不推荐用于生产环境
-- 密码必须使用 MD5 哈希值（32 位十六进制字符串）
-
-**生成 MD5 哈希：**
-
-```bash
-# Linux/macOS
-echo -n "password" | md5sum
-
-# 或使用在线工具
-```
-
-**示例：**
-
-```bash
-PASSWORDS=md5:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
-```
-
-#### `sha512` - SHA512 哈希
-
-**说明：**
-
-- 使用 SHA512 算法进行哈希
-- 安全性较高，推荐用于生产环境
-- 密码必须使用 SHA512 哈希值（128 位十六进制字符串）
-
-**生成 SHA512 哈希：**
-
-```bash
-# Linux/macOS
-echo -n "password" | shasum -a 512
-
-# 或使用在线工具
-```
-
-**示例：**
-
-```bash
-PASSWORDS=sha512:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
-```
+MD5 和未加盐 SHA-512 都是快速、无盐的通用哈希，并非密码哈希函数，因此配置时会被拒绝。
 
 ### 密码验证规则
 
-1. **密码规范化**：验证前会去除空格并转换为大写
+1. **精确匹配**：验证前不会移除空格或转换大小写
 2. **多密码支持**：可以配置多个密码，任一密码验证通过即可
 3. **算法一致性**：所有密码必须使用相同的算法
 
@@ -1178,7 +1132,7 @@ Error: Configuration error: invalid value for environment variable 'PASSWORDS': 
 ## 配置最佳实践
 
 1. **生产环境安全**：
-   - 使用 `bcrypt` 或 `sha512` 算法，避免使用 `plaintext`
+   - 使用 `bcrypt`，避免使用 `plaintext`
    - 设置 `DEBUG=false`
    - 使用强密码（密码认证模式）
    - 或使用 Warden + Herald OTP 认证（推荐）

--- a/src/internal/auth/auth.go
+++ b/src/internal/auth/auth.go
@@ -85,24 +85,18 @@ func GetValidPasswords() (string, []string) {
 		return "", []string{}
 	}
 
-	algorithm := parts[0]
+	algorithm := strings.ToLower(strings.TrimSpace(parts[0]))
 	passwordsStr := parts[1]
 	if passwordsStr == "" {
 		return algorithm, []string{}
 	}
 
-	passwords := strings.Split(passwordsStr, "|")
-	for k, v := range passwords {
-		normalized := strings.ToUpper(strings.TrimSpace(v))
-		normalized = strings.ReplaceAll(normalized, " ", "")
-		passwords[k] = normalized
-	}
-	return algorithm, passwords
+	return algorithm, strings.Split(passwordsStr, "|")
 }
 
 // CheckPassword validates a password against the configured valid passwords.
-// It normalizes the input password (uppercase, trim spaces) and checks it against
-// all configured passwords using the configured algorithm.
+// Passwords are opaque, case-sensitive byte strings. No whitespace or case
+// normalization is performed before verification.
 //
 // Parameters:
 //   - password: The password to check
@@ -122,11 +116,8 @@ func CheckPassword(password string) bool {
 		return false
 	}
 
-	tryToCheck := strings.ToUpper(strings.TrimSpace(password))
-	tryToCheck = strings.ReplaceAll(tryToCheck, " ", "")
-
 	for _, validPassword := range validPasswords {
-		if algorithmResolver.Check(validPassword, tryToCheck) {
+		if algorithmResolver.Check(validPassword, password) {
 			return true
 		}
 	}

--- a/src/internal/auth/auth_test.go
+++ b/src/internal/auth/auth_test.go
@@ -36,7 +36,7 @@ func TestGetValidPasswords(t *testing.T) {
 	testza.AssertNoError(t, err)
 
 	expectedAlgo := "plaintext"
-	expectedPasswords := []string{"PASS1", "PASS2", "PASS3"}
+	expectedPasswords := []string{"pass1", "pass2", "pass3"}
 
 	algorithm, passwords := GetValidPasswords()
 
@@ -52,7 +52,7 @@ func TestGetValidPasswords_WithSpaces(t *testing.T) {
 	testza.AssertNoError(t, err)
 
 	expectedAlgo := "plaintext"
-	expectedPasswords := []string{"PASS1", "PASS2", "PASS3"}
+	expectedPasswords := []string{" pass1 ", " pass2 ", " pass3 "}
 
 	algorithm, passwords := GetValidPasswords()
 
@@ -106,8 +106,8 @@ func TestCheckPassword_Plaintext_Success(t *testing.T) {
 
 	testza.AssertTrue(t, CheckPassword("test123"), "should accept valid password")
 	testza.AssertTrue(t, CheckPassword("test456"), "should accept valid password")
-	testza.AssertTrue(t, CheckPassword(" test123 "), "should trim spaces")
-	testza.AssertTrue(t, CheckPassword("TEST123"), "should be case insensitive")
+	testza.AssertFalse(t, CheckPassword(" test123 "), "surrounding spaces are significant")
+	testza.AssertFalse(t, CheckPassword("TEST123"), "passwords are case sensitive")
 }
 
 func TestCheckPassword_Plaintext_Failure(t *testing.T) {
@@ -123,23 +123,16 @@ func TestCheckPassword_Plaintext_Failure(t *testing.T) {
 
 func TestCheckPassword_Bcrypt(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
-	// Note: GetValidPasswords converts passwords to uppercase, which breaks bcrypt hashes
-	// This test documents the current behavior - bcrypt may not work correctly with current implementation
-	// The hash needs to be in the exact format expected by bcrypt
 	t.Setenv("PASSWORDS", "bcrypt:$2a$10$k8fBIpJInrE70BzYy5rO/OUSt1w2.IX0bWhiMdb2mJEhjheVHDhvK")
 
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	// The current implementation converts the hash to uppercase, which breaks bcrypt
-	// This is a known limitation - bcrypt hashes should not be case-converted
-	// For now, we test that the function doesn't panic
-	result := CheckPassword("Hello, World!")
-	_ = result // Accept that this may fail due to uppercase conversion issue
+	testza.AssertTrue(t, CheckPassword("Hello, World!"), "should preserve and verify bcrypt hashes")
 	testza.AssertFalse(t, CheckPassword("wrong"), "should reject invalid password")
 }
 
-func TestCheckPassword_MD5(t *testing.T) {
+func TestCheckPassword_MD5IsRejected(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	// Note: CheckPassword converts input to uppercase and removes spaces
 	// "test123" becomes "TEST123", so we use the MD5 hash of "TEST123"
@@ -149,15 +142,10 @@ func TestCheckPassword_MD5(t *testing.T) {
 	t.Setenv("PASSWORDS", "md5:22B75D6007E06F4A959D1B1D69B4C4BD")
 
 	err := config.Initialize(testLogger())
-	testza.AssertNoError(t, err)
-
-	// CheckPassword converts "test123" to "TEST123"
-	testza.AssertTrue(t, CheckPassword("test123"), "should accept valid MD5 password")
-	testza.AssertTrue(t, CheckPassword("TEST123"), "should accept valid MD5 password (uppercase)")
-	testza.AssertFalse(t, CheckPassword("wrong"), "should reject invalid password")
+	testza.AssertNotNil(t, err)
 }
 
-func TestCheckPassword_SHA512(t *testing.T) {
+func TestCheckPassword_SHA512IsRejected(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	// Note: CheckPassword converts input to uppercase and removes spaces
 	// "test123" becomes "TEST123", so we use the SHA512 hash of "TEST123"
@@ -167,12 +155,7 @@ func TestCheckPassword_SHA512(t *testing.T) {
 	t.Setenv("PASSWORDS", "sha512:79C377501595E6A0964F9531A661C1672BF3EF74798C130673B8D9E25DC1FD765B8EEE93F291A38518C9CA3B198AEDBEBD0A81E1B1C5780A60D9EB2F78209D81")
 
 	err := config.Initialize(testLogger())
-	testza.AssertNoError(t, err)
-
-	// CheckPassword converts "test123" to "TEST123"
-	testza.AssertTrue(t, CheckPassword("test123"), "should accept valid SHA512 password")
-	testza.AssertTrue(t, CheckPassword("TEST123"), "should accept valid SHA512 password (uppercase)")
-	testza.AssertFalse(t, CheckPassword("wrong"), "should reject invalid password")
+	testza.AssertNotNil(t, err)
 }
 
 func TestAuthenticate(t *testing.T) {
@@ -289,7 +272,7 @@ func TestGetValidPasswords_SinglePassword(t *testing.T) {
 	algorithm, passwords := GetValidPasswords()
 	testza.AssertEqual(t, "plaintext", algorithm)
 	testza.AssertEqual(t, 1, len(passwords))
-	testza.AssertEqual(t, "SINGLEPASS", passwords[0])
+	testza.AssertEqual(t, "singlepass", passwords[0])
 }
 
 func TestCheckPassword_EmptyAlgorithm(t *testing.T) {
@@ -304,18 +287,15 @@ func TestCheckPassword_EmptyAlgorithm(t *testing.T) {
 	}
 }
 
-func TestCheckPassword_UnsupportedAlgorithm(t *testing.T) {
-	// Note: This test requires modifying the config to have an unsupported algorithm
-	// Since validation prevents this, we'll test the CheckPassword logic with a mock scenario
+func TestCheckPassword_DoesNotNormalizeWhitespace(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	// Test with spaces that should be removed
-	result := CheckPassword(" test 123 ")
-	testza.AssertTrue(t, result, "should handle spaces correctly")
+	testza.AssertFalse(t, CheckPassword(" test 123 "), "whitespace must remain significant")
+	testza.AssertTrue(t, CheckPassword("test123"), "exact password should match")
 }
 
 func TestCheckPassword_EmptyPasswordList(t *testing.T) {
@@ -332,33 +312,26 @@ func TestCheckPassword_EmptyPasswordList(t *testing.T) {
 
 func TestCheckPassword_WithSpacesInPassword(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
-	// Note: GetValidPasswords converts "test 123" to "TEST 123" (uppercase, spaces kept in config)
-	// But CheckPassword removes spaces from input: "test 123" -> "TEST123"
-	// So we need to configure without spaces
-	t.Setenv("PASSWORDS", "plaintext:TEST123")
+	t.Setenv("PASSWORDS", "plaintext:test 123")
 
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	// CheckPassword converts "test123" to "TEST123" and removes spaces
-	// "test 123" becomes "TEST123" after conversion
-	result := CheckPassword("test123")
-	testza.AssertTrue(t, result, "should match password")
-	result = CheckPassword("test 123")
-	testza.AssertTrue(t, result, "should match password with spaces (spaces removed)")
+	testza.AssertFalse(t, CheckPassword("test123"), "spaces must not be removed")
+	testza.AssertTrue(t, CheckPassword("test 123"), "exact password should match")
 }
 
-func TestCheckPassword_CaseInsensitive(t *testing.T) {
+func TestCheckPassword_CaseSensitive(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:TestPassword")
 
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	testza.AssertTrue(t, CheckPassword("testpassword"), "should be case insensitive")
-	testza.AssertTrue(t, CheckPassword("TESTPASSWORD"), "should be case insensitive")
-	testza.AssertTrue(t, CheckPassword("TestPassword"), "should be case insensitive")
-	testza.AssertTrue(t, CheckPassword("TeStPaSsWoRd"), "should be case insensitive")
+	testza.AssertFalse(t, CheckPassword("testpassword"), "should be case sensitive")
+	testza.AssertFalse(t, CheckPassword("TESTPASSWORD"), "should be case sensitive")
+	testza.AssertTrue(t, CheckPassword("TestPassword"), "exact password should match")
+	testza.AssertFalse(t, CheckPassword("TeStPaSsWoRd"), "should be case sensitive")
 }
 
 func TestAuthenticate_MultipleTimes(t *testing.T) {

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -232,8 +232,8 @@ func TestValidatePasswords_Plaintext_Valid(t *testing.T) {
 		{"multiple passwords", "plaintext:pass1|pass2|pass3", true},
 		{"with spaces", "plaintext:pass1 | pass2", true},
 		{"bcrypt", "bcrypt:$2a$10$k8fBIpJInrE70BzYy5rO/OUSt1w2.IX0bWhiMdb2mJEhjheVHDhvK", true},
-		{"md5", "md5:65a8e27d8879283831b664bd8b7f0ad4", true},
-		{"sha512", "sha512:374d794a95cdcfd8b35993185fef9ba368f160d8daf432d08ba9f1ed1e5abe6cc69291e0fa2fe0006a52570ef18c19def4e617c33ce52ef0a6e5fbe318cb0387", true},
+		{"md5 is unsupported", "md5:65a8e27d8879283831b664bd8b7f0ad4", false},
+		{"sha512 is unsupported", "sha512:374d794a95cdcfd8b35993185fef9ba368f160d8daf432d08ba9f1ed1e5abe6cc69291e0fa2fe0006a52570ef18c19def4e617c33ce52ef0a6e5fbe318cb0387", false},
 	}
 
 	for _, tt := range tests {

--- a/src/internal/config/validation.go
+++ b/src/internal/config/validation.go
@@ -63,8 +63,6 @@ var (
 	SupportedAlgorithms = map[string]secure.HashResolver{
 		"plaintext": &secure.PlaintextResolver{},
 		"bcrypt":    &secure.BcryptResolver{},
-		"md5":       &secure.MD5Resolver{},
-		"sha512":    &secure.SHA512Resolver{},
 	}
 
 	ValidateNotEmptyString = func(v EnvVariable) bool {


### PR DESCRIPTION
## Summary

- treat configured and submitted passwords as opaque, case-sensitive byte strings
- stop removing whitespace or uppercasing passwords and bcrypt hashes
- make the existing bcrypt regression test require a successful verification
- reject MD5 and unsalted SHA-512 password configurations
- update English and Chinese security guidance to recommend bcrypt only

## Security impact

The previous normalization corrupted bcrypt hashes and silently reduced the password search space by making case and spaces insignificant. Fast unsalted hashes were also presented as production-safe. This restores standard password semantics and fails startup for the unsafe legacy algorithms.

## Validation

- regression tests cover bcrypt, case sensitivity, whitespace, and rejected legacy algorithms
- `git diff --check`
- full Go CI will run in GitHub Actions

Includes the checksum baseline from #38.