### PR TITLE
ci: make Codecov upload failures non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,9 @@ jobs:
           disable_search: true
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: true
+          # The local 70% coverage gate above remains authoritative. Codecov is
+          # reporting infrastructure and must not block PRs when it is unavailable.
+          fail_ci_if_error: false
 
   # 代码质量检查（使用 golangci-lint）
   lint:


### PR DESCRIPTION
## Summary

- set `fail_ci_if_error: false` for the Codecov upload step
- retain the local 70% coverage threshold as the authoritative hard gate
- prevent third-party reporting outages from blocking otherwise valid PRs

## Validation

- `git diff --check`