### PR TITLE
fix(release): align image, tags, and runtime contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -125,27 +125,6 @@ jobs:
           files: |
             dist/*
           name: Release ${{ steps.version.outputs.tag }}
-          body: |
-            ## Changes
-            
-            See [CHANGELOG](CHANGELOG.md) for details.
-            
-            ## Downloads
-            
-            ### Docker Image
-            ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
-            ```
-            
-            ### Binaries
-            - Linux AMD64: `stargate-linux-amd64`
-            - Linux ARM64: `stargate-linux-arm64`
-            - macOS AMD64: `stargate-darwin-amd64`
-            - macOS ARM64: `stargate-darwin-arm64`
-            - Windows AMD64: `stargate-windows-amd64.exe`
-            - Windows ARM64: `stargate-windows-arm64.exe`
-            
-            ### Checksums
-            See `checksums.txt` for SHA256 checksums.
+          generate_release_notes: true
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,24 @@
 services:
   stargate: # Your Stargate forward auth service
-    image: stargate
-    # Local development port mapping: host port 8080 -> container port 80
+    image: ghcr.io/soulteary/stargate:latest
+    # Local development port mapping: host port 8080 -> container port 8080
     # Purpose: Direct access to service during local development without traefik
-    # Production: Uses port 80 via traefik proxy (not mapped to host)
+    # Production: Uses port 8080 via traefik proxy (not mapped to host)
     # Note: Uncomment the ports configuration below to enable local development port mapping
     # ports:
-    #   - "8080:80"
+    #   - "8080:8080"
     environment:
       - AUTH_HOST=auth.test.localhost # Replace with your auth host (e.g.: auth.example.com).
       - PASSWORDS=plaintext:test1234|test1337 # Replace with your passwords. See the docs for more info.
+      - PORT=8080
     networks:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`) # Replace auth.test.localhost with your auth host defined above.
-      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth
+      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   whoami: # A demo whoami service that is protected with Stargate
     image: traefik/whoami
@@ -25,7 +26,7 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.whoami.entrypoints=http
       - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
       - "traefik.http.routers.whoami.middlewares=stargate"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 ENV GO111MODULE=on
 COPY go.mod .
 COPY go.sum .
-RUN go mod tidy
+RUN go mod download
 
 COPY . .
 
@@ -28,7 +28,12 @@ RUN if command -v upx > /dev/null 2>&1; then \
 FROM alpine:3.23
 COPY --from=builder /app/stargate /bin/stargate
 COPY --from=builder /app/src/internal/web/templates /app/web/templates
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl && \
+    addgroup -S stargate && \
+    adduser -S -D -H -u 10001 -G stargate stargate && \
+    chown -R stargate:stargate /app
 WORKDIR /app
-EXPOSE 80
+ENV PORT=8080
+USER 10001:10001
+EXPOSE 8080
 CMD ["stargate"]

--- a/docker/Dockerfile.manual
+++ b/docker/Dockerfile.manual
@@ -28,7 +28,7 @@ ARG TARGETARCH
 RUN BUILD_DATE=${BUILD_DATE:-$(date +%FT%T%z)} && \
     ARCH=${TARGETARCH:-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/;s/armv7l/arm/')} && \
     OS=${TARGETOS:-linux} && \
-    GO111MODULE=on GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -ldflags "-w -s -X 'github.com/soulteary/stargate/src/cmd/stargate.Version=$VERSION'" -o stargate ./src/cmd/stargate
+    GO111MODULE=on GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -ldflags "-w -s -X 'github.com/soulteary/version-kit.Version=$VERSION' -X 'github.com/soulteary/version-kit.Commit=$COMMIT' -X 'github.com/soulteary/version-kit.BuildDate=$BUILD_DATE'" -o stargate ./src/cmd/stargate
 # upx 压缩（如果失败则跳过，确保多平台构建兼容性）
 RUN if command -v upx > /dev/null 2>&1; then \
       upx -9 -o stargate.minify stargate 2>/dev/null && mv stargate.minify stargate || true; \
@@ -40,8 +40,13 @@ COPY --from=Builder /app/src/internal/web/templates /app/web/templates
 ENV TZ=Asia/Shanghai
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories
 RUN apk add tzdata curl && \
+    addgroup -S stargate && \
+    adduser -S -D -H -u 10001 -G stargate stargate && \
     cp /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* && \
+    chown -R stargate:stargate /app
 WORKDIR /app
-EXPOSE 80
+ENV PORT=8080
+USER 10001:10001
+EXPOSE 8080
 CMD ["stargate"]


### PR DESCRIPTION
## Summary

- publish `latest` for stable version tags and mark hyphenated tags as prereleases
- use generated GitHub release notes instead of linking a nonexistent CHANGELOG
- run both production images as UID/GID 10001 on port 8080
- stop mutating module files with `go mod tidy` during image builds
- fix manual Docker version-kit ldflags
- point Compose at `ghcr.io/soulteary/stargate:latest`
- make Compose network labels and internal ports consistent

## Operational impact

The published image and sample Compose file now agree, releases expose correct version metadata, and the runtime no longer requires root.

Validated diffs; Docker build will run in Actions. Includes #38 checksum baseline.