### PR TITLE
fix(proxy): define an explicit trusted forwarding boundary

### DIFF
--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -52,6 +52,8 @@ Below are all environment variables used in code. "Required" means the service w
 | `LOGIN_PAGE_TITLE` | String | Stargate - Login | No |
 | `LOGIN_PAGE_FOOTER_TEXT` | String | Copyright © 2024 - Stargate | No |
 | `USER_HEADER_NAME` | String | X-Forwarded-User | No |
+| `TRUSTED_PROXIES` | comma-separated IPs/CIDRs | empty | No |
+| `PROXY_HEADER` | HTTP header name | X-Forwarded-For | No |
 | `COOKIE_DOMAIN` | String | empty | No |
 | `CALLBACK_ALLOWED_HOSTS` | comma-separated hosts | empty | No |
 | `SESSION_EXCHANGE_SECRET` | Secret string (32+ chars) | empty | No |
@@ -260,6 +262,17 @@ User header name set after successful authentication.
 ```bash
 USER_HEADER_NAME=X-Authenticated-User
 ```
+
+### `TRUSTED_PROXIES` and `PROXY_HEADER`
+
+`TRUSTED_PROXIES` is the comma-separated allowlist of reverse-proxy source IPs or CIDRs. It is empty by default, so Stargate ignores `X-Forwarded-Host`, `X-Forwarded-Uri`, `X-Forwarded-Proto`, and the configured client-IP header until the immediate peer is trusted. `PROXY_HEADER` selects the header Fiber uses for the client IP and defaults to `X-Forwarded-For`.
+
+```bash
+TRUSTED_PROXIES=10.20.0.10,10.30.0.0/24
+PROXY_HEADER=X-Forwarded-For
+```
+
+Configure the narrowest proxy addresses possible. The proxy must remove client-supplied forwarding headers and write its own values before forwarding the request.
 
 ### `COOKIE_DOMAIN`
 

--- a/docs/enUS/SECURITY.md
+++ b/docs/enUS/SECURITY.md
@@ -26,6 +26,7 @@ This document explains Stargate's security features, security configuration, and
 - Set `MODE=production` to enable production mode
 - Configure `COOKIE_DOMAIN` for proper session management
 - Use HTTPS via reverse proxy (Traefik, Nginx, etc.)
+- Set `TRUSTED_PROXIES` to the reverse proxy's source IPs or CIDRs
 - Configure secure session cookie settings
 
 **Configuration Example**:
@@ -33,6 +34,7 @@ This document explains Stargate's security features, security configuration, and
 export AUTH_HOST=auth.example.com
 export PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
 export COOKIE_DOMAIN=.example.com
