### PR TITLE
fix(dev): make Compose and local HTTP login work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost # Replace with your auth host (e.g.: auth.example.com).
       - PASSWORDS=plaintext:test1234|test1337 # Replace with your passwords. See the docs for more info.
+      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - COOKIE_SECURE=false # Local HTTP only. Keep the default true in HTTPS deployments.
       - PORT=8080
     networks:
       - traefik

--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -55,6 +55,7 @@ Below are all environment variables used in code. "Required" means the service w
 | `TRUSTED_PROXIES` | comma-separated IPs/CIDRs | empty | No |
 | `PROXY_HEADER` | HTTP header name | X-Forwarded-For | No |
 | `COOKIE_DOMAIN` | String | empty | No |
+| `COOKIE_SECURE` | true/false | true | No |
 | `CALLBACK_ALLOWED_HOSTS` | comma-separated hosts | empty | No |
 | `SESSION_EXCHANGE_SECRET` | Secret string (32+ chars) | empty | No |
 | `LANGUAGE` | en, zh, fr, it, ja, de, ko | en | No |
@@ -312,8 +313,17 @@ After setting `COOKIE_DOMAIN=.example.com`:
 
 **Cookie and session behavior (current implementation)**:
 - **Session expiration**: Fixed to 24 hours in code; there is no `SESSION_TTL` (or similar) env variable.
-- **Cookie Secure**: Set from request protocol (e.g. `X-Forwarded-Proto: https`); there is no `COOKIE_SECURE` env variable.
+- **Cookie Secure**: Controlled by `COOKIE_SECURE` and enabled by default. Set it to `false` only for local HTTP development.
 - **Cookie SameSite**: Fixed to `Lax`; there is no `COOKIE_SAME_SITE` env variable.
+
+### `COOKIE_SECURE`
+
+Controls the `Secure` attribute on session and session-exchange cookies. The default `true` is appropriate for HTTPS deployments. Plain HTTP browsers will not return a Secure cookie, so the provided local Compose file and `start-local.sh` explicitly set `COOKIE_SECURE=false`.
+
+```bash
+# Local HTTP development only
+COOKIE_SECURE=false
+```
 
 ### `CALLBACK_ALLOWED_HOSTS`
 

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -171,6 +171,9 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
+      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
     networks:
       - traefik
     labels:

--- a/docs/enUS/SECURITY.md
+++ b/docs/enUS/SECURITY.md
@@ -37,7 +37,7 @@ export COOKIE_DOMAIN=.example.com
 export TRUSTED_PROXIES=10.20.0.10
 ```
 
-**Note**: In the current implementation, Cookie Secure is inferred from headers such as `X-Forwarded-Proto`; SameSite is fixed to `Lax`. The env vars `COOKIE_SECURE`, `COOKIE_SAME_SITE`, and `SESSION_TTL` are not implemented. See [CONFIG.md](CONFIG.md).
+**Note**: Cookie Secure is enabled by default and configurable through `COOKIE_SECURE`; SameSite remains fixed to `Lax`. `COOKIE_SAME_SITE` and `SESSION_TTL` are not implemented. See [CONFIG.md](CONFIG.md).
 
 ### 2. Password Security
 
@@ -63,7 +63,7 @@ export TRUSTED_PROXIES=10.20.0.10
 
 **Session Configuration** (per current implementation; full options in [CONFIG.md](CONFIG.md)):
 - **Cookie Domain**: Set `COOKIE_DOMAIN` to share sessions across subdomains
-- **Secure Flag**: Inferred from reverse proxy/request protocol (e.g. `X-Forwarded-Proto: https`); no `COOKIE_SECURE` env var
+- **Secure Flag**: Enabled by default through `COOKIE_SECURE=true`; disable only for local HTTP development
 - **SameSite**: Fixed to `Lax`; no `COOKIE_SAME_SITE` env var
 - **HttpOnly**: Cookies are automatically HttpOnly to prevent XSS attacks
 - **Expiration**: Fixed to 24 hours in code; no `SESSION_TTL` env var

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -55,6 +55,7 @@ services:
 | `TRUSTED_PROXIES` | 逗号分隔的 IP/CIDR | 空 | 否 |
 | `PROXY_HEADER` | HTTP 头名称 | X-Forwarded-For | 否 |
 | `COOKIE_DOMAIN` | String | 空 | 否 |
+| `COOKIE_SECURE` | true/false | true | 否 |
 | `CALLBACK_ALLOWED_HOSTS` | 逗号分隔的主机名 | 空 | 否 |
 | `SESSION_EXCHANGE_SECRET` | 密钥字符串（至少 32 字符） | 空 | 否 |
 | `LANGUAGE` | en, zh, fr, it, ja, de, ko | en | 否 |
@@ -312,8 +313,17 @@ COOKIE_DOMAIN=.example.com
 
 **Cookie 与会话行为说明（当前实现）**：
 - **会话过期时间**：由代码内常量固定为 24 小时，暂无 `SESSION_TTL` 等环境变量可配置。
-- **Cookie Secure**：根据请求协议（如 `X-Forwarded-Proto: https`）自动设置，暂无 `COOKIE_SECURE` 环境变量。
+- **Cookie Secure**：由 `COOKIE_SECURE` 控制，默认启用。仅在本地 HTTP 开发环境中设置为 `false`。
 - **Cookie SameSite**：固定为 `Lax`，暂无 `COOKIE_SAME_SITE` 环境变量。
+
+### `COOKIE_SECURE`
+
+控制会话 Cookie 与会话交换 Cookie 的 `Secure` 属性。默认值 `true` 适用于 HTTPS 部署。浏览器不会通过纯 HTTP 返回 Secure Cookie，因此仓库提供的本地 Compose 和 `start-local.sh` 会显式设置 `COOKIE_SECURE=false`。
+
+```bash
+# 仅用于本地 HTTP 开发
+COOKIE_SECURE=false
+```
 
 ### `CALLBACK_ALLOWED_HOSTS`
 

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -171,6 +171,9 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
+      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - COOKIE_SECURE=false # 仅本地 HTTP；HTTPS 部署请省略。
     networks:
       - traefik
     labels:

--- a/docs/zhCN/SECURITY.md
+++ b/docs/zhCN/SECURITY.md
@@ -37,7 +37,7 @@ export COOKIE_DOMAIN=.example.com
 export TRUSTED_PROXIES=10.20.0.10
 ```
 
-**说明**：当前实现中 Cookie 的 Secure 由 `X-Forwarded-Proto` 等请求头推断，SameSite 固定为 `Lax`；未提供 `COOKIE_SECURE`、`COOKIE_SAME_SITE`、`SESSION_TTL` 等环境变量，详见 [CONFIG.md](CONFIG.md)。
+**说明**：Cookie Secure 默认启用，并可通过 `COOKIE_SECURE` 配置；SameSite 仍固定为 `Lax`。当前未提供 `COOKIE_SAME_SITE`、`SESSION_TTL`，详见 [CONFIG.md](CONFIG.md)。
 
 ### 2. 密码安全
 
@@ -63,7 +63,7 @@ export TRUSTED_PROXIES=10.20.0.10
 
 **会话配置**（以当前实现为准，完整配置项见 [CONFIG.md](CONFIG.md)）:
 - **Cookie 域名**: 设置 `COOKIE_DOMAIN` 以在子域之间共享会话
