### PR TITLE
fix(auth): harden step-up route enforcement

### DIFF
--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -806,6 +806,8 @@ Paths that require step-up; comma-separated; prefix matching supported.
 
 **Example:** `/admin,/api/sensitive`
 
+At least one path is required when `STEP_UP_ENABLED=true`. Matching uses the request path only; query parameters do not affect protection.
+
 ### OpenTelemetry (Optional)
 
 #### `OTLP_ENABLED`

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -820,6 +820,8 @@ Redis 数据库编号。
 
 **示例：** `/admin,/api/sensitive`
 
+启用 `STEP_UP_ENABLED=true` 时必须配置至少一个路径。匹配仅使用请求路径，查询参数不会影响保护规则。
+
 ### OpenTelemetry（可选）
 
 #### `OTLP_ENABLED`

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -207,7 +207,7 @@ func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *he
 	app.Get(RouteSessionExchange, handlers.SessionShareRoute(store))
 	app.Get(RouteAuth, handlers.CheckRoute(store))
 	app.Get(RouteStepUp, handlers.StepUpRoute(store))
-	app.Post(RouteStepUp, handlers.StepUpAPI(store))
+	app.Post(RouteStepUp, sameOrigin, handlers.LoginRateLimit(), handlers.StepUpAPI(store))
 	// Prometheus metrics endpoint
 	app.Get("/metrics", metricskit.FiberHandlerFor(metrics.Registry))
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -466,6 +466,9 @@ func Initialize(l *logger.Logger) error {
 	if StepUpEnabled.ToBool() && Passwords.Value == "" {
 		return NewValidationError(StepUpEnabled.Name, "requires PASSWORDS for re-authentication", StepUpEnabled.PossibleValues)
 	}
+	if StepUpEnabled.ToBool() && strings.TrimSpace(StepUpPaths.Value) == "" {
+		return NewValidationError(StepUpPaths.Name, "must contain at least one protected path when step-up is enabled", StepUpPaths.PossibleValues)
+	}
 	if WardenEnabled.ToBool() {
 		if strings.TrimSpace(WardenURL.Value) == "" {
 			return NewValidationError(WardenURL.Name, i18n.TStatic("error.config_required_not_set"), WardenURL.PossibleValues)

--- a/src/internal/config/stepup_test.go
+++ b/src/internal/config/stepup_test.go
@@ -29,12 +29,8 @@ func TestInitStepUpMatcher_Enabled_EmptyPaths(t *testing.T) {
 	t.Setenv("STEP_UP_PATHS", "")
 
 	err := Initialize(testLogger())
-	testza.AssertNoError(t, err)
-	InitStepUpMatcher()
-
-	matcher := GetStepUpMatcher()
-	testza.AssertNotNil(t, matcher)
-	testza.AssertFalse(t, matcher.RequiresStepUp("/admin"))
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "STEP_UP_PATHS")
 }
 
 func TestInitStepUpMatcher_Enabled_SinglePath(t *testing.T) {

--- a/src/internal/handlers/step_up.go
+++ b/src/internal/handlers/step_up.go
@@ -24,7 +24,18 @@ func requiresStepUp(ctx *fiber.Ctx, sess *session.Session) bool {
 	if !config.StepUpEnabled.ToBool() || stepUpVerified(sess) {
 		return false
 	}
-	return config.GetStepUpMatcher().RequiresStepUp(GetForwardedURI(ctx))
+	return config.GetStepUpMatcher().RequiresStepUp(stepUpRequestPath(GetForwardedURI(ctx)))
+}
+
+// stepUpRequestPath removes the query and fragment before matching protected
+// routes. ForwardAuth proxies commonly send X-Forwarded-Uri as a request URI;
+// matching the raw value lets `/admin?x=1` bypass an exact `/admin` rule.
+func stepUpRequestPath(raw string) string {
+	parsed, err := url.ParseRequestURI(raw)
+	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.Path == "" || !strings.HasPrefix(parsed.Path, "/") {
+		return "/"
+	}
+	return parsed.Path
 }
 
 func safeStepUpCallback(raw string) string {

--- a/src/internal/handlers/step_up_test.go
+++ b/src/internal/handlers/step_up_test.go
@@ -32,6 +32,28 @@ func TestRequiresStepUpUsesForwardedBusinessPath(t *testing.T) {
 	testza.AssertFalse(t, requiresStepUp(ctx, sess))
 }
 
+func TestRequiresStepUpIgnoresForwardedQuery(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("STEP_UP_ENABLED", "true")
+	t.Setenv("STEP_UP_PATHS", "/admin")
+	testza.AssertNoError(t, config.Initialize(testLogger()))
+
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{"X-Forwarded-Uri": "/admin?view=users"}, "")
+	defer app.ReleaseCtx(ctx)
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+
+	testza.AssertTrue(t, requiresStepUp(ctx, sess))
+}
+
+func TestStepUpRequestPathRejectsInvalidURI(t *testing.T) {
+	testza.AssertEqual(t, "/", stepUpRequestPath("https://evil.example/admin"))
+	testza.AssertEqual(t, "/", stepUpRequestPath("not-a-path"))
+	testza.AssertEqual(t, "/admin", stepUpRequestPath("/admin?x=1"))
+}
+
 func TestStepUpAPIRecordsRecentVerification(t *testing.T) {
 	setupStepUpTest(t)
 	store := setupTestStore()


### PR DESCRIPTION
## Summary

- match step-up policies against the URL path, excluding query parameters
- reject invalid or absolute forwarded request URIs during policy matching
- require at least one `STEP_UP_PATHS` entry when step-up is enabled
- protect the step-up POST with same-origin validation and rate limiting
- document the fail-fast configuration behavior

## Why

An exact protected path such as `/admin` could be bypassed with `/admin?x=1` because the anchored matcher received the raw forwarded URI. The step-up verification endpoint also lacked the protections already used by the login endpoint.

## Tests

- query-bearing protected paths remain protected
- invalid and absolute URIs fail closed to the root path
- empty step-up policy configuration is rejected
- full Go test suite is delegated to GitHub Actions because the local execution environment has no Go toolchain