### PR TITLE
fix(startup): fail closed when integration clients cannot initialize

### DIFF
--- a/src/cmd/stargate/main.go
+++ b/src/cmd/stargate/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -14,6 +15,7 @@ import (
 	"github.com/soulteary/stargate/src/internal/auditlog"
 	"github.com/soulteary/stargate/src/internal/auth"
 	"github.com/soulteary/stargate/src/internal/config"
+	"github.com/soulteary/stargate/src/internal/handlers"
 	"github.com/soulteary/tracing-kit"
 	version "github.com/soulteary/version-kit"
 )
@@ -157,8 +159,14 @@ func initConfig() error {
 		log.SetLevel(logger.DebugLevel)
 	}
 
-	// Initialize Warden client after configuration is loaded
-	auth.InitWardenClient(log)
+	// Initialize enabled service clients before accepting traffic. A configured
+	// integration must never silently degrade to a nil client.
+	if err := auth.InitWardenClient(log); err != nil {
+		return fmt.Errorf("initialize Warden client: %w", err)
+	}
+	if err := handlers.InitHeraldClient(log); err != nil {
+		return fmt.Errorf("initialize Herald client: %w", err)
+	}
 
 	return nil
 }

--- a/src/cmd/stargate/main_test.go
+++ b/src/cmd/stargate/main_test.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/MarvinJWendt/testza"
 	"github.com/gofiber/fiber/v2"
 	logger "github.com/soulteary/logger-kit"
+	"github.com/soulteary/stargate/src/internal/auth"
 	"github.com/soulteary/stargate/src/internal/config"
+	"github.com/soulteary/stargate/src/internal/handlers"
 	version "github.com/soulteary/version-kit"
 )
 