+export TRUSTED_PROXIES=10.20.0.10
 ```
 
 **Note**: In the current implementation, Cookie Secure is inferred from headers such as `X-Forwarded-Proto`; SameSite is fixed to `Lax`. The env vars `COOKIE_SECURE`, `COOKIE_SAME_SITE`, and `SESSION_TTL` are not implemented. See [CONFIG.md](CONFIG.md).
@@ -81,7 +83,8 @@ export COOKIE_DOMAIN=.example.com
 
 **Recommended Configuration**:
 - Use Traefik with Let's Encrypt for automatic SSL certificates
-- Configure `TRUSTED_PROXY_IPS` if behind a reverse proxy
+- Configure the narrowest possible `TRUSTED_PROXIES` allowlist; forwarded headers are ignored by default
+- Ensure the proxy overwrites forwarding headers instead of appending untrusted client values
 - Use network policies to restrict service access
 - Monitor and log authentication attempts
 

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -52,6 +52,8 @@ services:
 | `LOGIN_PAGE_TITLE` | String | Stargate - Login | 否 |
 | `LOGIN_PAGE_FOOTER_TEXT` | String | Copyright © 2024 - Stargate | 否 |
 | `USER_HEADER_NAME` | String | X-Forwarded-User | 否 |
+| `TRUSTED_PROXIES` | 逗号分隔的 IP/CIDR | 空 | 否 |
+| `PROXY_HEADER` | HTTP 头名称 | X-Forwarded-For | 否 |
 | `COOKIE_DOMAIN` | String | 空 | 否 |
 | `CALLBACK_ALLOWED_HOSTS` | 逗号分隔的主机名 | 空 | 否 |
 | `SESSION_EXCHANGE_SECRET` | 密钥字符串（至少 32 字符） | 空 | 否 |
@@ -260,6 +262,17 @@ LOGIN_PAGE_FOOTER_TEXT=© 2024 我的公司
 ```bash
 USER_HEADER_NAME=X-Authenticated-User
 ```
+
+### `TRUSTED_PROXIES` 与 `PROXY_HEADER`
+
+`TRUSTED_PROXIES` 用于配置反向代理来源 IP 或 CIDR 白名单。默认值为空，因此在直接来源未被信任前，Stargate 会忽略 `X-Forwarded-Host`、`X-Forwarded-Uri`、`X-Forwarded-Proto` 以及客户端 IP 转发头。`PROXY_HEADER` 指定 Fiber 解析客户端 IP 使用的头，默认是 `X-Forwarded-For`。
+
+```bash
+TRUSTED_PROXIES=10.20.0.10,10.30.0.0/24
+PROXY_HEADER=X-Forwarded-For
+```
+
+应尽量只配置明确的代理地址；反向代理必须先删除客户端提供的转发头，再写入可信值。
 
 ### `COOKIE_DOMAIN`
 

--- a/docs/zhCN/SECURITY.md
+++ b/docs/zhCN/SECURITY.md
@@ -26,6 +26,7 @@
 - 设置 `MODE=production` 启用生产模式
 - 配置 `COOKIE_DOMAIN` 以正确管理会话
 - 通过反向代理（Traefik、Nginx 等）使用 HTTPS
+- 将反向代理的来源 IP 或 CIDR 配置到 `TRUSTED_PROXIES`
 - 配置安全的会话 Cookie 设置
 
 **配置示例**:
@@ -33,6 +34,7 @@
 export AUTH_HOST=auth.example.com
 export PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
 export COOKIE_DOMAIN=.example.com
+export TRUSTED_PROXIES=10.20.0.10
 ```
 
 **说明**：当前实现中 Cookie 的 Secure 由 `X-Forwarded-Proto` 等请求头推断，SameSite 固定为 `Lax`；未提供 `COOKIE_SECURE`、`COOKIE_SAME_SITE`、`SESSION_TTL` 等环境变量，详见 [CONFIG.md](CONFIG.md)。
@@ -81,7 +83,8 @@ export COOKIE_DOMAIN=.example.com
 
 **推荐配置**:
 - 使用带 Let's Encrypt 的 Traefik 自动获取 SSL 证书
-- 如果在反向代理后面，配置 `TRUSTED_PROXY_IPS`
+- 配置尽可能精确的 `TRUSTED_PROXIES` 白名单；默认忽略所有转发头
+- 确保代理覆盖转发头，而不是追加客户端提供的不可信值
 - 使用网络策略限制服务访问
 - 监控和记录认证尝试
 

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -60,6 +60,17 @@ func setupTemplates() *html.Engine {
 	return html.New(templatesPath, ".html")
 }
 
+func parseTrustedProxies() []string {
+	values := strings.Split(config.TrustedProxies.String(), ",")
+	proxies := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			proxies = append(proxies, value)
+		}
+	}
+	return proxies
+}
+
 // setupSessionStore initializes the session store with configured settings.
 // It sets up cookie-based session management with configurable domain support.
 // If Redis storage is enabled via SESSION_STORAGE_ENABLED=true, it will use Redis for session storage.
