### PR TITLE
fix(auth): make step-up enforcement functional

### DIFF
--- a/src/cmd/stargate/constants.go
+++ b/src/cmd/stargate/constants.go
@@ -14,6 +14,8 @@ const (
 	RouteSessionExchange = "/_session_exchange"
 	// RouteAuth is the authentication check route
 	RouteAuth = "/_auth"
+	// RouteStepUp is the additional authentication route
+	RouteStepUp = "/_step_up"
 	// RouteHealth is the health check route
 	RouteHealth = "/health"
 

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -205,6 +205,8 @@ func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *he
 	app.Get(RouteLogout, handlers.LogoutRoute(store))
 	app.Get(RouteSessionExchange, handlers.SessionShareRoute())
 	app.Get(RouteAuth, handlers.CheckRoute(store))
+	app.Get(RouteStepUp, handlers.StepUpRoute(store))
+	app.Post(RouteStepUp, handlers.StepUpAPI(store))
 	// Prometheus metrics endpoint
 	app.Get("/metrics", metricskit.FiberHandlerFor(metrics.Registry))
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -380,6 +380,9 @@ func Initialize(l *logger.Logger) error {
 	if !WardenEnabled.ToBool() && Passwords.Value == "" {
 		return NewValidationError(Passwords.Name, i18n.TStatic("error.config_required_not_set"), Passwords.PossibleValues)
 	}
+	if StepUpEnabled.ToBool() && Passwords.Value == "" {
+		return NewValidationError(StepUpEnabled.Name, "requires PASSWORDS for re-authentication", StepUpEnabled.PossibleValues)
+	}
 
 	// Log language setting
 	if Language.Value != "" {

--- a/src/internal/handlers/check.go
+++ b/src/internal/handlers/check.go
@@ -63,6 +63,9 @@ func CheckRoute(store SessionStoreForCheck) func(c *fiber.Ctx) error {
 			tracing.RecordError(forwardAuthSpan, err)
 			return SendErrorResponse(ctx, fiber.StatusInternalServerError, i18n.T(ctx, "error.session_store_failed"))
 		}
+		if requiresStepUp(ctx, sess) {
+			return redirectToStepUp(ctx)
+		}
 
 		// Wrap Fiber context and session for forwardauth-kit
 		faCtx := forwardauth.NewFiberContext(ctx)

--- a/src/internal/handlers/forwardauth.go
+++ b/src/internal/handlers/forwardauth.go
@@ -115,7 +115,8 @@ func InitForwardAuthHandler(l *logger.Logger) {
 		},
 
 		// Step-up authentication
-		StepUpEnabled:    config.StepUpEnabled.ToBool(),
+		// Enforced by CheckRoute against X-Forwarded-Uri; the library only sees /_auth.
+		StepUpEnabled:    false,
 		StepUpPaths:      parseStepUpPaths(),
 		StepUpURL:        "/_step_up",
 		StepUpSessionKey: "step_up_verified",

--- a/src/internal/handlers/step_up.go
+++ b/src/internal/handlers/step_up.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"html"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/session"
+	"github.com/soulteary/stargate/src/internal/auth"
+	"github.com/soulteary/stargate/src/internal/config"
+)
+
+const stepUpValidity = 10 * time.Minute
+
+func stepUpVerified(sess *session.Session) bool {
+	verifiedAt, ok := sess.Get("step_up_verified_at").(int64)
+	age := time.Since(time.Unix(verifiedAt, 0))
+	return ok && age >= 0 && age <= stepUpValidity
+}
+
+func requiresStepUp(ctx *fiber.Ctx, sess *session.Session) bool {
+	if !config.StepUpEnabled.ToBool() || stepUpVerified(sess) {
+		return false
+	}
+	return config.GetStepUpMatcher().RequiresStepUp(GetForwardedURI(ctx))
+}
+
+func safeStepUpCallback(raw string) string {
+	if raw == "" || !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") {
+		return "/"
+	}
+	return raw
+}
+
+func redirectToStepUp(ctx *fiber.Ctx) error {
+	callback := safeStepUpCallback(GetForwardedURI(ctx))
+	return ctx.Redirect("/_step_up?callback=" + url.QueryEscape(callback))
+}
+
+func StepUpRoute(store *session.Store) func(c *fiber.Ctx) error {
+	return func(ctx *fiber.Ctx) error {
+		sess, err := store.Get(ctx)
+		if err != nil || !auth.IsAuthenticated(sess) {
+			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "authentication required")
+		}
+		callback := safeStepUpCallback(ctx.Query("callback"))
+		return ctx.Type("html").SendString(`<!doctype html><html><body><form method="post" action="/_step_up"><input type="password" name="password" autocomplete="current-password" required><input type="hidden" name="callback" value="` + html.EscapeString(callback) + `"><button type="submit">Verify</button></form></body></html>`)
+	}
+}
+
+func StepUpAPI(store *session.Store) func(c *fiber.Ctx) error {
+	return func(ctx *fiber.Ctx) error {
+		sess, err := store.Get(ctx)
+		if err != nil || !auth.IsAuthenticated(sess) {
+			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "authentication required")
+		}
+		if !auth.CheckPassword(ctx.FormValue("password")) {
+			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "additional authentication failed")
+		}
+		sess.Set("step_up_verified_at", time.Now().Unix())
+		if err := sess.Save(); err != nil {
+			return SendErrorResponse(ctx, fiber.StatusInternalServerError, "failed to save additional authentication")
+		}
+		return ctx.Redirect(safeStepUpCallback(ctx.FormValue("callback")))
+	}
+}

