### PR TITLE
test: cover critical authentication flows

### DIFF
--- a/src/internal/auth/warden_tls_test.go
+++ b/src/internal/auth/warden_tls_test.go
@@ -2,6 +2,10 @@ package auth
 
 import (
 	"crypto/tls"
+	"encoding/pem"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/MarvinJWendt/testza"
@@ -23,4 +27,42 @@ func TestBuildWardenTLSConfigSetsSecureDefaults(t *testing.T) {
 	testza.AssertNoError(t, err)
 	testza.AssertEqual(t, uint16(tls.VersionTLS12), cfg.MinVersion)
 	testza.AssertEqual(t, "warden.internal", cfg.ServerName)
+}
+
+func TestBuildWardenTLSConfigRejectsUnreadableAndInvalidCA(t *testing.T) {
+	_, err := buildWardenTLSConfig(filepath.Join(t.TempDir(), "missing.pem"), "", "", "")
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "read Warden CA certificate")
+
+	invalidCA := filepath.Join(t.TempDir(), "invalid.pem")
+	testza.AssertNoError(t, os.WriteFile(invalidCA, []byte("not a certificate"), 0o600))
+	_, err = buildWardenTLSConfig(invalidCA, "", "", "")
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "contains no valid certificates")
+}
+
+func TestBuildWardenTLSConfigLoadsCA(t *testing.T) {
+	server := httptest.NewTLSServer(nil)
+	defer server.Close()
+
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.TLS.Certificates[0].Certificate[0]})
+	testza.AssertNoError(t, os.WriteFile(caFile, certificate, 0o600))
+
+	cfg, err := buildWardenTLSConfig(caFile, "", "", "warden.internal")
+	testza.AssertNoError(t, err)
+	testza.AssertNotNil(t, cfg.RootCAs)
+	testza.AssertEqual(t, "warden.internal", cfg.ServerName)
+}
+
+func TestBuildWardenTLSConfigRejectsInvalidClientPair(t *testing.T) {
+	tmp := t.TempDir()
+	certFile := filepath.Join(tmp, "client.pem")
+	keyFile := filepath.Join(tmp, "client.key")
+	testza.AssertNoError(t, os.WriteFile(certFile, []byte("invalid"), 0o600))
+	testza.AssertNoError(t, os.WriteFile(keyFile, []byte("invalid"), 0o600))
+
+	_, err := buildWardenTLSConfig("", certFile, keyFile, "")
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "load Warden client certificate")
 }

--- a/src/internal/handlers/send_verify_code_test.go
+++ b/src/internal/handlers/send_verify_code_test.go
@@ -35,6 +35,91 @@ func setupSendVerifyCodeBaseEnv(t *testing.T) {
 	t.Setenv("PASSWORDS", "plaintext:test123")
 }
 
