### PR TITLE
fix(server): enforce timeouts and graceful shutdown

### DIFF
--- a/src/cmd/stargate/main.go
+++ b/src/cmd/stargate/main.go
@@ -55,6 +55,7 @@ func runApplication() error {
 	// Setup graceful shutdown for tracer
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
 
 	// Start server in a goroutine
 	serverErr := make(chan error, 1)
@@ -70,6 +71,9 @@ func runApplication() error {
 		}
 	case sig := <-sigChan:
 		log.Info().Str("signal", sig.String()).Msg("Received signal, shutting down gracefully...")
+		if err := app.ShutdownWithTimeout(10 * time.Second); err != nil {
+			log.Error().Err(err).Msg("Failed to shut down HTTP server cleanly")
+		}
 
 		// Shutdown tracer
 		if config.OTLPEnabled.ToBool() {

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -317,6 +317,10 @@ func createApp() *fiber.App {
 	app := fiber.New(fiber.Config{
 		Views:                 engine,
 		DisableStartupMessage: true,
+		BodyLimit:             1 * 1024 * 1024,
+		ReadTimeout:           10 * time.Second,
+		WriteTimeout:          15 * time.Second,
+		IdleTimeout:           60 * time.Second,
 	})
 
 	setupMiddleware(app)

--- a/src/cmd/stargate/server_test.go
+++ b/src/cmd/stargate/server_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/MarvinJWendt/testza"
 	"github.com/gofiber/fiber/v2"
@@ -349,6 +350,18 @@ func TestCreateApp_AllRoutesRegistered(t *testing.T) {
 			testza.AssertNotNil(t, resp)
 		})
 	}
+}
+
+func TestCreateApp_HasProductionLimits(t *testing.T) {
+	ensureTestWorkingDir(t)
+	setupTestConfig(t)
+	app := createApp()
+	cfg := app.Config()
+
+	testza.AssertEqual(t, 1*1024*1024, cfg.BodyLimit)
+	testza.AssertEqual(t, 10*time.Second, cfg.ReadTimeout)
+	testza.AssertEqual(t, 15*time.Second, cfg.WriteTimeout)
+	testza.AssertEqual(t, 60*time.Second, cfg.IdleTimeout)
 }
 
 func TestStartServer_PortLogic_DefaultPort(t *testing.T) {


### PR DESCRIPTION
## Summary

- cap request bodies at 1 MiB
- configure 10s read, 15s write, and 60s idle timeouts
- call Fiber `ShutdownWithTimeout` on SIGINT/SIGTERM before shutting down tracing
- stop signal notifications during cleanup
- add configuration regression tests

## Operational impact

Slow or oversized clients can no longer hold resources indefinitely, and termination stops accepting new connections while allowing in-flight requests up to ten seconds to complete.

`git diff --check`; full CI runs in Actions. Includes #38 checksum baseline.