-- **Secure 标志**: 由反向代理/请求协议（如 `X-Forwarded-Proto: https`）推断，暂无 `COOKIE_SECURE` 环境变量
+- **Secure 标志**: 默认通过 `COOKIE_SECURE=true` 启用；仅本地 HTTP 开发环境可关闭
 - **SameSite**: 当前固定为 `Lax`，暂无 `COOKIE_SAME_SITE` 环境变量
 - **HttpOnly**: Cookie 自动设置为 HttpOnly 以防止 XSS 攻击
 - **过期时间**: 当前为代码内固定 24 小时，暂无 `SESSION_TTL` 环境变量

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -83,6 +83,7 @@ func setupSessionStore() (*fibersession.Store, *redis.Client) {
 		WithExpiration(config.SessionExpiration).
 		WithCookieName(auth.SessionCookieName).
 		WithCookiePath("/").
+		WithSecure(config.CookieSecure.ToBool()).
 		WithHTTPOnly(true).
 		WithSameSite("Lax")
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -89,6 +89,14 @@ var (
 		Validator:      ValidateAny, // Empty value is also valid (means not setting domain)
 	}
 
+	CookieSecure = EnvVariable{
+		Name:           "COOKIE_SECURE",
+		Required:       false,
+		DefaultValue:   "true",
+		PossibleValues: []string{"true", "false"},
+		Validator:      ValidateCaseInsensitivePossibleValues,
+	}
+
 	CallbackAllowedHosts = EnvVariable{
 		Name:           "CALLBACK_ALLOWED_HOSTS",
 		Required:       false,
@@ -453,7 +461,7 @@ func Initialize(l *logger.Logger) error {
 	}
 
 	// Then validate all other configuration variables
-	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &TrustedProxies, &ProxyHeader, &CookieDomain, &CallbackAllowedHosts, &SessionExchangeSecret, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
+	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &TrustedProxies, &ProxyHeader, &CookieDomain, &CookieSecure, &CallbackAllowedHosts, &SessionExchangeSecret, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
 
 	for _, variable := range envVariables {
 		err := variable.Validate()

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -420,6 +420,7 @@ func TestInitialize_WithDefaults(t *testing.T) {
 	testza.AssertEqual(t, "", TrustedProxies.Value)
 	testza.AssertEqual(t, "X-Forwarded-For", ProxyHeader.Value)
 	testza.AssertEqual(t, "", CookieDomain.Value)
+	testza.AssertEqual(t, "true", CookieSecure.Value)
 	testza.AssertEqual(t, "en", Language.Value)
 }
 
@@ -429,6 +430,16 @@ func TestValidateIPOrCIDRList(t *testing.T) {
 	testza.AssertFalse(t, ValidateIPOrCIDRList(EnvVariable{Value: "proxy.example.com"}))
 	testza.AssertFalse(t, ValidateIPOrCIDRList(EnvVariable{Value: "10.0.0.0/99"}))
 	testza.AssertFalse(t, ValidateIPOrCIDRList(EnvVariable{Value: "127.0.0.1,"}))
+}
+
+func TestInitialize_AllowsInsecureCookieForLocalHTTP(t *testing.T) {
+	t.Setenv("AUTH_HOST", "localhost")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("COOKIE_SECURE", "false")
+
+	err := Initialize(testLogger())
+	testza.AssertNoError(t, err)
+	testza.AssertFalse(t, CookieSecure.ToBool())
 }
 
 func TestInitialize_Language_FR(t *testing.T) {

--- a/src/internal/handlers/session_share.go
+++ b/src/internal/handlers/session_share.go
@@ -28,6 +28,7 @@ func SessionShareRoute(store *session.Store, replayStores ...SessionExchangeRepl
 		WithCookieName(auth.SessionCookieName).
 		WithExpiration(config.SessionExpiration).
 		WithCookieDomain(config.CookieDomain.Value).
+		WithSecure(config.CookieSecure.ToBool()).
 		WithSameSite("Lax").
 		WithHTTPOnly(true)
 

--- a/start-local.sh
+++ b/start-local.sh
@@ -38,6 +38,9 @@ while [[ $# -gt 0 ]]; do
             echo "  PORT                   服务端口"
             echo "  AUTH_HOST              认证服务主机名"
             echo "  PASSWORDS              密码配置"
+            echo "  COOKIE_SECURE          Cookie 仅限 HTTPS（本地默认 false）"
+            echo "  CALLBACK_ALLOWED_HOSTS 允许的回调主机"
+            echo "  SESSION_EXCHANGE_SECRET 会话交换密钥（至少 32 字符）"
             echo "  DEBUG                  调试模式（true/false）"
             echo "  LANGUAGE               界面语言（zh/en）"
             echo "  WARDEN_ENABLED         启用 Warden 集成（true/false）"
@@ -58,13 +61,13 @@ echo -e "${GREEN}=== StarGate 本地启动脚本 ===${NC}\n"
 
 # 检查是否在正确的目录
 if [ ! -d "src" ]; then
-    echo -e "${RED}错误: 请在 codes 目录下运行此脚本${NC}"
+    echo -e "${RED}错误: 请在 Stargate 仓库根目录运行此脚本${NC}"
     exit 1
 fi
 
 # 检查 Go 是否安装
 if ! command -v go &> /dev/null; then
-    echo -e "${RED}错误: 未找到 Go，请先安装 Go 1.18+${NC}"
+    echo -e "${RED}错误: 未找到 Go，请先安装 Go 1.26.6+${NC}"
     exit 1
 fi
 
@@ -73,6 +76,9 @@ AUTH_HOST=${AUTH_HOST:-"localhost"}
 PASSWORDS=${PASSWORDS:-"plaintext:test123|admin123"}
 DEBUG=${DEBUG:-"true"}
 LANGUAGE=${LANGUAGE:-"zh"}
+COOKIE_SECURE=${COOKIE_SECURE:-"false"}
+CALLBACK_ALLOWED_HOSTS=${CALLBACK_ALLOWED_HOSTS:-"localhost"}
+SESSION_EXCHANGE_SECRET=${SESSION_EXCHANGE_SECRET:-"local-development-session-secret-change-me"}
 # 端口设置：命令行参数 > 环境变量 > 默认值
 if [ -n "$CUSTOM_PORT" ]; then
     PORT="$CUSTOM_PORT"
@@ -88,9 +94,10 @@ WARDEN_CACHE_TTL=${WARDEN_CACHE_TTL:-"300"}
 
 echo -e "${BLUE}配置信息:${NC}"
 echo "  AUTH_HOST: $AUTH_HOST"
-echo "  PASSWORDS: $PASSWORDS"
+echo "  PASSWORDS: 已设置（已隐藏）"
 echo "  DEBUG: $DEBUG"
 echo "  LANGUAGE: $LANGUAGE"
+echo "  COOKIE_SECURE: $COOKIE_SECURE"
 echo "  端口: $PORT"
 if [ -n "$CUSTOM_PORT" ]; then
     echo -e "  ${GREEN}✓ 端口通过命令行参数设置: $CUSTOM_PORT${NC}"
@@ -121,6 +128,9 @@ export AUTH_HOST
 export PASSWORDS
 export DEBUG
 export LANGUAGE
+export COOKIE_SECURE
+export CALLBACK_ALLOWED_HOSTS
+export SESSION_EXCHANGE_SECRET
 export PORT
 export WARDEN_ENABLED
 export WARDEN_URL


### PR DESCRIPTION
## Summary

- add explicit `COOKIE_SECURE` configuration with a secure-by-default value of `true`
- apply it consistently to session and session-exchange cookies
- set `COOKIE_SECURE=false` only in the local HTTP Compose and startup script
- add the callback allowlist and 32+ character session-exchange secret required by the demo
- stop printing configured passwords in `start-local.sh`
- update the required Go version and local startup guidance
- align English and Chinese configuration, deployment, and security docs

## Why

The supplied Compose example used plain HTTP while session-kit generated Secure cookies, so browsers did not return the login session. Cross-domain demo callbacks also lacked `CALLBACK_ALLOWED_HOSTS` and `SESSION_EXCHANGE_SECRET`, causing the example flow to fail closed. The local script additionally printed the full `PASSWORDS` value.

## Security

Production remains secure by default: `COOKIE_SECURE=true`. Disabling it is documented and configured only for local plain-HTTP development.

## Tests

- validates the default and local override
- runs shell syntax validation locally; full Go and Docker checks run in CI