### PR TITLE
feat: split liveness and readiness health probes

### DIFF
--- a/README.deDE.md
+++ b/README.deDE.md
@@ -143,7 +143,7 @@ Umfassende Dokumentation ist verfügbar, um Ihnen zu helfen, das Beste aus Starg
 
 ### Schnellreferenz
 
-- **API-Endpunkte**: `GET /_auth` (Auth-Prüfung), `GET /_login` (Login-Seite), `POST /_login` (Login), `POST /_send_verify_code` (OTP senden), `POST /_logout` (Logout), `GET /_session_exchange?ticket=...` (Cross-Domain), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke` (TOTP bei Herald), `GET /health` (Gesundheitsprüfung), `GET /metrics` (Prometheus)
+- **API-Endpunkte**: `GET /_auth` (Auth-Prüfung), `GET /_login` (Login-Seite), `POST /_login` (Login), `POST /_send_verify_code` (OTP senden), `POST /_logout` (Logout), `GET /_session_exchange?ticket=...` (Cross-Domain), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke` (TOTP bei Herald), `GET /healthz`, `GET /readyz` (Gesundheitsprüfung), `GET /metrics` (Prometheus)
 - **Bereitstellung**: Docker Compose wird für den Schnellstart empfohlen. Siehe [DEPLOYMENT.md](docs/deDE/DEPLOYMENT.md) für die Produktionsbereitstellung.
 - **Entwicklung**: Für entwicklungsbezogene Dokumentation siehe [ARCHITECTURE.md](docs/deDE/ARCHITECTURE.md)
 

--- a/README.frFR.md
+++ b/README.frFR.md
@@ -143,7 +143,7 @@ Une documentation complète est disponible pour vous aider à tirer le meilleur 
 
 ### Référence Rapide
 
-- **Points de Terminaison API** : `GET /_auth` (vérification d’auth), `GET /_login` (page de connexion), `POST /_login` (connexion), `POST /_send_verify_code` (envoyer OTP), `POST /_logout` (déconnexion), `GET /_session_exchange?ticket=...` (cross-domain), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke` (TOTP si Herald activé), `GET /health` (santé), `GET /metrics` (Prometheus)
+- **Points de Terminaison API** : `GET /_auth` (vérification d’auth), `GET /_login` (page de connexion), `POST /_login` (connexion), `POST /_send_verify_code` (envoyer OTP), `POST /_logout` (déconnexion), `GET /_session_exchange?ticket=...` (cross-domain), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke` (TOTP si Herald activé), `GET /healthz`, `GET /readyz` (santé), `GET /metrics` (Prometheus)
 - **Déploiement** : Docker Compose recommandé pour un démarrage rapide. Voir [DEPLOYMENT.md](docs/frFR/DEPLOYMENT.md) pour le déploiement en production.
 - **Développement** : Pour la documentation liée au développement, voir [ARCHITECTURE.md](docs/frFR/ARCHITECTURE.md)
 

--- a/README.itIT.md
+++ b/README.itIT.md
@@ -143,7 +143,7 @@ Accedi alla pagina di login a `http://localhost:8080/_login?callback=localhost`
 
 ### Riferimento Rapido
 
-- **Endpoint API**: `GET /_auth` (verifica auth), `GET /_login` (pagina login), `POST /_login` (login), `POST /_send_verify_code` (invia OTP), `POST /_logout` (logout), `GET /_session_exchange?ticket=...` (cross-domain), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke` (TOTP se Herald abilitato), `GET /health` (salute), `GET /metrics` (Prometheus)
+- **Endpoint API**: `GET /_auth` (verifica auth), `GET /_login` (pagina login), `POST /_login` (login), `POST /_send_verify_code` (invia OTP), `POST /_logout` (logout), `GET /_session_exchange?ticket=...` (cross-domain), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke` (TOTP se Herald abilitato), `GET /healthz`, `GET /readyz` (salute), `GET /metrics` (Prometheus)
 - **Deployment**: Docker Compose consigliato per avvio rapido. Vedi [DEPLOYMENT.md](docs/itIT/DEPLOYMENT.md) per il deployment in produzione.
 - **Sviluppo**: Per la documentazione relativa allo sviluppo, vedi [ARCHITECTURE.md](docs/itIT/ARCHITECTURE.md)
 

