### PR TITLE
fix(audit): emit configured audit records to stdout

### DIFF
--- a/src/cmd/stargate/main.go
+++ b/src/cmd/stargate/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/pterm/pterm/putils"
 	logger "github.com/soulteary/logger-kit"
+	"github.com/soulteary/stargate/src/internal/auditlog"
 	"github.com/soulteary/stargate/src/internal/auth"
 	"github.com/soulteary/stargate/src/internal/config"
 	"github.com/soulteary/tracing-kit"
@@ -34,6 +35,10 @@ func runApplication() error {
 	if err := initConfig(); err != nil {
 		return err
 	}
+	if err := auditlog.InitDefault(); err != nil {
+		return err
+	}
+	defer func() { _ = auditlog.Stop() }()
 
 	// Initialize OpenTelemetry tracing if enabled
 	if config.OTLPEnabled.ToBool() {

--- a/src/internal/auditlog/auditlog.go
+++ b/src/internal/auditlog/auditlog.go
@@ -2,6 +2,10 @@ package auditlog
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
 	"sync"
 
 	audit "github.com/soulteary/audit-kit"
@@ -24,24 +28,67 @@ func Init(storage audit.Storage, cfg *audit.Config) {
 		if config.AuditLogEnabled.Value != "" {
 			cfg.Enabled = config.AuditLogEnabled.ToBool()
 		}
-
 		if storage == nil {
-			// Use no-op storage if none provided
-			storage = audit.NewNoopStorage()
+			return
 		}
 
 		logger = audit.NewLoggerWithWriter(storage, cfg)
 	})
 }
 
+// InitDefault configures audit events to stdout. No-op logging is used only
+// when audit logging is explicitly disabled.
+func InitDefault() error {
+	cfg := audit.DefaultConfig()
+	cfg.Enabled = config.AuditLogEnabled.ToBool()
+	if !cfg.Enabled {
+		Init(audit.NewNoopStorage(), cfg)
+		return nil
+	}
+	format := config.AuditLogFormat.String()
+	if format != "json" && format != "text" {
+		return fmt.Errorf("unsupported audit log format %q", format)
+	}
+	Init(NewStreamStorage(os.Stdout, format), cfg)
+	return nil
+}
+
 // GetLogger returns the audit logger instance
 func GetLogger() *audit.Logger {
-	if logger == nil {
-		// Initialize with no-op storage if not initialized
-		Init(nil, nil)
-	}
 	return logger
 }
+
+type StreamStorage struct {
+	writer io.Writer
+	format string
+	mu     sync.Mutex
+}
+
+func NewStreamStorage(writer io.Writer, format string) *StreamStorage {
+	return &StreamStorage{writer: writer, format: format}
+}
+
+func (s *StreamStorage) Write(_ context.Context, record *audit.Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.format == "text" {
+		_, err := fmt.Fprintf(s.writer, "timestamp=%d event=%s result=%s user_id=%q ip=%q reason=%q metadata=%v\n",
+			record.Timestamp, record.EventType, record.Result, record.UserID, record.IP, record.Reason, record.Metadata)
+		return err
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(s.writer, string(data))
+	return err
+}
+
+func (s *StreamStorage) Query(context.Context, *audit.QueryFilter) ([]*audit.Record, error) {
+	return nil, fmt.Errorf("stream audit storage does not support queries")
+}
+
+func (s *StreamStorage) Close() error { return nil }
 
 // Stop stops the audit logger
 func Stop() error {

--- a/src/internal/auditlog/auditlog_test.go
+++ b/src/internal/auditlog/auditlog_test.go
@@ -1,6 +1,7 @@
 package auditlog
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"testing"
@@ -73,9 +74,22 @@ func TestGetLoggerWithoutInit(t *testing.T) {
 	logger = nil
 	loggerInit = sync.Once{}
 
-	// GetLogger should auto-initialize with no-op storage
 	l := GetLogger()
-	assert.NotNil(t, l)
+	assert.Nil(t, l)
+}
+
+func TestStreamStorageHonorsFormats(t *testing.T) {
+	record := audit.NewRecord(audit.EventLoginSuccess, audit.ResultSuccess)
+	record.UserID = "user1"
+
+	var jsonOutput bytes.Buffer
+	assert.NoError(t, NewStreamStorage(&jsonOutput, "json").Write(context.Background(), record))
+	assert.Contains(t, jsonOutput.String(), "\"event_type\"")
+
+	var textOutput bytes.Buffer
+	assert.NoError(t, NewStreamStorage(&textOutput, "text").Write(context.Background(), record))
+	assert.Contains(t, textOutput.String(), "event=")
+	assert.Contains(t, textOutput.String(), "user_id=\"user1\"")
 }
 
 func TestStop_WhenLoggerNil(t *testing.T) {


### PR DESCRIPTION
## Summary

- initialize audit logging during application startup
- emit audit records to stdout instead of silently selecting Noop storage
- honor `AUDIT_LOG_FORMAT=json|text`
- use Noop only when audit logging is explicitly disabled
- stop the async audit writer during shutdown
- return nil when callers access an uninitialized logger instead of silently discarding records

## Operational impact

Container log collectors can now persist and route authentication audit events. JSON remains the default; text provides a human-readable key/value stream.

## Validation

Tests cover JSON/text serialization and uninitialized behavior. `git diff --check`; full CI runs in Actions. Includes #38 checksum baseline.