--- a/src/internal/handlers/step_up_test.go
+++ b/src/internal/handlers/step_up_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MarvinJWendt/testza"
+	"github.com/gofiber/fiber/v2"
+	"github.com/soulteary/stargate/src/internal/auth"
+	"github.com/soulteary/stargate/src/internal/config"
+)
+
+func setupStepUpTest(t *testing.T) {
+	t.Helper()
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("STEP_UP_ENABLED", "true")
+	t.Setenv("STEP_UP_PATHS", "/admin/*")
+	testza.AssertNoError(t, config.Initialize(testLogger()))
+}
+
+func TestRequiresStepUpUsesForwardedBusinessPath(t *testing.T) {
+	setupStepUpTest(t)
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{"X-Forwarded-Uri": "/admin/users"}, "")
+	defer app.ReleaseCtx(ctx)
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+
+	testza.AssertTrue(t, requiresStepUp(ctx, sess))
+	sess.Set("step_up_verified_at", time.Now().Unix())
+	testza.AssertFalse(t, requiresStepUp(ctx, sess))
+}
+
+func TestStepUpAPIRecordsRecentVerification(t *testing.T) {
+	setupStepUpTest(t)
+	store := setupTestStore()
+	ctx, app := createTestContext("POST", "/_step_up", map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}, "password=test123&callback=/admin/users")
+	defer app.ReleaseCtx(ctx)
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	ctx.Request().Header.SetCookie(auth.SessionCookieName, sess.ID())
+
+	err = StepUpAPI(store)(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
+	testza.AssertEqual(t, "/admin/users", string(ctx.Response().Header.Peek("Location")))
+	verifiedSession, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	verified, ok := verifiedSession.Get("step_up_verified_at").(int64)
+	testza.AssertTrue(t, ok)
+	testza.AssertTrue(t, verified > 0)
+}
+
+func TestSafeStepUpCallbackRejectsExternalURLs(t *testing.T) {
+	testza.AssertEqual(t, "/", safeStepUpCallback("https://evil.example"))
+	testza.AssertEqual(t, "/", safeStepUpCallback("//evil.example"))
+	testza.AssertEqual(t, "/admin", safeStepUpCallback("/admin"))
+}


### PR DESCRIPTION
## Summary

- match protected resources against `X-Forwarded-Uri` instead of the `/_auth` endpoint path
- add authenticated GET/POST `/_step_up` handlers
- verify the configured password again and record a time-limited verification timestamp
- accept only relative, same-origin callback paths
- require `PASSWORDS` when step-up is enabled
- disable the library-level matcher that cannot see the original resource path

## Security impact

Step-up configuration previously could not complete: no route set the session marker, and matching inspected the auth endpoint rather than the protected resource. Protected paths are now enforced and a successful re-authentication is valid for ten minutes.

## Validation

Regression tests cover forwarded-path matching, verification persistence, and callback safety. `git diff --check`; full Go CI will run in Actions.

Includes #38 checksum baseline.