--- a/README.jaJP.md
+++ b/README.jaJP.md
@@ -143,7 +143,7 @@ Stargate を最大限に活用するための包括的なドキュメントが�
 
 ### クイックリファレンス
 
-- **API エンドポイント**：`GET /_auth`（認証チェック）、`GET /_login`（ログインページ）、`POST /_login`（ログイン）、`POST /_send_verify_code`（OTP 送信）、`POST /_logout`（ログアウト）、`GET /_session_exchange?ticket=...`（クロスドメイン）、`POST /totp/enroll`、`POST /totp/enroll/confirm`、`GET /totp/revoke`、`POST /totp/revoke`（Herald TOTP 有効時）、`GET /health`（ヘルスチェック）、`GET /metrics`（Prometheus）
+- **API エンドポイント**：`GET /_auth`（認証チェック）、`GET /_login`（ログインページ）、`POST /_login`（ログイン）、`POST /_send_verify_code`（OTP 送信）、`POST /_logout`（ログアウト）、`GET /_session_exchange?ticket=...`（クロスドメイン）、`POST /totp/enroll`、`POST /totp/enroll/confirm`、`GET /totp/revoke`、`POST /totp/revoke`（Herald TOTP 有効時）、`GET /healthz`, `GET /readyz`（ヘルスチェック）、`GET /metrics`（Prometheus）
 - **デプロイメント**：クイックスタートには Docker Compose を推奨。本番環境デプロイメントについては [DEPLOYMENT.md](docs/jaJP/DEPLOYMENT.md) を参照。
 - **開発**：開発関連のドキュメントについては [ARCHITECTURE.md](docs/jaJP/ARCHITECTURE.md) を参照
 

--- a/README.koKR.md
+++ b/README.koKR.md
@@ -143,7 +143,7 @@ Stargate를 최대한 활용할 수 있도록 포괄적인 문서가 제공됩�
 
 ### 빠른 참조
 
-- **API 엔드포인트**: `GET /_auth`(인증 확인), `GET /_login`(로그인 페이지), `POST /_login`(로그인), `POST /_send_verify_code`(OTP 발송), `POST /_logout`(로그아웃), `GET /_session_exchange?ticket=...`(크로스 도메인), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke`(Herald TOTP 사용 시), `GET /health`(상태 확인), `GET /metrics`(Prometheus)
+- **API 엔드포인트**: `GET /_auth`(인증 확인), `GET /_login`(로그인 페이지), `POST /_login`(로그인), `POST /_send_verify_code`(OTP 발송), `POST /_logout`(로그아웃), `GET /_session_exchange?ticket=...`(크로스 도메인), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke`(Herald TOTP 사용 시), `GET /healthz`, `GET /readyz`(상태 확인), `GET /metrics`(Prometheus)
 - **배포**: 빠른 시작에는 Docker Compose를 권장합니다. 프로덕션 배포는 [DEPLOYMENT.md](docs/koKR/DEPLOYMENT.md)를 참조하세요.
 - **개발**: 개발 관련 문서는 [ARCHITECTURE.md](docs/koKR/ARCHITECTURE.md)를 참조하세요
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Comprehensive documentation is available to help you get the most out of Stargat
 
 ### Quick Reference
 
