### PR TITLE
ci: add SBOM, provenance, vulnerability scanning, and signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
 
     steps:
       - name: Checkout code
@@ -72,6 +75,15 @@ jobs:
           GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "${LDFLAGS}" -o dist/stargate-windows-amd64.exe ./src/cmd/stargate
           GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "${LDFLAGS}" -o dist/stargate-windows-arm64.exe ./src/cmd/stargate
 
+      - name: Generate release SBOM
+        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        with:
+          path: dist
+          format: cyclonedx-json
+          output-file: dist/stargate-sbom.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
       - name: Generate checksums
         run: |
           cd dist
@@ -80,6 +92,11 @@ jobs:
           # matches the final file), which later makes `sha256sum -c` report
           # "checksums.txt: FAILED". Hash every artifact EXCEPT the manifest.
           sha256sum $(ls | grep -v '^checksums.txt$') > checksums.txt
+
+      - name: Attest release artifacts
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-checksums: dist/checksums.txt
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -104,6 +121,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push Docker image
+        id: image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
@@ -118,6 +136,37 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+          provenance: mode=max
+          sbom: true
+
+      - name: Scan image for high and critical vulnerabilities
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.image.outputs.digest }}
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+
+      - name: Attest container image
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign container image
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.image.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Sign checksum manifest
+        run: cosign sign-blob --yes --bundle dist/checksums.txt.sigstore.json dist/checksums.txt
 
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2


### PR DESCRIPTION
## Summary

- generate a CycloneDX JSON SBOM and include it in release checksums/assets
- attest binary release artifacts and the pushed container image with GitHub/Sigstore provenance
- emit BuildKit SBOM and max-mode provenance for the multi-platform image
- block releases on fixed HIGH/CRITICAL image vulnerabilities with Trivy
- keylessly sign the image digest and checksum manifest with Cosign
- pin every newly introduced action to an immutable commit SHA

## Validation

- parsed `.github/workflows/release.yml` as YAML
- `git diff --check`
- checked action inputs and current releases against their official repositories