+func newWardenUserServer(t *testing.T, phone, mail string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Phone  string `json:"phone"`
+			Mail   string `json:"mail"`
+			UserID string `json:"user_id"`
+			Status string `json:"status"`
+		}{Phone: phone, Mail: mail, UserID: "user-1", Status: "active"})
+	}))
+}
+
+func TestSendVerifyCodeAPIRejectsInvalidPhone(t *testing.T) {
+	setupSendVerifyCodeBaseEnv(t)
+	t.Setenv("HERALD_ENABLED", "true")
+	testza.AssertNoError(t, config.Initialize(testLoggerSendVerifyCode()))
+
+	ctx, app := createTestContext("POST", "/_send_verify_code", map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}, "phone=not-a-phone")
+	defer app.ReleaseCtx(ctx)
+
+	err := SendVerifyCodeAPI()(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusBadRequest, ctx.Response().StatusCode())
+	testza.AssertContains(t, string(ctx.Response().Body()), "invalid_phone_format")
+}
+
+func TestSendVerifyCodeAPIReportsUninitializedHerald(t *testing.T) {
+	setupSendVerifyCodeBaseEnv(t)
+	t.Setenv("HERALD_ENABLED", "true")
+	t.Setenv("WARDEN_ENABLED", "true")
+	wardenServer := newWardenUserServer(t, "13800138000", "user@example.com")
+	defer wardenServer.Close()
+	t.Setenv("WARDEN_URL", wardenServer.URL)
+
+	auth.ResetWardenClientForTesting()
+	resetHeraldClientForTesting()
+	testLog := testLoggerSendVerifyCode()
+	testza.AssertNoError(t, config.Initialize(testLog))
+	testza.AssertNoError(t, auth.InitWardenClient(testLog))
+
+	ctx, app := createTestContext("POST", "/_send_verify_code", map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}, "phone=13800138000")
+	defer app.ReleaseCtx(ctx)
+
+	err := SendVerifyCodeAPI()(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusServiceUnavailable, ctx.Response().StatusCode())
+	testza.AssertContains(t, string(ctx.Response().Body()), "connection_failed")
+}
+
+func TestSendVerifyCodeAPIRejectsDisabledSMSChannel(t *testing.T) {
+	setupSendVerifyCodeBaseEnv(t)
+	t.Setenv("HERALD_ENABLED", "true")
+	t.Setenv("WARDEN_ENABLED", "true")
+	t.Setenv("LOGIN_SMS_ENABLED", "false")
+	t.Setenv("LOGIN_EMAIL_ENABLED", "false")
+	wardenServer := newWardenUserServer(t, "13800138000", "")
+	defer wardenServer.Close()
+	t.Setenv("WARDEN_URL", wardenServer.URL)
+
+	auth.ResetWardenClientForTesting()
+	resetHeraldClientForTesting()
+	testLog := testLoggerSendVerifyCode()
+	testza.AssertNoError(t, config.Initialize(testLog))
+	testza.AssertNoError(t, auth.InitWardenClient(testLog))
+
+	ctx, app := createTestContext("POST", "/_send_verify_code", map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}, "phone=13800138000&deliver_via=sms")
+	defer app.ReleaseCtx(ctx)
+
+	err := SendVerifyCodeAPI()(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusBadRequest, ctx.Response().StatusCode())
+	testza.AssertContains(t, string(ctx.Response().Body()), "channel_disabled")
+}
+
 func TestSendVerifyCodeAPI_NoIdentifier(t *testing.T) {
 	setupSendVerifyCodeBaseEnv(t)
 	t.Setenv("HERALD_ENABLED", "true")

--- a/src/internal/handlers/step_up_test.go
+++ b/src/internal/handlers/step_up_test.go
@@ -1,6 +1,9 @@
 package handlers
 
 import (
+	"io"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,6 +12,68 @@ import (
 	"github.com/soulteary/stargate/src/internal/auth"
 	"github.com/soulteary/stargate/src/internal/config"
 )
+
+func TestRedirectToStepUpPreservesOnlyLocalCallback(t *testing.T) {
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{"X-Forwarded-Uri": "/admin/users?tab=roles"}, "")
+	defer app.ReleaseCtx(ctx)
+
+	err := redirectToStepUp(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
+	testza.AssertEqual(t, "/_step_up?callback=%2Fadmin%2Fusers%3Ftab%3Droles", string(ctx.Response().Header.Peek("Location")))
+}
+
+func TestStepUpRouteRequiresAuthentication(t *testing.T) {
+	setupStepUpTest(t)
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/_step_up", nil, "")
+	defer app.ReleaseCtx(ctx)
+
+	err := StepUpRoute(store)(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusUnauthorized, ctx.Response().StatusCode())
+}
+
+func TestStepUpRouteEscapesCallbackInForm(t *testing.T) {
+	setupStepUpTest(t)
+	store := setupTestStore()
+	app := fiber.New()
+	app.Get("/_step_up", StepUpRoute(store))
+
+	seedCtx, seedApp := createTestContext("GET", "/", nil, "")
+	sess, err := store.Get(seedCtx)
+	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	testza.AssertNoError(t, sess.Save())
+	cookie := auth.SessionCookieName + "=" + sess.ID()
+	seedApp.ReleaseCtx(seedCtx)
+
+	req := httptest.NewRequest("GET", "/_step_up?callback=%2Fadmin%22%3E%3Cscript%3E", nil)
+	req.Header.Set("Cookie", cookie)
+	resp, err := app.Test(req)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	testza.AssertNoError(t, err)
+	testza.AssertContains(t, string(body), "/admin&#34;&gt;&lt;script&gt;")
+	testza.AssertFalse(t, strings.Contains(string(body), `<script>`))
+}
+
+func TestStepUpAPIRejectsWrongPassword(t *testing.T) {
+	setupStepUpTest(t)
+	store := setupTestStore()
+	ctx, app := createTestContext("POST", "/_step_up", map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}, "password=wrong&callback=/admin")
+	defer app.ReleaseCtx(ctx)
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
+
+	err = StepUpAPI(store)(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusUnauthorized, ctx.Response().StatusCode())
+}
 
 func setupStepUpTest(t *testing.T) {
 	t.Helper()

--- a/src/internal/handlers/totp_revoke_test.go
+++ b/src/internal/handlers/totp_revoke_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/MarvinJWendt/testza"
@@ -12,6 +13,29 @@ import (
 	"github.com/soulteary/stargate/src/internal/config"
 	"github.com/soulteary/stargate/src/internal/i18n"
 )
+
+func TestRevokeErrorReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", want: ""},
+		{name: "http unauthorized", err: errors.New("401"), want: "unauthorized"},
+		{name: "text unauthorized", err: errors.New("unauthorized"), want: "unauthorized"},
+		{name: "missing route", err: errors.New("Cannot POST /totp/revoke"), want: "unavailable"},
+		{name: "rate limited", err: errors.New("rate_limit exceeded"), want: "rate_limited"},
+		{name: "bad gateway", err: errors.New("502 upstream failure"), want: "service_unavailable"},
+		{name: "connection", err: errors.New("connection refused"), want: "service_unavailable"},
+		{name: "unknown", err: errors.New("invalid response"), want: "service_error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testza.AssertEqual(t, tt.want, revokeErrorReason(tt.err))
+		})
+	}
+}
 
 func TestTOTPRevokeRoute_NotAuthenticated_Redirects(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")


### PR DESCRIPTION
## Summary

- cover every TOTP revoke error classification
- cover Step-up page auth, callback escaping, redirect behavior, and bad-password rejection
- cover Warden TLS CA loading and failure paths
- cover verification-code invalid input, unavailable Herald, and disabled-channel behavior

## Coverage

- repository total: 69.0% → 71.2%
- `buildWardenTLSConfig`: 52.4% → 90.5%
- `redirectToStepUp`: 0% → 100%
- `StepUpRoute`: 0% → 88.9%
- `revokeErrorReason`: 0% → 100%
- `SendVerifyCodeAPI`: 54.6% → 60.5%

## Validation

- `go test -race ./...`