@@ -318,12 +329,16 @@ func createApp() *fiber.App {
 
 	log.Debug().Msg("Creating web server instance")
 	app := fiber.New(fiber.Config{
-		Views:                 engine,
-		DisableStartupMessage: true,
-		BodyLimit:             1 * 1024 * 1024,
-		ReadTimeout:           10 * time.Second,
-		WriteTimeout:          15 * time.Second,
-		IdleTimeout:           60 * time.Second,
+		Views:                   engine,
+		DisableStartupMessage:   true,
+		BodyLimit:               1 * 1024 * 1024,
+		ReadTimeout:             10 * time.Second,
+		WriteTimeout:            15 * time.Second,
+		IdleTimeout:             60 * time.Second,
+		EnableTrustedProxyCheck: true,
+		TrustedProxies:          parseTrustedProxies(),
+		ProxyHeader:             config.ProxyHeader.String(),
+		EnableIPValidation:      true,
 	})
 
 	setupMiddleware(app)

--- a/src/cmd/stargate/server_test.go
+++ b/src/cmd/stargate/server_test.go
@@ -32,6 +32,14 @@ func setupTestConfig(t *testing.T) {
 	testza.AssertNoError(t, err)
 }
 
+func TestParseTrustedProxies(t *testing.T) {
+	original := config.TrustedProxies.Value
+	t.Cleanup(func() { config.TrustedProxies.Value = original })
+	config.TrustedProxies.Value = "127.0.0.1, 10.0.0.0/8,::1"
+
+	testza.AssertEqual(t, []string{"127.0.0.1", "10.0.0.0/8", "::1"}, parseTrustedProxies())
+}
+
 // ensureTestWorkingDir ensures tests run from the project root directory
 // where the src/internal/web/templates path exists
 func ensureTestWorkingDir(t *testing.T) {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -65,6 +65,22 @@ var (
 		Validator:      ValidateNotEmptyString,
 	}
 
+	TrustedProxies = EnvVariable{
+		Name:           "TRUSTED_PROXIES",
+		Required:       false,
+		DefaultValue:   "",
+		PossibleValues: []string{"127.0.0.1,10.0.0.0/8"},
+		Validator:      ValidateIPOrCIDRList,
+	}
+
+	ProxyHeader = EnvVariable{
+		Name:           "PROXY_HEADER",
+		Required:       false,
+		DefaultValue:   "X-Forwarded-For",
+		PossibleValues: []string{"X-Forwarded-For", "CF-Connecting-IP"},
+		Validator:      ValidateNotEmptyString,
+	}
+
 	CookieDomain = EnvVariable{
 		Name:           "COOKIE_DOMAIN",
 		Required:       false,
@@ -437,7 +453,7 @@ func Initialize(l *logger.Logger) error {
 	}
 
 	// Then validate all other configuration variables
-	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &CookieDomain, &CallbackAllowedHosts, &SessionExchangeSecret, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
+	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &TrustedProxies, &ProxyHeader, &CookieDomain, &CallbackAllowedHosts, &SessionExchangeSecret, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
 
 	for _, variable := range envVariables {
 		err := variable.Validate()

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -407,6 +407,7 @@ func TestInitialize_AllConfigVariables(t *testing.T) {
 func TestInitialize_WithDefaults(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("TRUSTED_PROXIES", "")
 	// Don't set optional variables to test defaults
 
 	err := Initialize(testLogger())
@@ -416,8 +417,18 @@ func TestInitialize_WithDefaults(t *testing.T) {
 	testza.AssertEqual(t, "Stargate - Login", LoginPageTitle.Value)
 	testza.AssertEqual(t, "Copyright © 2024 - Stargate", LoginPageFooterText.Value)
 	testza.AssertEqual(t, "X-Forwarded-User", UserHeaderName.Value)
+	testza.AssertEqual(t, "", TrustedProxies.Value)
+	testza.AssertEqual(t, "X-Forwarded-For", ProxyHeader.Value)
 	testza.AssertEqual(t, "", CookieDomain.Value)
 	testza.AssertEqual(t, "en", Language.Value)
+}
+
+func TestValidateIPOrCIDRList(t *testing.T) {
+	testza.AssertTrue(t, ValidateIPOrCIDRList(EnvVariable{Value: ""}))
+	testza.AssertTrue(t, ValidateIPOrCIDRList(EnvVariable{Value: "127.0.0.1, 10.0.0.0/8, ::1"}))
+	testza.AssertFalse(t, ValidateIPOrCIDRList(EnvVariable{Value: "proxy.example.com"}))
+	testza.AssertFalse(t, ValidateIPOrCIDRList(EnvVariable{Value: "10.0.0.0/99"}))
+	testza.AssertFalse(t, ValidateIPOrCIDRList(EnvVariable{Value: "127.0.0.1,"}))
 }
 
 func TestInitialize_Language_FR(t *testing.T) {

--- a/src/internal/config/validation.go
+++ b/src/internal/config/validation.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"strings"
 	"time"
 
@@ -80,6 +81,24 @@ var (
 		return v.Value != ""
 	}
 	ValidateAny = func(v EnvVariable) bool {
+		return true
+	}
+	ValidateIPOrCIDRList = func(v EnvVariable) bool {
+		if strings.TrimSpace(v.Value) == "" {
+			return true
+		}
+		for _, value := range strings.Split(v.Value, ",") {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				return false
+			}
+			if net.ParseIP(value) != nil {
+				continue
+			}
+			if _, _, err := net.ParseCIDR(value); err != nil {
+				return false
+			}
+		}
 		return true
 	}
 	ValidateStrictPossibleValues = func(v EnvVariable) bool {

--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -27,6 +27,7 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("AUTH_HOST", "auth.example.com")
 	_ = os.Setenv("PASSWORDS", "plaintext:test123")
 	_ = os.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com,test.example.com,cookie.example.com,form.example.com,query.example.com")
+	_ = os.Setenv("TRUSTED_PROXIES", "127.0.0.1")
 	_ = os.Setenv("WARDEN_URL", "http://warden.test")
 	_ = os.Setenv("HERALD_URL", "http://herald.test")
 	_ = os.Setenv("SESSION_EXCHANGE_SECRET", "test-session-exchange-secret-32-bytes")

--- a/src/internal/handlers/utils.go
+++ b/src/internal/handlers/utils.go
@@ -21,25 +21,33 @@ import (
 // CallbackCookieName stores the cookie name for origin domain
 const CallbackCookieName = "stargate_callback"
 
+func trustForwardedHeaders(ctx *fiber.Ctx) bool {
+	return strings.TrimSpace(config.TrustedProxies.String()) != "" && ctx.IsProxyTrusted()
+}
+
 // GetForwardedHost returns the forwarded hostname from the request.
 // It prioritizes the X-Forwarded-Host header if present, otherwise falls back to the request's Hostname.
 //
 // This is useful when the application is behind a reverse proxy (like Traefik)
 // that forwards the original hostname via headers.
 func GetForwardedHost(ctx *fiber.Ctx) string {
-	forwardedHost := ctx.Get("X-Forwarded-Host")
-	if forwardedHost != "" {
-		return forwardedHost
+	if trustForwardedHeaders(ctx) {
+		forwardedHost := strings.TrimSpace(strings.Split(ctx.Get("X-Forwarded-Host"), ",")[0])
+		if forwardedHost != "" {
+			return forwardedHost
+		}
 	}
-	return ctx.Hostname()
+	return string(ctx.Request().URI().Host())
 }
 
 // GetForwardedURI returns the forwarded URI from the request.
 // It prioritizes the X-Forwarded-Uri header if present, otherwise falls back to the request's Path.
 func GetForwardedURI(ctx *fiber.Ctx) string {
-	forwardedURI := ctx.Get("X-Forwarded-Uri")
-	if forwardedURI != "" {
-		return forwardedURI
+	if trustForwardedHeaders(ctx) {
+		forwardedURI := ctx.Get("X-Forwarded-Uri")
+		if forwardedURI != "" {
+			return forwardedURI
+		}
 	}
 	return ctx.Path()
 }
@@ -50,11 +58,13 @@ func GetForwardedURI(ctx *fiber.Ctx) string {
 // This is useful for determining whether the original request was HTTP or HTTPS
 // when behind a reverse proxy.
 func GetForwardedProto(ctx *fiber.Ctx) string {
-	forwardedProto := strings.ToLower(strings.TrimSpace(strings.Split(ctx.Get("X-Forwarded-Proto"), ",")[0]))
-	if forwardedProto == "http" || forwardedProto == "https" {
-		return forwardedProto
+	if trustForwardedHeaders(ctx) {
+		forwardedProto := strings.ToLower(strings.TrimSpace(strings.Split(ctx.Get("X-Forwarded-Proto"), ",")[0]))
+		if forwardedProto == "http" || forwardedProto == "https" {
+			return forwardedProto
+		}
 	}
-	if strings.EqualFold(ctx.Protocol(), "https") {
+	if ctx.Context().IsTLS() {
 		return "https"
 	}
 	return "http"

--- a/src/internal/handlers/utils_test.go
+++ b/src/internal/handlers/utils_test.go
@@ -44,6 +44,24 @@ func TestGetForwardedHost_WithHeader(t *testing.T) {
 	testza.AssertEqual(t, "forwarded.example.com", result)
 }
 
+func TestGetForwardedHeadersIgnoredWithoutTrustedProxy(t *testing.T) {
+	original := config.TrustedProxies.Value
+	t.Cleanup(func() { config.TrustedProxies.Value = original })
+	config.TrustedProxies.Value = ""
+
+	ctx, app := createTestContextForUtils("GET", "/original", map[string]string{
+		"X-Forwarded-Host":  "attacker.example.com",
+		"X-Forwarded-Uri":   "/admin",
+		"X-Forwarded-Proto": "https",
+		"Host":              "direct.example.com",
+	})
+	defer app.ReleaseCtx(ctx)
+
+	testza.AssertEqual(t, "direct.example.com", GetForwardedHost(ctx))
+	testza.AssertEqual(t, "/", GetForwardedURI(ctx))
+	testza.AssertEqual(t, "http", GetForwardedProto(ctx))
+}
+
 func TestGetForwardedHost_WithoutHeader(t *testing.T) {
 	ctx, app := createTestContextForUtils("GET", "/test", map[string]string{
 		"Host": "original.example.com",


### PR DESCRIPTION
## Summary

- add `TRUSTED_PROXIES` IP/CIDR allowlisting and configurable `PROXY_HEADER`
- enable Fiber trusted-proxy checks and client-IP validation for every request
- ignore forwarded host, URI, and protocol headers unless the immediate peer is trusted
- make existing login, callback, step-up, audit, and rate-limit paths use the trusted boundary
- reject invalid proxy IP/CIDR configuration at startup
- document the secure default and proxy header overwrite requirement

## Why

Stargate previously trusted `X-Forwarded-Host`, `X-Forwarded-Uri`, and `X-Forwarded-Proto` from any direct client, while rate limiting and audit logging could collapse all users to the reverse proxy IP. This allowed header spoofing to influence redirects, step-up routing, cookie security decisions, and attribution.

## Compatibility

`TRUSTED_PROXIES` is intentionally empty by default. Reverse-proxy deployments must configure the immediate proxy IPs or CIDRs; direct deployments need no change.

## Tests

- covers valid and invalid IP/CIDR lists
- verifies forwarding headers are ignored without a trusted proxy
- covers proxy list parsing and existing forwarded-header behavior in the trusted test fixture
- full CI provides build, format, race tests, lint, and security scanning