### PR TITLE
fix(auth): expose upstream service authentication options

### DIFF
--- a/src/internal/auth/auth.go
+++ b/src/internal/auth/auth.go
@@ -3,6 +3,10 @@ package auth
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -167,6 +171,22 @@ func InitWardenClient(l *logger.Logger) {
 			WithAPIKey(config.WardenAPIKey.String()).
 			WithCacheTTL(cacheTTL)
 
+		if keyID, secret := config.WardenHMACKeyID.String(), config.WardenHMACSecret.String(); keyID != "" || secret != "" {
+			opts = opts.WithHMAC(keyID, secret)
+		}
+
+		tlsConfig, err := buildWardenTLSConfig(
+			config.WardenTLSCACertFile.String(), config.WardenTLSClientCert.String(),
+			config.WardenTLSClientKey.String(), config.WardenTLSServerName.String(),
+		)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to configure Warden TLS")
+			return
+		}
+		if tlsConfig != nil {
+			opts = opts.WithTLSConfig(tlsConfig)
+		}
+
 		// Create client
 		client, err := warden.NewClient(opts)
 		if err != nil {
@@ -177,6 +197,39 @@ func InitWardenClient(l *logger.Logger) {
 		wardenClient = client
 		log.Info().Msg("Warden client initialized successfully")
 	})
+}
+
+func buildWardenTLSConfig(caFile, certFile, keyFile, serverName string) (*tls.Config, error) {
+	if caFile == "" && certFile == "" && keyFile == "" && serverName == "" {
+		return nil, nil
+	}
+	if (certFile == "") != (keyFile == "") {
+		return nil, fmt.Errorf("WARDEN_TLS_CLIENT_CERT_FILE and WARDEN_TLS_CLIENT_KEY_FILE must be configured together")
+	}
+
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, ServerName: serverName}
+	if caFile != "" {
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("read Warden CA certificate: %w", err)
+		}
+		roots, err := x509.SystemCertPool()
+		if err != nil || roots == nil {
+			roots = x509.NewCertPool()
+		}
+		if !roots.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("WARDEN_TLS_CA_CERT_FILE contains no valid certificates")
+		}
+		tlsConfig.RootCAs = roots
+	}
+	if certFile != "" {
+		certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load Warden client certificate: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{certificate}
+	}
+	return tlsConfig, nil
 }
 
 // getWardenClient returns the warden client.

--- a/src/internal/auth/warden_tls_test.go
+++ b/src/internal/auth/warden_tls_test.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/MarvinJWendt/testza"
+)
+
+func TestBuildWardenTLSConfigDisabled(t *testing.T) {
+	cfg, err := buildWardenTLSConfig("", "", "", "")
+	testza.AssertNoError(t, err)
+	testza.AssertNil(t, cfg)
+}
+
+func TestBuildWardenTLSConfigRequiresCertificatePair(t *testing.T) {
+	_, err := buildWardenTLSConfig("", "client.crt", "", "")
+	testza.AssertNotNil(t, err)
+}
+
+func TestBuildWardenTLSConfigSetsSecureDefaults(t *testing.T) {
+	cfg, err := buildWardenTLSConfig("", "", "", "warden.internal")
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+	testza.AssertEqual(t, "warden.internal", cfg.ServerName)
+}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -115,6 +115,25 @@ var (
 		Sensitive:      true,
 	}
 
