### PR TITLE
fix(auth): make Warden revocation refresh safe by default

### DIFF
--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -85,7 +85,7 @@ Below are all environment variables used in code. "Required" means the service w
 | `STEP_UP_PATHS` | comma-separated paths | empty | No |
 | `OTLP_ENABLED` | true/false | false | No |
 | `OTLP_ENDPOINT` | String | empty | No |
-| `AUTH_REFRESH_ENABLED` | true/false | false | No |
+| `AUTH_REFRESH_ENABLED` | true/false | true | No |
 | `AUTH_REFRESH_INTERVAL` | duration | 5m | No |
 
 ## Required Configuration
@@ -1117,7 +1117,7 @@ Error: Configuration error: invalid value for environment variable 'PASSWORDS': 
   - When `STEP_UP_ENABLED=true`, use `STEP_UP_PATHS` to define paths that require a second factor
 
 - **Auth Refresh**:
-  - When `AUTH_REFRESH_ENABLED=true`, Warden must be enabled (`WARDEN_ENABLED=true`); use `AUTH_REFRESH_INTERVAL` to tune refresh interval
+  - Authorization refresh is enabled by default for Warden sessions; it is a no-op in standalone password mode. Use `AUTH_REFRESH_INTERVAL` to tune the refresh interval or set `AUTH_REFRESH_ENABLED=false` only when delayed revocation is acceptable.
 
 - **Warden + Herald Combined Usage** (Optional):
   - When OTP authentication is needed, can optionally enable both Warden and Herald

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -85,7 +85,7 @@ services:
 | `STEP_UP_PATHS` | 逗号分隔路径 | 空 | 否 |
 | `OTLP_ENABLED` | true/false | false | 否 |
 | `OTLP_ENDPOINT` | String | 空 | 否 |
-| `AUTH_REFRESH_ENABLED` | true/false | false | 否 |
+| `AUTH_REFRESH_ENABLED` | true/false | true | 否 |
 | `AUTH_REFRESH_INTERVAL` | duration | 5m | 否 |
 
 ## 必需配置
@@ -1131,7 +1131,7 @@ Error: Configuration error: invalid value for environment variable 'PASSWORDS': 
   - `STEP_UP_ENABLED=true` 时，可通过 `STEP_UP_PATHS` 指定需二次认证的路径
 
 - **授权刷新**：
