### PR TITLE
fix(session): enforce exchange ticket replay protection across replicas

### DIFF
--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -320,7 +320,7 @@ Encryption key for short-lived session exchange tickets. Configure at least 32 r
 SESSION_EXCHANGE_SECRET=<at-least-32-random-characters>
 ```
 
-The value is never logged. Without it, session exchange requests fail closed.
+The value is never logged. Without it, session exchange requests fail closed. When Redis session storage is enabled, consumed ticket hashes are also stored in Redis with their remaining lifetime so replay protection is shared by every Stargate replica. In-memory deployments enforce single use only within one process.
 
 ### `PORT`
 

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -320,7 +320,7 @@ CALLBACK_ALLOWED_HOSTS=app.example.com,admin.example.com
 SESSION_EXCHANGE_SECRET=<至少-32-个随机字符>
 ```
 
-该值不会写入日志。未配置时，会话交换会安全失败。
+该值不会写入日志。未配置时，会话交换会安全失败。启用 Redis 会话存储后，已消费票据的哈希也会按剩余有效期写入 Redis，使所有 Stargate 副本共享防重放状态；内存模式仅能在单个进程内保证一次性消费。
 
 ### `PORT`
 

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -186,7 +186,7 @@ func setupHealthChecker(redisClient *redis.Client) *health.Aggregator {
 
 // setupRoutes registers all HTTP routes for the application.
 // This includes authentication, login, logout, session exchange, and health check endpoints.
-func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *health.Aggregator) {
+func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *health.Aggregator, replayStore handlers.SessionExchangeReplayStore) {
 	log.Debug().Msg("Registering routes")
 	// Initialize ForwardAuth handler
 	handlers.InitForwardAuthHandler(log)
@@ -204,7 +204,7 @@ func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *he
 	app.Get("/totp/revoke", handlers.TOTPRevokeRoute(store))
 	app.Post("/totp/revoke", sameOrigin, handlers.VerificationRateLimit(), handlers.TOTPRevokeConfirmAPI(store))
 	app.Post(RouteLogout, sameOrigin, handlers.LogoutRoute(store))
-	app.Get(RouteSessionExchange, handlers.SessionShareRoute(store))
+	app.Get(RouteSessionExchange, handlers.SessionShareRoute(store, replayStore))
 	app.Get(RouteAuth, handlers.CheckRoute(store))
 	app.Get(RouteStepUp, handlers.StepUpRoute(store))
 	app.Post(RouteStepUp, sameOrigin, handlers.LoginRateLimit(), handlers.StepUpAPI(store))
@@ -329,8 +329,9 @@ func createApp() *fiber.App {
 	setupMiddleware(app)
 	store, redisClient := setupSessionStore()
 	healthAggregator := setupHealthChecker(redisClient)
+	replayStore := handlers.NewSessionExchangeReplayStore(redisClient)
 
-	setupRoutes(app, store, healthAggregator)
+	setupRoutes(app, store, healthAggregator, replayStore)
 	setupStaticFiles(app)
 
 	return app

--- a/src/cmd/stargate/server_test.go
+++ b/src/cmd/stargate/server_test.go
@@ -13,6 +13,7 @@ import (
 	health "github.com/soulteary/health-kit"
 	logger "github.com/soulteary/logger-kit"
 	"github.com/soulteary/stargate/src/internal/config"
+	"github.com/soulteary/stargate/src/internal/handlers"
 )
 
 // testLoggerMain creates a logger instance for testing
@@ -212,7 +213,7 @@ func TestSetupRoutes(t *testing.T) {
 
 	// Test that setupRoutes doesn't panic
 	testza.AssertNotPanics(t, func() {
-		setupRoutes(app, store, aggregator)
+		setupRoutes(app, store, aggregator, handlers.NewSessionExchangeReplayStore(nil))
 	})
 
 	// Verify routes are registered by testing health endpoint

--- a/src/internal/handlers/session_exchange_token.go
+++ b/src/internal/handlers/session_exchange_token.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -14,12 +15,61 @@ import (
 	"sync"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/soulteary/stargate/src/internal/config"
 )
 
 const sessionExchangeTicketTTL = 2 * time.Minute
 
 var consumedSessionExchangeTickets sync.Map
+
+// SessionExchangeReplayStore atomically records a consumed ticket hash. A
+// shared implementation is required when sessions are shared across replicas.
+type SessionExchangeReplayStore interface {
+	Consume(ctx context.Context, key string, ttl time.Duration) (bool, error)
+}
+
+type memorySessionExchangeReplayStore struct {
+	consumed *sync.Map
+}
+
+func (s *memorySessionExchangeReplayStore) Consume(_ context.Context, key string, ttl time.Duration) (bool, error) {
+	if _, loaded := s.consumed.LoadOrStore(key, struct{}{}); loaded {
+		return false, nil
+	}
+	time.AfterFunc(ttl, func() { s.consumed.Delete(key) })
+	return true, nil
+}
+
+type redisSessionExchangeReplayStore struct {
+	client redis.Cmdable
+	prefix string
+}
+
+func (s *redisSessionExchangeReplayStore) Consume(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+	return s.client.SetNX(ctx, s.prefix+key, "1", ttl).Result()
+}
+
+var defaultSessionExchangeReplayStore SessionExchangeReplayStore = &memorySessionExchangeReplayStore{
+	consumed: &consumedSessionExchangeTickets,
+}
+
+// NewSessionExchangeReplayStore uses Redis when it is available so all
+// Stargate replicas enforce the same single-use ticket state. Standalone
+// in-memory deployments retain the process-local implementation.
+func NewSessionExchangeReplayStore(client redis.Cmdable) SessionExchangeReplayStore {
+	if client == nil {
+		return defaultSessionExchangeReplayStore
+	}
+	prefix := config.SessionStorageRedisKeyPrefix.String()
+	if prefix == "" {
+		prefix = "stargate:session:"
+	}
+	return &redisSessionExchangeReplayStore{
+		client: client,
+		prefix: prefix + "exchange:used:",
+	}
+}
 
 type sessionExchangeClaims struct {
 	SessionID string `json:"sid"`
@@ -82,6 +132,10 @@ func createSessionExchangeTicket(sessionID, audience string) (string, error) {
 }
 
 func consumeSessionExchangeTicket(token, audience string) (string, error) {
+	return consumeSessionExchangeTicketWithStore(context.Background(), token, audience, defaultSessionExchangeReplayStore)
+}
+
+func consumeSessionExchangeTicketWithStore(ctx context.Context, token, audience string, replayStore SessionExchangeReplayStore) (string, error) {
 	audience = normalizeExchangeAudience(audience)
 	if token == "" || audience == "" {
 		return "", errors.New("invalid session exchange ticket")
@@ -102,17 +156,22 @@ func consumeSessionExchangeTicket(token, audience string) (string, error) {
 	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
 		return "", errors.New("invalid session exchange ticket")
 	}
-	if claims.SessionID == "" || claims.Audience != audience || time.Now().Unix() > claims.ExpiresAt {
+	remaining := time.Until(time.Unix(claims.ExpiresAt, 0))
+	if claims.SessionID == "" || claims.Audience != audience || remaining <= 0 {
 		return "", errors.New("expired or misdirected session exchange ticket")
 	}
 
 	ticketHash := sha256.Sum256([]byte(token))
 	key := base64.RawURLEncoding.EncodeToString(ticketHash[:])
-	if _, loaded := consumedSessionExchangeTickets.LoadOrStore(key, struct{}{}); loaded {
+	if replayStore == nil {
+		return "", errors.New("session exchange replay protection is not configured")
+	}
+	consumed, err := replayStore.Consume(ctx, key, remaining)
+	if err != nil {
+		return "", errors.New("failed to record session exchange ticket consumption")
+	}
+	if !consumed {
 		return "", errors.New("session exchange ticket has already been used")
 	}
-	time.AfterFunc(sessionExchangeTicketTTL, func() {
-		consumedSessionExchangeTickets.Delete(key)
-	})
 	return claims.SessionID, nil
 }

--- a/src/internal/handlers/session_exchange_token_test.go
+++ b/src/internal/handlers/session_exchange_token_test.go
@@ -1,8 +1,11 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/MarvinJWendt/testza"
 	"github.com/soulteary/stargate/src/internal/config"
@@ -13,6 +16,39 @@ func setSessionExchangeSecret(t *testing.T) {
 	original := config.SessionExchangeSecret.Value
 	t.Cleanup(func() { config.SessionExchangeSecret.Value = original })
 	config.SessionExchangeSecret.Value = "test-session-exchange-secret-32-bytes"
+}
+
+func TestSessionExchangeTicketReplayIsSharedThroughRedis(t *testing.T) {
+	setSessionExchangeSecret(t)
+	redisClient := setupTestRedis(t)
+	t.Cleanup(func() { _ = redisClient.Close() })
+
+	firstReplica := NewSessionExchangeReplayStore(redisClient)
+	secondReplica := NewSessionExchangeReplayStore(redisClient)
+	ticket, err := createSessionExchangeTicket("shared-session-id", "app.example.com")
+	testza.AssertNoError(t, err)
+
+	sessionID, err := consumeSessionExchangeTicketWithStore(context.Background(), ticket, "app.example.com", firstReplica)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, "shared-session-id", sessionID)
+
+	_, err = consumeSessionExchangeTicketWithStore(context.Background(), ticket, "app.example.com", secondReplica)
+	testza.AssertNotNil(t, err)
+}
+
+type failingSessionExchangeReplayStore struct{}
+
+func (failingSessionExchangeReplayStore) Consume(context.Context, string, time.Duration) (bool, error) {
+	return false, errors.New("backend unavailable")
+}
+
+func TestSessionExchangeTicketFailsClosedWhenReplayStoreFails(t *testing.T) {
+	setSessionExchangeSecret(t)
+	ticket, err := createSessionExchangeTicket("session-id", "app.example.com")
+	testza.AssertNoError(t, err)
+
+	_, err = consumeSessionExchangeTicketWithStore(context.Background(), ticket, "app.example.com", failingSessionExchangeReplayStore{})
+	testza.AssertNotNil(t, err)
 }
 
 func TestSessionExchangeTicketIsOpaqueAndAudienceBound(t *testing.T) {

--- a/src/internal/handlers/session_share.go
+++ b/src/internal/handlers/session_share.go
@@ -18,7 +18,11 @@ import (
 //   - ticket: encrypted, short-lived, single-use session exchange ticket
 //
 // Returns a Fiber handler function.
-func SessionShareRoute(store *session.Store) func(c *fiber.Ctx) error {
+func SessionShareRoute(store *session.Store, replayStores ...SessionExchangeReplayStore) func(c *fiber.Ctx) error {
+	replayStore := defaultSessionExchangeReplayStore
+	if len(replayStores) > 0 && replayStores[0] != nil {
+		replayStore = replayStores[0]
+	}
 	// Create session config for cookie creation
 	sessionConfig := sessionkit.DefaultConfig().
 		WithCookieName(auth.SessionCookieName).
@@ -32,7 +36,7 @@ func SessionShareRoute(store *session.Store) func(c *fiber.Ctx) error {
 		if ticket == "" {
 			return SendErrorResponse(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.missing_session_id"))
 		}
-		sessionID, err := consumeSessionExchangeTicket(ticket, GetForwardedHost(ctx))
+		sessionID, err := consumeSessionExchangeTicketWithStore(ctx.Context(), ticket, GetForwardedHost(ctx), replayStore)
 		if err != nil {
 			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "invalid session exchange ticket")
 		}


### PR DESCRIPTION
## Summary

- introduce an atomic session-exchange replay store abstraction
- use Redis `SET NX` with the ticket's remaining lifetime when shared session storage is enabled
- inject the replay store into the session exchange route
- fail closed if the shared replay backend is unavailable
- retain process-local protection for standalone in-memory deployments
- document the multi-replica behavior

## Why

Consumed ticket hashes were held in a package-level `sync.Map`. In a multi-replica deployment, the same encrypted ticket could therefore be redeemed once on every replica, and restarting a replica also cleared its replay history.

## Tests

- verifies two logical Stargate replicas sharing Redis cannot consume the same ticket
- verifies replay-store failures reject the exchange
- existing tests continue to cover tampering, audience binding, opacity, and local replay
- full CI provides Redis, Go build, race tests, lint, and security scanning