+	WardenHMACKeyID = EnvVariable{
+		Name: "WARDEN_HMAC_KEY_ID", PossibleValues: []string{"*"}, Validator: ValidateAny,
+	}
+	WardenHMACSecret = EnvVariable{
+		Name: "WARDEN_HMAC_SECRET", PossibleValues: []string{"*"}, Validator: ValidateAny, Sensitive: true,
+	}
+	WardenTLSCACertFile = EnvVariable{
+		Name: "WARDEN_TLS_CA_CERT_FILE", PossibleValues: []string{"*"}, Validator: ValidateAny,
+	}
+	WardenTLSClientCert = EnvVariable{
+		Name: "WARDEN_TLS_CLIENT_CERT_FILE", PossibleValues: []string{"*"}, Validator: ValidateAny,
+	}
+	WardenTLSClientKey = EnvVariable{
+		Name: "WARDEN_TLS_CLIENT_KEY_FILE", PossibleValues: []string{"*"}, Validator: ValidateAny, Sensitive: true,
+	}
+	WardenTLSServerName = EnvVariable{
+		Name: "WARDEN_TLS_SERVER_NAME", PossibleValues: []string{"*"}, Validator: ValidateAny,
+	}
+
 	WardenEnabled = EnvVariable{
 		Name:           "WARDEN_ENABLED",
 		Required:       false,
@@ -207,6 +226,14 @@ var (
 		PossibleValues: []string{"*"},
 		Validator:      ValidateAny, // Empty value is also valid (means using API key instead)
 		Sensitive:      true,
+	}
+
+	HeraldHMACKeyID = EnvVariable{
+		Name:           "HERALD_HMAC_KEY_ID",
+		Required:       false,
+		DefaultValue:   "",
+		PossibleValues: []string{"*"},
+		Validator:      ValidateAny,
 	}
 
 	HeraldTLSCACertFile = EnvVariable{
@@ -401,7 +428,7 @@ func Initialize(l *logger.Logger) error {
 	}
 
 	// Then validate all other configuration variables
-	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &CookieDomain, &CallbackAllowedHosts, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
+	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &CookieDomain, &CallbackAllowedHosts, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
 
 	for _, variable := range envVariables {
 		err := variable.Validate()
@@ -430,6 +457,12 @@ func Initialize(l *logger.Logger) error {
 		if strings.TrimSpace(WardenURL.Value) == "" {
 			return NewValidationError(WardenURL.Name, i18n.TStatic("error.config_required_not_set"), WardenURL.PossibleValues)
 		}
+	}
+	if (WardenHMACKeyID.Value == "") != (WardenHMACSecret.Value == "") {
+		return NewValidationError(WardenHMACSecret.Name, "HMAC key ID and secret must be configured together", WardenHMACSecret.PossibleValues)
+	}
+	if (WardenTLSClientCert.Value == "") != (WardenTLSClientKey.Value == "") {
+		return NewValidationError(WardenTLSClientCert.Name, "client certificate and key must be configured together", WardenTLSClientCert.PossibleValues)
 	}
 	if HeraldEnabled.ToBool() {
 		if strings.TrimSpace(HeraldURL.Value) == "" {

--- a/src/internal/handlers/login.go
+++ b/src/internal/handlers/login.go
@@ -62,7 +62,7 @@ func InitHeraldClient(l *logger.Logger) {
 		// HMAC takes precedence over API key if both are set
 		hmacSecret := config.HeraldHMACSecret.String()
 		if hmacSecret != "" {
-			opts = opts.WithHMACSecret(hmacSecret)
+			opts = opts.WithHMACSecret(hmacSecret).WithKeyID(config.HeraldHMACKeyID.String())
 			log.Debug().Msg("Herald client will use HMAC authentication")
 		} else if config.HeraldAPIKey.String() != "" {
 			log.Debug().Msg("Herald client will use API key authentication")


### PR DESCRIPTION
## Summary
- expose Warden HMAC v2 key ID/secret configuration
- support custom CA roots, mTLS client certificates, and TLS server names for Warden
- forward Herald HMAC key IDs for multi-key v2 deployments
- redact credential-like configuration values so the new secrets never enter logs
- reject partial Warden client-certificate configuration and require TLS 1.2+

## Verification
- added focused Warden TLS configuration tests
- `git diff --check` passes
- Go toolchain is unavailable in the authoring environment; repository CI is the execution gate

## P1 finding
Closes the gap where Stargate's SDK dependencies supported secure service authentication but deployment configuration did not expose it.