-- **API Endpoints**: `GET /_auth` (auth check), `GET /_login` (login page), `POST /_login` (login), `POST /_send_verify_code` (send OTP), `POST /_logout` (logout), `GET /_session_exchange?ticket=...` (cross-domain), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke` (TOTP when Herald TOTP enabled), `GET /health` (health check), `GET /metrics` (Prometheus)
+- **API Endpoints**: `GET /_auth` (auth check), `GET /_login` (login page), `POST /_login` (login), `POST /_send_verify_code` (send OTP), `POST /_logout` (logout), `GET /_session_exchange?ticket=...` (cross-domain), `POST /totp/enroll`, `POST /totp/enroll/confirm`, `GET /totp/revoke`, `POST /totp/revoke` (TOTP when Herald TOTP enabled), `GET /healthz`, `GET /readyz` (health check), `GET /metrics` (Prometheus)
 - **Deployment**: Docker Compose recommended for quick start. See [DEPLOYMENT.md](docs/enUS/DEPLOYMENT.md) for production deployment.
 - **Development**: For development-related documentation, see [ARCHITECTURE.md](docs/enUS/ARCHITECTURE.md)
 

--- a/README.zhCN.md
+++ b/README.zhCN.md
@@ -139,7 +139,7 @@ chmod +x start-local.sh
 
 ### 快速参考
 
-- **API 端点**：`GET /_auth`（认证检查）、`GET /_login`（登录页）、`POST /_login`（登录）、`POST /_send_verify_code`（发送 OTP）、`POST /_logout`（登出）、`GET /_session_exchange?ticket=...`（跨域）、`POST /totp/enroll`、`POST /totp/enroll/confirm`、`GET /totp/revoke`、`POST /totp/revoke`（Herald TOTP 启用时）、`GET /health`（健康检查）、`GET /metrics`（Prometheus）
+- **API 端点**：`GET /_auth`（认证检查）、`GET /_login`（登录页）、`POST /_login`（登录）、`POST /_send_verify_code`（发送 OTP）、`POST /_logout`（登出）、`GET /_session_exchange?ticket=...`（跨域）、`POST /totp/enroll`、`POST /totp/enroll/confirm`、`GET /totp/revoke`、`POST /totp/revoke`（Herald TOTP 启用时）、`GET /healthz`, `GET /readyz`（健康检查）、`GET /metrics`（Prometheus）
 - **部署**：推荐使用 Docker Compose 快速开始。生产环境部署请参阅 [DEPLOYMENT.md](docs/zhCN/DEPLOYMENT.md)
 - **开发**：开发相关文档请参阅 [ARCHITECTURE.md](docs/zhCN/ARCHITECTURE.md)
 

--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -424,31 +424,22 @@ Confirms TOTP unbind (removes TOTP from the account).
 
 **Notes:** TOTP creation and verification are performed by Herald (which may proxy to herald-totp). Stargate only orchestrates the UI and session; it does not implement OTP algorithms.
 
-## Health Check Endpoint
+## Health Check Endpoints
 
-### `GET /health`
+### `GET /healthz`
 
-Service health check endpoint. Used to monitor service status.
+Process liveness endpoint. It returns `200 OK` while Stargate is running and does not query Redis, Warden, or Herald. Use it for container health checks and Kubernetes liveness probes.
 
-#### Response
+### `GET /readyz`
 
-**Success Response (200 OK)**
-
-```
-HTTP/1.1 200 OK
-```
-
-#### Example
+Dependency readiness endpoint. It aggregates the configured Redis, Warden, and Herald checks and returns a non-2xx response when a required dependency is unavailable. Use it for Kubernetes readiness probes and load-balancer routing.
 
 ```bash
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
+curl http://auth.example.com/readyz
 ```
 
-**Typical Uses:**
-
-- Docker health checks
-- Kubernetes liveness probes
-- Load balancer health checks
+`GET /health` remains a deprecated compatibility alias for `GET /readyz`.
 
 ## Metrics Endpoint
 

--- a/docs/enUS/ARCHITECTURE.md
+++ b/docs/enUS/ARCHITECTURE.md
@@ -103,9 +103,9 @@ Handlers are responsible for processing HTTP requests:
 - **GET /metrics**: Prometheus metrics (metrics-kit)
 
 **Health check endpoints (to avoid confusion with downstream services):**
-- **Stargate**: Exposes `GET /health` as the aggregated health entrypoint. It reports Stargate, Redis (when session storage is enabled), and optionally Warden/Herald status.
-- **Herald**: Uses `GET /healthz`. When Herald is enabled, Stargate's `/health` calls `HERALD_URL/healthz` to determine Herald availability.
-- **Warden**: Uses `GET /health`. When Warden is enabled, Stargate's `/health` calls `WARDEN_URL/health` to determine Warden availability.
+- **Stargate**: Exposes `GET /healthz` for process liveness and `GET /readyz` for aggregated dependency readiness. The deprecated `GET /health` route aliases readiness.
+- **Herald**: Uses `GET /healthz`. When Herald is enabled, Stargate readiness calls `HERALD_URL/healthz`.
+- **Warden**: Uses `GET /health`. When Warden is enabled, Stargate readiness calls `WARDEN_URL/health`.
 
 ### 4. Password and Security
 
@@ -390,7 +390,7 @@ Modify the `internal/web/templates/login.html` template file.
 - Uses Zerolog (via logger-kit) for structured logging
 - Supports debug mode (DEBUG=true)
 - All critical operations are logged
-- Health check endpoint (`GET /health`) and Prometheus metrics (`GET /metrics`) available for monitoring
+- Liveness (`GET /healthz`), readiness (`GET /readyz`), and Prometheus metrics (`GET /metrics`) available for monitoring
 
 ## Testing
 

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -380,7 +380,7 @@ services:
 services:
   stargate:
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      test: ["CMD", "curl", "-f", "http://localhost/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -430,12 +430,12 @@ services:
 
 #### 2. Health Check Endpoint
 
-Use the `/health` endpoint for monitoring:
+Use `/healthz` for process liveness. Use `/readyz` separately when traffic should only be sent after Redis, Warden, and Herald dependencies are ready. The legacy `/health` endpoint remains a deprecated readiness alias.
 
 ```bash
 # Health check script
 #!/bin/bash
