### PR TITLE
test(ci): fix request host and session cookie handling

### DIFF
--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -84,13 +84,15 @@ func createTestContext(method, path string, headers map[string]string, body stri
 }
 
 func responseCookieValue(ctx *fiber.Ctx, name string) string {
-	for _, part := range strings.Split(string(ctx.Response().Header.Peek("Set-Cookie")), ";") {
-		key, value, found := strings.Cut(strings.TrimSpace(part), "=")
-		if found && key == name {
-			return value
-		}
+	raw := ctx.Response().Header.PeekCookie(name)
+	if len(raw) == 0 {
+		return ""
 	}
-	return ""
+	var cookie fasthttp.Cookie
+	if err := cookie.ParseBytes(raw); err != nil {
+		return ""
+	}
+	return string(cookie.Value())
 }
 
 func TestCheckRoute_Authenticated(t *testing.T) {
@@ -1383,8 +1385,10 @@ func TestLogoutRoute_AfterLogin(t *testing.T) {
 	// Verify session is authenticated
 	sessionID := responseCookieValue(ctx1, auth.SessionCookieName)
 	testza.AssertNotEqual(t, "", sessionID)
-	ctx1.Request().Header.SetCookie(auth.SessionCookieName, sessionID)
-	sess, err := store.Get(ctx1)
+	checkCtx, checkApp := createTestContext("GET", "/", nil, "")
+	defer checkApp.ReleaseCtx(checkCtx)
+	checkCtx.Request().Header.SetCookie(auth.SessionCookieName, sessionID)
+	sess, err := store.Get(checkCtx)
 	testza.AssertNoError(t, err)
 	testza.AssertTrue(t, auth.IsAuthenticated(sess), "session should be authenticated after login")
 
@@ -1392,19 +1396,18 @@ func TestLogoutRoute_AfterLogin(t *testing.T) {
 	ctx2, app2 := createTestContext("GET", "/_logout", nil, "")
 	defer app2.ReleaseCtx(ctx2)
 
-	// Copy session cookie from login response to logout request
-	cookie := ctx1.Response().Header.Peek("Set-Cookie")
-	if len(cookie) > 0 {
-		ctx2.Request().Header.Set("Cookie", string(cookie))
-	}
+	ctx2.Request().Header.SetCookie(auth.SessionCookieName, sessionID)
 
 	err = logoutHandler(ctx2)
 	testza.AssertNoError(t, err)
 	testza.AssertEqual(t, fiber.StatusOK, ctx2.Response().StatusCode())
 	testza.AssertEqual(t, "Logged out", string(ctx2.Response().Body()))
 
-	// Verify session is no longer authenticated
-	sess2, err := store.Get(ctx2)
+	// Verify the destroyed session ID cannot authenticate a new request.
+	verifyCtx, verifyApp := createTestContext("GET", "/", nil, "")
+	defer verifyApp.ReleaseCtx(verifyCtx)
+	verifyCtx.Request().Header.SetCookie(auth.SessionCookieName, sessionID)
+	sess2, err := store.Get(verifyCtx)
 	testza.AssertNoError(t, err)
 	testza.AssertFalse(t, auth.IsAuthenticated(sess2), "session should not be authenticated after logout")
 }

--- a/src/internal/handlers/request_protection_test.go
+++ b/src/internal/handlers/request_protection_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -8,16 +9,24 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
+func newRequestProtectionTestRequest(method, path string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	req.Host = "auth.example.com"
+	return req
+}
+
 func TestRequireSameOriginRejectsCrossSiteBrowserWrite(t *testing.T) {
 	app := fiber.New()
 	app.Post("/write", RequireSameOrigin(), func(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusNoContent)
 	})
-	req := httptest.NewRequest(fiber.MethodPost, "http://auth.example.com/write", nil)
+	req := newRequestProtectionTestRequest(fiber.MethodPost, "/write")
 	req.Header.Set("Origin", "https://evil.example")
 
 	resp, err := app.Test(req)
-	testza.AssertNoError(t, err)
+	if err != nil {
+		t.Fatalf("execute request: %v", err)
+	}
 	testza.AssertEqual(t, fiber.StatusForbidden, resp.StatusCode)
 }
 
@@ -26,11 +35,13 @@ func TestRequireSameOriginAllowsMatchingOrigin(t *testing.T) {
 	app.Post("/write", RequireSameOrigin(), func(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusNoContent)
 	})
-	req := httptest.NewRequest(fiber.MethodPost, "http://auth.example.com/write", nil)
+	req := newRequestProtectionTestRequest(fiber.MethodPost, "/write")
 	req.Header.Set("Origin", "https://auth.example.com")
 
 	resp, err := app.Test(req)
-	testza.AssertNoError(t, err)
+	if err != nil {
+		t.Fatalf("execute request: %v", err)
+	}
 	testza.AssertEqual(t, fiber.StatusNoContent, resp.StatusCode)
 }
 
@@ -40,11 +51,15 @@ func TestLoginRateLimitRejectsBurst(t *testing.T) {
 		return c.SendStatus(fiber.StatusNoContent)
 	})
 	for i := 0; i < 10; i++ {
-		resp, err := app.Test(httptest.NewRequest(fiber.MethodPost, "http://auth.example.com/_login", nil))
-		testza.AssertNoError(t, err)
+		resp, err := app.Test(newRequestProtectionTestRequest(fiber.MethodPost, "/_login"))
+		if err != nil {
+			t.Fatalf("execute request %d: %v", i+1, err)
+		}
 		testza.AssertEqual(t, fiber.StatusNoContent, resp.StatusCode)
 	}
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodPost, "http://auth.example.com/_login", nil))
-	testza.AssertNoError(t, err)
+	resp, err := app.Test(newRequestProtectionTestRequest(fiber.MethodPost, "/_login"))
+	if err != nil {
+		t.Fatalf("execute rate-limited request: %v", err)
+	}
 	testza.AssertEqual(t, fiber.StatusTooManyRequests, resp.StatusCode)
 }


### PR DESCRIPTION
## Summary

- build Fiber test requests with a relative path and an explicit `Host`, so fasthttp can parse them before the same-origin middleware runs
- fail immediately when `app.Test` cannot construct a response, avoiding the follow-on nil-response panic
- read the session cookie through fasthttp's named cookie API
- verify login and logout state with independent request contexts and a request-form cookie

## Root cause

Recent `main` runs after #47, #53, #43, and #55 failed in the test job. `TestRequireSameOriginRejectsCrossSiteBrowserWrite` serialized an absolute request target without a `Host` header; Fiber rejected the request before middleware execution and the test then dereferenced a nil response. After session rotation landed, `TestLogoutRoute_AfterLogin` also reused response-cookie serialization and the original request context instead of presenting the rotated cookie in a fresh request.

## Validation

- `git diff --check`
- no production code or dependency changes
- CI runs exclusively on GitHub-hosted `ubuntu-latest` runners