@@ -112,6 +115,40 @@ func TestInitConfig_MissingRequiredConfig(t *testing.T) {
 	// Call initConfig - should return error
 	err := initConfig()
 	testza.AssertNotNil(t, err)
+}
+
+func TestInitConfig_ReturnsWardenClientInitializationError(t *testing.T) {
+	initLogger()
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("WARDEN_ENABLED", "true")
+	t.Setenv("WARDEN_URL", "https://warden.example.com")
+	t.Setenv("WARDEN_TLS_CA_CERT_FILE", filepath.Join(t.TempDir(), "missing-ca.pem"))
+	t.Setenv("HERALD_ENABLED", "false")
+
+	auth.ResetWardenClientForTesting()
+	t.Cleanup(auth.ResetWardenClientForTesting)
+	err := initConfig()
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "initialize Warden client")
+}
+
+func TestInitConfig_ReturnsHeraldClientInitializationError(t *testing.T) {
+	initLogger()
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("WARDEN_ENABLED", "false")
+	t.Setenv("HERALD_ENABLED", "true")
+	t.Setenv("HERALD_URL", "https://herald.example.com")
+	t.Setenv("HERALD_TLS_CA_CERT_FILE", filepath.Join(t.TempDir(), "missing-ca.pem"))
+
+	auth.ResetWardenClientForTesting()
+	handlers.ResetHeraldClientForTest()
+	t.Cleanup(auth.ResetWardenClientForTesting)
+	t.Cleanup(handlers.ResetHeraldClientForTest)
+	err := initConfig()
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "initialize Herald client")
 }
 
 func TestInitConfig_DebugFalse(t *testing.T) {

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -202,8 +202,6 @@ func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *he
 	log.Debug().Msg("Registering routes")
 	// Initialize ForwardAuth handler
 	handlers.InitForwardAuthHandler(log)
-	// Initialize Herald client (used for OTP and TOTP via Herald proxy)
-	handlers.InitHeraldClient(log)
 
 	app.Get(RouteHealth, health.FiberHandler(healthAggregator))
 	app.Get(RouteRoot, handlers.IndexRoute(store))

--- a/src/internal/auth/auth.go
+++ b/src/internal/auth/auth.go
@@ -133,17 +133,19 @@ func CheckPassword(password string) bool {
 // It's initialized once and reused for all requests.
 var wardenClient *warden.Client
 var wardenClientInit sync.Once
+var wardenClientInitErr error
 
 // ResetWardenClientForTesting resets the Warden client and initialization state for testing purposes.
 // This function should only be used in tests.
 func ResetWardenClientForTesting() {
 	wardenClient = nil
 	wardenClientInit = sync.Once{}
+	wardenClientInitErr = nil
 }
 
 // InitWardenClient initializes the Warden client if enabled.
 // This should be called after configuration is loaded.
-func InitWardenClient(l *logger.Logger) {
+func InitWardenClient(l *logger.Logger) error {
 	log = l
 	wardenClientInit.Do(func() {
 		if !config.WardenEnabled.ToBool() {
@@ -153,7 +155,7 @@ func InitWardenClient(l *logger.Logger) {
 
 		wardenURL := config.WardenURL.String()
 		if wardenURL == "" {
-			log.Warn().Msg("WARDEN_URL is not set, Warden client will not be initialized")
+			wardenClientInitErr = fmt.Errorf("WARDEN_URL is required when Warden is enabled")
 			return
 		}
 
@@ -180,7 +182,7 @@ func InitWardenClient(l *logger.Logger) {
 			config.WardenTLSClientKey.String(), config.WardenTLSServerName.String(),
 		)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to configure Warden TLS")
+			wardenClientInitErr = fmt.Errorf("configure Warden TLS: %w", err)
 			return
 		}
 		if tlsConfig != nil {
@@ -190,13 +192,15 @@ func InitWardenClient(l *logger.Logger) {
 		// Create client
 		client, err := warden.NewClient(opts)
 		if err != nil {
-			log.Warn().Err(err).Msg("Failed to initialize Warden client. Check WARDEN_URL and WARDEN_ENABLED configuration.")
+			wardenClientInitErr = fmt.Errorf("create Warden client: %w", err)
 			return
 		}
 
 		wardenClient = client
 		log.Info().Msg("Warden client initialized successfully")
 	})
+
+	return wardenClientInitErr
 }
 
 func buildWardenTLSConfig(caFile, certFile, keyFile, serverName string) (*tls.Config, error) {

--- a/src/internal/auth/auth_test.go
+++ b/src/internal/auth/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -396,7 +397,7 @@ func TestInitWardenClient_NotEnabled(t *testing.T) {
 	testza.AssertNoError(t, err)
 
 	wardenClient = nil
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNil(t, wardenClient)
 }
 
@@ -409,6 +410,26 @@ func TestInitWardenClient_NoURL(t *testing.T) {
 
 	err := config.Initialize(testLogger())
 	testza.AssertNotNil(t, err)
+}
+
+func TestInitWardenClient_ReturnsAndRemembersTLSConfigurationError(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("WARDEN_ENABLED", "true")
+	t.Setenv("WARDEN_URL", "https://warden.example.com")
+	t.Setenv("WARDEN_TLS_CA_CERT_FILE", filepath.Join(t.TempDir(), "missing-ca.pem"))
+
+	ResetWardenClientForTesting()
+	t.Cleanup(ResetWardenClientForTesting)
+	testza.AssertNoError(t, config.Initialize(testLogger()))
+
+	err := InitWardenClient(testLogger())
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "configure Warden TLS")
+	testza.AssertNil(t, wardenClient)
+
+	// sync.Once must not turn a failed first initialization into a later nil error.
+	testza.AssertNotNil(t, InitWardenClient(testLogger()))
 }
 
 // TestInitWardenClient_CustomTTL tests that InitWardenClient uses custom TTL when provided
@@ -425,7 +446,7 @@ func TestInitWardenClient_CustomTTL(t *testing.T) {
 	// Reset client to nil for this test
 	wardenClient = nil
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	// Even if client creation fails (due to invalid URL or network), the function should not panic
 	// We're testing that custom TTL is parsed correctly
 }
@@ -444,7 +465,7 @@ func TestInitWardenClient_InvalidTTL(t *testing.T) {
 	// Reset client to nil for this test
 	wardenClient = nil
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	// Should not panic even with invalid TTL (should use default)
 }
 
@@ -462,7 +483,7 @@ func TestInitWardenClient_NegativeTTL(t *testing.T) {
 	// Reset client to nil for this test
 	wardenClient = nil
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	// Should not panic even with negative TTL (should use default)
 }
 
@@ -480,7 +501,7 @@ func TestInitWardenClient_ZeroTTL(t *testing.T) {
 	// Reset client to nil for this test
 	wardenClient = nil
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	// Should not panic even with zero TTL (should use default)
 }
 
@@ -709,7 +730,7 @@ func TestInitWardenClient_Success(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	// Client should be initialized
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 }
@@ -783,7 +804,7 @@ func TestCheckUserInList_Success_WithPhone(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 
 	// Test with valid phone
@@ -834,7 +855,7 @@ func TestCheckUserInList_PhoneWithSpaces(t *testing.T) {
 	ResetWardenClientForTesting()
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 
 	result := CheckUserInList(context.Background(), "138 0013 8000", "")
 	testza.AssertTrue(t, result, "should return true when phone has spaces (normalized to 13800138000)")
@@ -909,7 +930,7 @@ func TestCheckUserInList_Success_WithMail(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 
 	// Test with valid email
@@ -993,7 +1014,7 @@ func TestCheckUserInList_Success_WithBoth(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 
 	// Test with both phone and email (should match by phone first)
@@ -1061,7 +1082,7 @@ func TestCheckUserInList_Success_WithBoth_FallbackToMail(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 
 	// Test with phone that doesn't exist but mail that does (should fallback to mail)
@@ -1117,7 +1138,7 @@ func TestCheckUserInList_Failure_UserNotInList(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 
 	// Test with user not in list
@@ -1186,7 +1207,7 @@ func TestCheckUserInList_WithContext(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 
 	// Test with custom context
@@ -1240,7 +1261,7 @@ func TestGetUserInfo_PrefersPhone(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 
 	user := GetUserInfo(context.Background(), "13800138000", "user1@example.com")
@@ -1298,7 +1319,7 @@ func TestGetUserInfo_FallbackToMail(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 
 	user := GetUserInfo(context.Background(), "99999999999", "user2@example.com")
@@ -1341,7 +1362,7 @@ func TestGetUserInfo_InactiveUser(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 	testza.AssertNotNil(t, wardenClient, "Warden client should be initialized")
 
 	user := GetUserInfo(context.Background(), "13800138000", "")
@@ -1356,7 +1377,7 @@ func TestGetUserInfo_WardenDisabled(t *testing.T) {
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 	// InitWardenClient sets the package-level logger so log.Debug() in GetUserInfo does not panic
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 
 	user := GetUserInfo(context.Background(), "13800138000", "user@example.com")
 	testza.AssertNil(t, user, "should return nil when Warden is disabled")
@@ -1371,7 +1392,7 @@ func TestGetUserInfo_EmptyIdentifiers(t *testing.T) {
 	ResetWardenClientForTesting()
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 
 	user := GetUserInfo(context.Background(), "", "")
 	testza.AssertNil(t, user, "should return nil when both phone and mail are empty")
@@ -1402,7 +1423,7 @@ func TestGetUserInfo_WithContext(t *testing.T) {
 	ResetWardenClientForTesting()
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
-	InitWardenClient(testLogger())
+	testza.AssertNoError(t, InitWardenClient(testLogger()))
 
 	user := GetUserInfo(context.TODO(), "13800138000", "")
 	testza.AssertNotNil(t, user, "should return user with valid context")

--- a/src/internal/handlers/client_init_test.go
+++ b/src/internal/handlers/client_init_test.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/MarvinJWendt/testza"
+	"github.com/soulteary/stargate/src/internal/config"
+)
+
+func TestInitHeraldClientReturnsAndRemembersConfigurationError(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("HERALD_ENABLED", "true")
+	t.Setenv("HERALD_URL", "https://herald.example.com")
+	t.Setenv("HERALD_TLS_CA_CERT_FILE", filepath.Join(t.TempDir(), "missing-ca.pem"))
+
+	ResetHeraldClientForTest()
+	t.Cleanup(ResetHeraldClientForTest)
+	testza.AssertNoError(t, config.Initialize(testLogger()))
+
+	err := InitHeraldClient(testLogger())
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "create Herald client")
+	testza.AssertNil(t, heraldClient)
+
+	// sync.Once must not turn a failed first initialization into a later nil error.
+	testza.AssertNotNil(t, InitHeraldClient(testLogger()))
+}

--- a/src/internal/handlers/e2e_integration_test.go
+++ b/src/internal/handlers/e2e_integration_test.go
@@ -395,8 +395,8 @@ func TestE2E_CompleteLoginFlow(t *testing.T) {
 
 	resetHeraldClientForTesting()
 	auth.ResetWardenClientForTesting()
-	auth.InitWardenClient(testLoggerE2E())
-	InitHeraldClient(testLoggerE2E())
+	testza.AssertNoError(t, auth.InitWardenClient(testLoggerE2E()))
+	testza.AssertNoError(t, InitHeraldClient(testLoggerE2E()))
 
 	// Create Stargate app
 	store := session.New(session.Config{

--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -255,7 +255,7 @@ func TestLoginAPI_WardenUserNotFound(t *testing.T) {
 	auth.ResetWardenClientForTesting()
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
-	auth.InitWardenClient(testLogger())
+	testza.AssertNoError(t, auth.InitWardenClient(testLogger()))
 
 	store := setupTestStore()
 	handler := LoginAPI(store)
@@ -1727,7 +1727,7 @@ func TestCheckRoute_WardenAuth_ValidPhone(t *testing.T) {
 	t.Setenv("WARDEN_URL", server.URL)
 	_ = config.Initialize(testLogger())
 	auth.ResetWardenClientForTesting()
-	auth.InitWardenClient(testLogger())
+	testza.AssertNoError(t, auth.InitWardenClient(testLogger()))
 
 	store := setupTestStore()
 	handler := CheckRoute(store)
@@ -1827,7 +1827,7 @@ func TestCheckRoute_WardenAuth_ValidMail(t *testing.T) {
 	t.Setenv("WARDEN_URL", server.URL)
 	_ = config.Initialize(testLogger())
 	auth.ResetWardenClientForTesting()
-	auth.InitWardenClient(testLogger())
+	testza.AssertNoError(t, auth.InitWardenClient(testLogger()))
 
 	store := setupTestStore()
 	handler := CheckRoute(store)
@@ -1899,7 +1899,7 @@ func TestCheckRoute_WardenAuth_InvalidUser(t *testing.T) {
 	t.Setenv("WARDEN_URL", server.URL)
 	_ = config.Initialize(testLogger())
 	auth.ResetWardenClientForTesting()
-	auth.InitWardenClient(testLogger())
+	testza.AssertNoError(t, auth.InitWardenClient(testLogger()))
 
 	store := setupTestStore()
 	handler := CheckRoute(store)
@@ -2026,7 +2026,7 @@ func TestCheckRoute_WardenAuth_WithBothHeaders(t *testing.T) {
 	t.Setenv("WARDEN_URL", server.URL)
 	_ = config.Initialize(testLogger())
 	auth.ResetWardenClientForTesting()
-	auth.InitWardenClient(testLogger())
+	testza.AssertNoError(t, auth.InitWardenClient(testLogger()))
 
 	store := setupTestStore()
 	handler := CheckRoute(store)
@@ -2113,7 +2113,7 @@ func TestCheckRoute_WardenAuth_WithCustomUserHeader(t *testing.T) {
 	t.Setenv("WARDEN_URL", server.URL)
 	_ = config.Initialize(testLogger())
 	auth.ResetWardenClientForTesting()
-	auth.InitWardenClient(testLogger())
+	testza.AssertNoError(t, auth.InitWardenClient(testLogger()))
 
 	store := setupTestStore()
 	handler := CheckRoute(store)

--- a/src/internal/handlers/login.go
+++ b/src/internal/handlers/login.go
@@ -34,12 +34,13 @@ func SetLogger(l *logger.Logger) {
 }
 
 var (
-	heraldClient     *herald.Client
-	heraldClientInit sync.Once
+	heraldClient        *herald.Client
+	heraldClientInit    sync.Once
+	heraldClientInitErr error
 )
 
 // InitHeraldClient initializes the Herald client if enabled
-func InitHeraldClient(l *logger.Logger) {
+func InitHeraldClient(l *logger.Logger) error {
 	log = l
 	heraldClientInit.Do(func() {
 		if !config.HeraldEnabled.ToBool() {
@@ -49,7 +50,7 @@ func InitHeraldClient(l *logger.Logger) {
 
 		heraldURL := config.HeraldURL.String()
 		if heraldURL == "" {
-			log.Warn().Msg("HERALD_URL is not set, Herald client will not be initialized")
+			heraldClientInitErr = fmt.Errorf("HERALD_URL is required when Herald is enabled")
 			return
 		}
 
@@ -91,13 +92,15 @@ func InitHeraldClient(l *logger.Logger) {
 
 		client, err := herald.NewClient(opts)
 		if err != nil {
-			log.Warn().Err(err).Msg("Failed to initialize Herald client. Check HERALD_URL and HERALD_ENABLED configuration.")
+			heraldClientInitErr = fmt.Errorf("create Herald client: %w", err)
 			return
 		}
 
 		heraldClient = client
 		log.Info().Msg("Herald client initialized successfully")
 	})
+
+	return heraldClientInitErr
 }
 
 // getHeraldClient returns the herald client.
@@ -110,6 +113,7 @@ func getHeraldClient() *herald.Client {
 func ResetHeraldClientForTest() {
 	heraldClient = nil
 	heraldClientInit = sync.Once{}
+	heraldClientInitErr = nil
 }
 
 // generateUserID generates a user ID from phone/mail

--- a/src/internal/handlers/send_verify_code_test.go
+++ b/src/internal/handlers/send_verify_code_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/MarvinJWendt/testza"
@@ -28,8 +27,7 @@ func testLoggerSendVerifyCode() *logger.Logger {
 }
 
 func resetHeraldClientForTesting() {
-	heraldClient = nil
-	heraldClientInit = sync.Once{}
+	ResetHeraldClientForTest()
 }
 
 func setupSendVerifyCodeBaseEnv(t *testing.T) {
@@ -102,7 +100,7 @@ func TestSendVerifyCodeAPI_WardenUserNotFound(t *testing.T) {
 	testLog := testLoggerSendVerifyCode()
 	err := config.Initialize(testLog)
 	testza.AssertNoError(t, err)
-	auth.InitWardenClient(testLog)
+	testza.AssertNoError(t, auth.InitWardenClient(testLog))
 	SetLogger(testLog)
 
 	ctx, app := createTestContext("POST", "/_send_verify_code", map[string]string{
@@ -181,8 +179,8 @@ func TestSendVerifyCodeAPI_Success(t *testing.T) {
 	testLog := testLoggerSendVerifyCode()
 	err := config.Initialize(testLog)
 	testza.AssertNoError(t, err)
-	auth.InitWardenClient(testLog)
-	InitHeraldClient(testLog)
+	testza.AssertNoError(t, auth.InitWardenClient(testLog))
+	testza.AssertNoError(t, InitHeraldClient(testLog))
 
 	app := fiber.New()
 	app.Post("/_send_verify_code", SendVerifyCodeAPI())
@@ -263,8 +261,8 @@ func TestSendVerifyCodeAPI_IdempotencyKeyPassthrough(t *testing.T) {
 	testLog := testLoggerSendVerifyCode()
 	err := config.Initialize(testLog)
 	testza.AssertNoError(t, err)
-	auth.InitWardenClient(testLog)
-	InitHeraldClient(testLog)
+	testza.AssertNoError(t, auth.InitWardenClient(testLog))
+	testza.AssertNoError(t, InitHeraldClient(testLog))
 
 	app := fiber.New()
 	app.Post("/_send_verify_code", SendVerifyCodeAPI())
@@ -336,8 +334,8 @@ func TestSendVerifyCodeAPI_LocaleFromConfig(t *testing.T) {
 	testLog := testLoggerSendVerifyCode()
 	err := config.Initialize(testLog)
 	testza.AssertNoError(t, err)
-	auth.InitWardenClient(testLog)
-	InitHeraldClient(testLog)
+	testza.AssertNoError(t, auth.InitWardenClient(testLog))
+	testza.AssertNoError(t, InitHeraldClient(testLog))
 
 	app := fiber.New()
 	app.Post("/_send_verify_code", SendVerifyCodeAPI())
@@ -421,8 +419,8 @@ func TestSendVerifyCodeAPI_GetLocaleFromConfig_AllLanguages(t *testing.T) {
 			testLog := testLoggerSendVerifyCode()
 			err := config.Initialize(testLog)
 			testza.AssertNoError(t, err)
-			auth.InitWardenClient(testLog)
-			InitHeraldClient(testLog)
+			testza.AssertNoError(t, auth.InitWardenClient(testLog))
+			testza.AssertNoError(t, InitHeraldClient(testLog))
 
 			app := fiber.New()
 			app.Post("/_send_verify_code", SendVerifyCodeAPI())
@@ -484,8 +482,8 @@ func TestSendVerifyCodeAPI_HeraldRateLimited(t *testing.T) {
 	testLog := testLoggerSendVerifyCode()
 	err := config.Initialize(testLog)
 	testza.AssertNoError(t, err)
-	auth.InitWardenClient(testLog)
-	InitHeraldClient(testLog)
+	testza.AssertNoError(t, auth.InitWardenClient(testLog))
+	testza.AssertNoError(t, InitHeraldClient(testLog))
 
 	app := fiber.New()
 	app.Post("/_send_verify_code", SendVerifyCodeAPI())

--- a/src/internal/handlers/totp_enroll_test.go
+++ b/src/internal/handlers/totp_enroll_test.go
@@ -122,7 +122,7 @@ func TestTOTPEnrollRoute_AlreadyBound_RedirectsToRevoke(t *testing.T) {
 	t.Setenv("HERALD_TOTP_ENABLED", "true")
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
-	InitHeraldClient(testLogger())
+	testza.AssertNoError(t, InitHeraldClient(testLogger()))
 
 	store := setupTestStore()
 	handler := TOTPEnrollRoute(store)

--- a/src/internal/handlers/totp_revoke_test.go
+++ b/src/internal/handlers/totp_revoke_test.go
@@ -44,7 +44,7 @@ func TestTOTPRevokeRoute_Authenticated_NoUserID_400(t *testing.T) {
 	t.Setenv("HERALD_TOTP_ENABLED", "true")
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
-	InitHeraldClient(testLogger())
+	testza.AssertNoError(t, InitHeraldClient(testLogger()))
 
 	store := setupTestStore()
 	handler := TOTPRevokeRoute(store)
@@ -121,7 +121,7 @@ func TestTOTPRevokeConfirmAPI_NoUserID_400(t *testing.T) {
 	t.Setenv("HERALD_TOTP_ENABLED", "true")
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
-	InitHeraldClient(testLogger())
+	testza.AssertNoError(t, InitHeraldClient(testLogger()))
 
 	store := setupTestStore()
 	handler := TOTPRevokeConfirmAPI(store)


### PR DESCRIPTION
## Summary

- make Warden and Herald client initialization return actionable errors
- retain initialization failures across `sync.Once` calls instead of later reporting success
- initialize both enabled integrations during startup, before the server accepts traffic
- remove late Herald initialization from route registration
- update existing tests to assert initialization and add TLS failure/startup propagation coverage

## Why

When either integration was enabled but its URL, TLS material, or SDK options were invalid, Stargate only logged a warning and continued with a nil client. The process could therefore appear healthy while configured authentication or verification paths were unusable. This change fails startup closed for invalid enabled integrations.

## Tests

- Warden TLS initialization failure is returned and remembered
- Herald client construction failure is returned and remembered
- `initConfig` propagates failures from both integrations
- existing initializer call sites now assert success

Full formatting, vet, race, lint, and build checks run in CI.