-if curl -f http://localhost/health > /dev/null 2>&1; then
+if curl -f http://localhost/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -493,7 +493,7 @@ docker stats stargate
 Monitor response time using the health check endpoint:
 
 ```bash
-time curl http://auth.example.com/health
+time curl http://auth.example.com/healthz
 ```
 
 ### Regular Maintenance
@@ -589,7 +589,7 @@ DEBUG=true
 
 ```bash
 # Test from inside container
-docker exec stargate curl -f http://localhost/health
+docker exec stargate curl -f http://localhost/healthz
 ```
 
 #### 3. View Traefik Logs
@@ -602,7 +602,7 @@ docker logs traefik
 
 ```bash
 # Test health check
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
 
 # Test authentication (using Header)
 curl -H "Stargate-Password: yourpassword" http://auth.example.com/_auth
@@ -650,7 +650,7 @@ docker run -d \
 5. **Verify Service:**
 
 ```bash
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
 ```
 
 ### Rollback

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -420,29 +420,20 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## 健康检查端点
 
-### `GET /health`
+### `GET /healthz`
 
-服务健康检查端点。用于监控服务状态。
+进程存活端点。只要 Stargate 进程正常运行就返回 `200 OK`，不会查询 Redis、Warden 或 Herald。用于容器健康检查和 Kubernetes 存活探针。
 
-#### 响应
+### `GET /readyz`
 
-**成功响应（200 OK）**
-
-```
-HTTP/1.1 200 OK
-```
-
-#### 示例
+依赖就绪端点。聚合已配置的 Redis、Warden 和 Herald 检查；必要依赖不可用时返回非 2xx。用于 Kubernetes 就绪探针和负载均衡器摘流。
 
 ```bash
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
+curl http://auth.example.com/readyz
 ```
 
-**典型用途：**
-
-- Docker 健康检查
-- Kubernetes 存活探针
-- 负载均衡器健康检查
+`GET /health` 保留为 `GET /readyz` 的弃用兼容别名。
 
 ## 指标端点
 

--- a/docs/zhCN/ARCHITECTURE.md
+++ b/docs/zhCN/ARCHITECTURE.md
@@ -103,9 +103,9 @@ src/
 - **GET /metrics**: Prometheus 指标（metrics-kit）
 
 **健康检查端点说明（避免与下游混淆）：**
-- **Stargate**：暴露 `GET /health`，作为自身及聚合健康检查入口。该端点会汇总 Stargate、Redis（若启用会话存储）、以及可选的 Warden / Herald 健康状态。
-- **Herald**：健康检查路径为 `GET /healthz`。当启用 Herald 时，Stargate 的 `/health` 会请求 `HERALD_URL/healthz` 以判断 Herald 是否可用。
-- **Warden**：健康检查路径为 `GET /health`。当启用 Warden 时，Stargate 的 `/health` 会请求 `WARDEN_URL/health` 以判断 Warden 是否可用。
+- **Stargate**：暴露 `GET /healthz` 作为进程存活检查，暴露 `GET /readyz` 聚合依赖就绪状态；弃用的 `GET /health` 保留为就绪检查别名。
+- **Herald**：健康检查路径为 `GET /healthz`。启用 Herald 时，Stargate 就绪检查会请求 `HERALD_URL/healthz`。
+- **Warden**：健康检查路径为 `GET /health`。启用 Warden 时，Stargate 就绪检查会请求 `WARDEN_URL/health`。
 
 ### 4. 密码与安全
 
@@ -390,7 +390,7 @@ Stargate 支持可选的服务集成，以扩展认证功能。这些集成都�
 - 使用 Zerolog（通过 logger-kit）进行结构化日志记录
 - 支持调试模式（DEBUG=true）
 - 所有关键操作都有日志记录
-- 健康检查端点（`GET /health`）与 Prometheus 指标（`GET /metrics`）可用于监控
+- 存活检查（`GET /healthz`）、就绪检查（`GET /readyz`）与 Prometheus 指标（`GET /metrics`）可用于监控
 
 ## 测试
 

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -488,7 +488,7 @@ services:
 services:
   stargate:
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      test: ["CMD", "curl", "-f", "http://localhost/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -538,12 +538,12 @@ services:
 
 #### 2. 健康检查端点
 
-使用 `/health` 端点进行监控：
+使用 `/healthz` 检查进程存活。需要在 Redis、Warden 和 Herald 依赖就绪后才接收流量时，另用 `/readyz`；旧的 `/health` 端点保留为弃用的就绪检查别名。
 
 ```bash
 # 健康检查脚本
 #!/bin/bash