-  - `AUTH_REFRESH_ENABLED=true` 时，需启用 Warden（`WARDEN_ENABLED=true`），并可通过 `AUTH_REFRESH_INTERVAL` 调整刷新间隔
+  - Warden 会话默认启用授权刷新；在独立密码模式下该配置不会生效。可通过 `AUTH_REFRESH_INTERVAL` 调整刷新间隔；仅在可接受撤权延迟时设置 `AUTH_REFRESH_ENABLED=false`。
 
 - **Warden + Herald 组合使用**（可选）：
   - 当需要 OTP 认证时，可以选择同时启用 Warden 和 Herald

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -380,7 +380,7 @@ var (
 	AuthRefreshEnabled = EnvVariable{
 		Name:           "AUTH_REFRESH_ENABLED",
 		Required:       false,
-		DefaultValue:   "false",
+		DefaultValue:   "true",
 		PossibleValues: []string{"true", "false"},
 		Validator:      ValidateCaseInsensitivePossibleValues,
 	}
@@ -488,10 +488,6 @@ func Initialize(l *logger.Logger) error {
 	if (HeraldTLSClientCert.Value == "") != (HeraldTLSClientKey.Value == "") {
 		return NewValidationError(HeraldTLSClientCert.Name, "client certificate and key must be configured together", HeraldTLSClientCert.PossibleValues)
 	}
-	if AuthRefreshEnabled.ToBool() && !WardenEnabled.ToBool() {
-		return NewValidationError(AuthRefreshEnabled.Name, "requires WARDEN_ENABLED=true", AuthRefreshEnabled.PossibleValues)
-	}
-
 	if HeaderAuthEnabled.ToBool() {
 		if !WardenEnabled.ToBool() {
 			return NewValidationError(HeaderAuthEnabled.Name, "requires WARDEN_ENABLED=true", HeaderAuthEnabled.PossibleValues)

--- a/src/internal/handlers/auth_refresh.go
+++ b/src/internal/handlers/auth_refresh.go
@@ -17,7 +17,10 @@ var lookupRefreshUser = func(ctx context.Context, phone, mail string) *warden.Al
 }
 
 func refreshAuthorizationIfNeeded(ctx context.Context, sess *session.Session) (bool, error) {
-	if !config.AuthRefreshEnabled.ToBool() {
+	// Authorization refresh only applies to authenticated Warden sessions. In
+	// particular, an anonymous request must continue through the normal
+	// ForwardAuth flow so that HTML clients are redirected to login.
+	if !config.AuthRefreshEnabled.ToBool() || !config.WardenEnabled.ToBool() || !auth.IsAuthenticated(sess) {
 		return false, nil
 	}
 	interval := config.AuthRefreshInterval.ToDuration()

--- a/src/internal/handlers/auth_refresh_test.go
+++ b/src/internal/handlers/auth_refresh_test.go
@@ -16,13 +16,16 @@ func setupRefreshTest(t *testing.T) {
 	originalEnabled := config.AuthRefreshEnabled.Value
 	originalInterval := config.AuthRefreshInterval.Value
 	originalLookup := lookupRefreshUser
+	originalWardenEnabled := config.WardenEnabled.Value
 	t.Cleanup(func() {
 		config.AuthRefreshEnabled.Value = originalEnabled
 		config.AuthRefreshInterval.Value = originalInterval
 		lookupRefreshUser = originalLookup
+		config.WardenEnabled.Value = originalWardenEnabled
 	})
 	config.AuthRefreshEnabled.Value = "true"
 	config.AuthRefreshInterval.Value = "1s"
+	config.WardenEnabled.Value = "true"
 }
 
 func TestAuthRefreshRejectsMissingOrDisabledUser(t *testing.T) {
@@ -70,4 +73,39 @@ func TestAuthRefreshReplacesRevokedAuthorization(t *testing.T) {
 	testza.AssertTrue(t, refreshed)
 	testza.AssertEqual(t, "viewer", sess.Get("user_role"))
 	testza.AssertEqual(t, []string{"read"}, sess.Get("user_scope"))
+}
+
+func TestAuthRefreshSkipsAnonymousSession(t *testing.T) {
+	setupRefreshTest(t)
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/_auth", nil, "")
+	defer app.ReleaseCtx(ctx)
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	lookupCalled := false
+	lookupRefreshUser = func(context.Context, string, string) *warden.AllowListUser {
+		lookupCalled = true
+		return nil
+	}
+
+	refreshed, err := refreshAuthorizationIfNeeded(context.Background(), sess)
+	testza.AssertNoError(t, err)
+	testza.AssertFalse(t, refreshed)
+	testza.AssertFalse(t, lookupCalled)
+}
+
+func TestAuthRefreshSkipsStandaloneSession(t *testing.T) {
+	setupRefreshTest(t)
+	config.WardenEnabled.Value = "false"
+
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/_auth", nil, "")
+	defer app.ReleaseCtx(ctx)
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
+
+	refreshed, err := refreshAuthorizationIfNeeded(context.Background(), sess)
+	testza.AssertNoError(t, err)
+	testza.AssertFalse(t, refreshed)
 }

--- a/src/internal/handlers/auth_refresh_test.go
+++ b/src/internal/handlers/auth_refresh_test.go
@@ -37,7 +37,11 @@ func TestAuthRefreshRejectsMissingOrDisabledUser(t *testing.T) {
 	testza.AssertNoError(t, err)
 	sess.Set("user_mail", "disabled@example.com")
 	sess.Set("auth_refreshed_at", time.Now().Add(-time.Minute).Unix())
+	sessionID := sess.ID()
 	testza.AssertNoError(t, auth.Authenticate(sess))
+	ctx.Request().Header.SetCookie(auth.SessionCookieName, sessionID)
+	sess, err = store.Get(ctx)
+	testza.AssertNoError(t, err)
 	lookupRefreshUser = func(context.Context, string, string) *warden.AllowListUser {
 		return &warden.AllowListUser{Status: "disabled"}
 	}
@@ -58,6 +62,11 @@ func TestAuthRefreshReplacesRevokedAuthorization(t *testing.T) {
 	sess.Set("user_mail", "active@example.com")
 	sess.Set("user_scope", []string{"old-admin"})
 	sess.Set("auth_refreshed_at", time.Now().Add(-time.Minute).Unix())
+	sessionID := sess.ID()
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	ctx.Request().Header.SetCookie(auth.SessionCookieName, sessionID)
+	sess, err = store.Get(ctx)
+	testza.AssertNoError(t, err)
 	lookupRefreshUser = func(context.Context, string, string) *warden.AllowListUser {
 		return &warden.AllowListUser{
 			UserID: "user-1",
@@ -103,7 +112,11 @@ func TestAuthRefreshSkipsStandaloneSession(t *testing.T) {
 	defer app.ReleaseCtx(ctx)
 	sess, err := store.Get(ctx)
 	testza.AssertNoError(t, err)
+	sessionID := sess.ID()
 	testza.AssertNoError(t, auth.Authenticate(sess))
+	ctx.Request().Header.SetCookie(auth.SessionCookieName, sessionID)
+	sess, err = store.Get(ctx)
+	testza.AssertNoError(t, err)
 
 	refreshed, err := refreshAuthorizationIfNeeded(context.Background(), sess)
 	testza.AssertNoError(t, err)

--- a/src/internal/handlers/check.go
+++ b/src/internal/handlers/check.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/session"
 	forwardauth "github.com/soulteary/forwardauth-kit"
+	"github.com/soulteary/stargate/src/internal/auth"
 	"github.com/soulteary/stargate/src/internal/config"
 	"github.com/soulteary/stargate/src/internal/i18n"
 	"github.com/soulteary/tracing-kit"
@@ -87,9 +88,12 @@ func CheckRoute(store SessionStoreForCheck) func(c *fiber.Ctx) error {
 			tracing.RecordError(forwardAuthSpan, err)
 			return SendErrorResponse(ctx, fiber.StatusInternalServerError, i18n.T(ctx, "error.session_store_failed"))
 		}
-		refreshed, err := refreshAuthorizationIfNeeded(spanCtx, sess)
-		if err != nil {
-			return SendErrorResponse(ctx, fiber.StatusUnauthorized, i18n.T(ctx, "error.auth_required"))
+		refreshed := false
+		if auth.IsAuthenticated(sess) {
+			refreshed, err = refreshAuthorizationIfNeeded(spanCtx, sess)
+			if err != nil {
+				return SendErrorResponse(ctx, fiber.StatusUnauthorized, i18n.T(ctx, "error.auth_required"))
+			}
 		}
 		if requiresStepUp(ctx, sess) {
 			return redirectToStepUp(ctx)

--- a/src/internal/handlers/forwardauth.go
+++ b/src/internal/handlers/forwardauth.go
@@ -122,7 +122,10 @@ func InitForwardAuthHandler(l *logger.Logger) {
 		StepUpSessionKey: "step_up_verified",
 
 		// Auth refresh
-		AuthRefreshEnabled:  config.AuthRefreshEnabled.ToBool(),
+		// CheckRoute performs the authoritative Warden refresh so revoked or
+		// disabled users fail closed. Keep the library's best-effort refresh off
+		// to avoid a second lookup and inconsistent status handling.
+		AuthRefreshEnabled:  false,
 		AuthRefreshInterval: config.AuthRefreshInterval.ToDuration(),
 
 		// Response headers


### PR DESCRIPTION
## Summary

- refresh authorization only for authenticated Warden sessions
- enable Warden authorization refresh by default while keeping standalone password mode unchanged
- fail closed for revoked/disabled users without breaking anonymous login redirects
- disable the forwardauth-kit's duplicate best-effort refresh path
- document the secure default in English and Chinese

## Why

With `AUTH_REFRESH_ENABLED=true`, an anonymous request had no refresh identity and returned 401 before the normal ForwardAuth login redirect. At the same time, refresh was disabled by default, so Warden revocations could remain effective only after the 24-hour session expired.

## Tests

- adds coverage for anonymous sessions and standalone password sessions
- existing refresh tests cover revoked and changed authorization
- full Go test suite is delegated to GitHub Actions because the local execution environment has no Go toolchain