-if curl -f http://localhost/health > /dev/null 2>&1; then
+if curl -f http://localhost/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -601,7 +601,7 @@ docker stats stargate
 使用健康检查端点监控响应时间：
 
 ```bash
-time curl http://auth.example.com/health
+time curl http://auth.example.com/healthz
 ```
 
 ### 定期维护
@@ -772,7 +772,7 @@ DEBUG=true
 
 ```bash
 # 从容器内测试
-docker exec stargate curl -f http://localhost/health
+docker exec stargate curl -f http://localhost/healthz
 ```
 
 #### 3. 查看 Traefik 日志
@@ -785,7 +785,7 @@ docker logs traefik
 
 ```bash
 # 测试健康检查
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
 
 # 测试认证（使用 Header）
 curl -H "Stargate-Password: yourpassword" http://auth.example.com/_auth
@@ -833,7 +833,7 @@ docker run -d \
 5. **验证服务**：
 
 ```bash
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
 ```
 
 ### 回滚

--- a/src/cmd/stargate/constants.go
+++ b/src/cmd/stargate/constants.go
@@ -16,8 +16,12 @@ const (
 	RouteAuth = "/_auth"
 	// RouteStepUp is the additional authentication route
 	RouteStepUp = "/_step_up"
-	// RouteHealth is the health check route
+	// RouteHealth is the deprecated readiness-check compatibility route.
 	RouteHealth = "/health"
+	// RouteHealthz is the process liveness route.
+	RouteHealthz = "/healthz"
+	// RouteReadyz is the dependency readiness route.
+	RouteReadyz = "/readyz"
 
 	// StaticAssetsPath is the static assets path
 	StaticAssetsPath = "./internal/web/templates/assets"

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -204,6 +204,11 @@ func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *he
 	// Initialize ForwardAuth handler
 	handlers.InitForwardAuthHandler(log)
 
+	// Liveness deliberately excludes dependencies so an external outage does not
+	// cause the container runtime to restart an otherwise healthy process.
+	app.Get(RouteHealthz, health.SimpleFiberHandler("stargate"))
+	app.Get(RouteReadyz, health.FiberHandler(healthAggregator))
+	// Keep /health as a backwards-compatible alias for readiness.
 	app.Get(RouteHealth, health.FiberHandler(healthAggregator))
 	app.Get(RouteRoot, handlers.IndexRoute(store))
 	app.Get(RouteLogin, handlers.LoginRoute(store))
@@ -280,7 +285,7 @@ func setupMiddleware(app *fiber.App) {
 	// 5. Request logging with logger-kit
 	app.Use(logger.FiberMiddleware(logger.MiddlewareConfig{
 		Logger:           log,
-		SkipPaths:        []string{"/healthz", "/metrics"},
+		SkipPaths:        []string{RouteHealthz, RouteReadyz, RouteHealth, "/metrics"},
 		IncludeRequestID: true,
 		IncludeLatency:   true,
 	}))

--- a/src/cmd/stargate/server_test.go
+++ b/src/cmd/stargate/server_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -224,11 +225,37 @@ func TestSetupRoutes(t *testing.T) {
 		setupRoutes(app, store, aggregator, handlers.NewSessionExchangeReplayStore(nil))
 	})
 
-	// Verify routes are registered by testing health endpoint
-	req := httptest.NewRequest("GET", RouteHealth, nil)
-	resp, err := app.Test(req)
+	// Verify liveness, readiness, and the compatibility route are registered.
+	for _, route := range []string{RouteHealthz, RouteReadyz, RouteHealth} {
+		req := httptest.NewRequest("GET", route, nil)
+		resp, err := app.Test(req)
+		testza.AssertNoError(t, err)
+		testza.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
+	}
+}
+
+func TestHealthzStaysLiveWhenDependencyIsUnready(t *testing.T) {
+	setupTestConfig(t)
+
+	app := fiber.New()
+	store, _ := setupSessionStore()
+	aggregator := health.NewAggregator(health.DefaultConfig().WithServiceName("stargate"))
+	aggregator.AddChecker(health.NewCheckerFunc("dependency", func(context.Context) health.CheckResult {
+		return health.CheckResult{Name: "dependency", Status: health.StatusUnhealthy}
+	}))
+	setupRoutes(app, store, aggregator, handlers.NewSessionExchangeReplayStore(nil))
+
+	liveness, err := app.Test(httptest.NewRequest("GET", RouteHealthz, nil))
 	testza.AssertNoError(t, err)
-	testza.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
+	testza.AssertEqual(t, fiber.StatusOK, liveness.StatusCode)
+
+	readiness, err := app.Test(httptest.NewRequest("GET", RouteReadyz, nil))
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusServiceUnavailable, readiness.StatusCode)
+
+	legacy, err := app.Test(httptest.NewRequest("GET", RouteHealth, nil))
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusServiceUnavailable, legacy.StatusCode)
 }
 
 func TestFindAssetsPath(t *testing.T) {
@@ -343,6 +370,8 @@ func TestCreateApp_AllRoutesRegistered(t *testing.T) {
 	// Test all routes are registered
 	routes := []string{
 		RouteHealth,
+		RouteHealthz,
+		RouteReadyz,
 		RouteRoot,
 		RouteLogin,
 		RouteLogout,


### PR DESCRIPTION
## Summary

- add `GET /healthz` as dependency-free process liveness
- add `GET /readyz` as aggregated Redis/Warden/Herald readiness
- retain `GET /health` as a deprecated readiness compatibility alias
- exclude all probe routes from request logging and update README/API/deployment/architecture documentation
- add a regression test proving dependency failure returns 503 from readiness while liveness remains 200

## Validation

- `go test ./...`
- `git diff --check`