### PR TITLE
fix(auth): disable password header authentication by default

### DIFF
--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -221,7 +221,7 @@ func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *he
 	app.Post("/totp/revoke", sameOrigin, handlers.VerificationRateLimit(), handlers.TOTPRevokeConfirmAPI(store))
 	app.Post(RouteLogout, sameOrigin, handlers.LogoutRoute(store))
 	app.Get(RouteSessionExchange, handlers.SessionShareRoute(store, replayStore))
-	app.Get(RouteAuth, handlers.CheckRoute(store))
+	app.Get(RouteAuth, handlers.PasswordHeaderRateLimit(), handlers.CheckRoute(store))
 	app.Get(RouteStepUp, handlers.StepUpRoute(store))
 	app.Post(RouteStepUp, sameOrigin, handlers.LoginRateLimit(), handlers.StepUpAPI(store))
 	// Prometheus metrics endpoint

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -57,6 +57,14 @@ var (
 		Sensitive:      true,
 	}
 
+	PasswordHeaderAuthEnabled = EnvVariable{
+		Name:           "PASSWORD_HEADER_AUTH_ENABLED",
+		Required:       false,
+		DefaultValue:   "false",
+		PossibleValues: []string{"true", "false"},
+		Validator:      ValidateCaseInsensitivePossibleValues,
+	}
+
 	UserHeaderName = EnvVariable{
 		Name:           "USER_HEADER_NAME",
 		Required:       false,
@@ -461,7 +469,7 @@ func Initialize(l *logger.Logger) error {
 	}
 
 	// Then validate all other configuration variables
-	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &UserHeaderName, &TrustedProxies, &ProxyHeader, &CookieDomain, &CookieSecure, &CallbackAllowedHosts, &SessionExchangeSecret, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
+	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &PasswordHeaderAuthEnabled, &UserHeaderName, &TrustedProxies, &ProxyHeader, &CookieDomain, &CookieSecure, &CallbackAllowedHosts, &SessionExchangeSecret, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
 
 	for _, variable := range envVariables {
 		err := variable.Validate()
@@ -486,6 +494,9 @@ func Initialize(l *logger.Logger) error {
 	// PASSWORDS is required when not using Warden (password-only mode). When WardenEnabled=true, pure Warden deployment may omit PASSWORDS.
 	if !WardenEnabled.ToBool() && Passwords.Value == "" {
 		return NewValidationError(Passwords.Name, i18n.TStatic("error.config_required_not_set"), Passwords.PossibleValues)
+	}
+	if PasswordHeaderAuthEnabled.ToBool() && Passwords.Value == "" {
+		return NewValidationError(PasswordHeaderAuthEnabled.Name, "requires PASSWORDS", PasswordHeaderAuthEnabled.PossibleValues)
 	}
 	if StepUpEnabled.ToBool() && Passwords.Value == "" {
 		return NewValidationError(StepUpEnabled.Name, "requires PASSWORDS for re-authentication", StepUpEnabled.PossibleValues)

--- a/src/internal/handlers/forwardauth.go
+++ b/src/internal/handlers/forwardauth.go
@@ -83,7 +83,7 @@ func InitForwardAuthHandler(l *logger.Logger) {
 		SessionEnabled: true,
 
 		// Password authentication
-		PasswordEnabled:   algo != "" && len(validPasswords) > 0,
+		PasswordEnabled:   config.PasswordHeaderAuthEnabled.ToBool() && algo != "" && len(validPasswords) > 0,
 		PasswordHeader:    "Stargate-Password",
 		ValidPasswords:    validPasswords,
 		PasswordAlgorithm: algo,

--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -152,6 +152,7 @@ func TestCheckRoute_NotAuthenticated(t *testing.T) {
 func TestCheckRoute_HeaderAuth_Valid(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("PASSWORD_HEADER_AUTH_ENABLED", "true")
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
 
@@ -681,6 +682,7 @@ func TestSessionShareRoute_WithoutCookieDomain(t *testing.T) {
 func TestCheckRoute_SetsUserHeader(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("PASSWORD_HEADER_AUTH_ENABLED", "true")
 	t.Setenv("USER_HEADER_NAME", "X-Custom-User")
 	testLog := testLogger()
 	err := config.Initialize(testLog)
@@ -706,6 +708,7 @@ func TestCheckRoute_SetsUserHeader(t *testing.T) {
 func TestCheckRoute_SetsDefaultUserHeader(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("PASSWORD_HEADER_AUTH_ENABLED", "true")
 	testLog := testLogger()
 	err := config.Initialize(testLog)
 	testza.AssertNoError(t, err)
@@ -2138,4 +2141,25 @@ func TestCheckRoute_WardenAuth_WithCustomUserHeader(t *testing.T) {
 	// Verify custom user header is set (forwardauth-kit uses actual user_id when available)
 	userHeader := string(ctx.Response().Header.Peek("X-Custom-User"))
 	testza.AssertEqual(t, "user1", userHeader)
+}
+
+
+func TestCheckRoute_PasswordHeaderDisabledByDefault(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("PASSWORD_HEADER_AUTH_ENABLED", "false")
+	testLog := testLogger()
+	testza.AssertNoError(t, config.Initialize(testLog))
+	InitForwardAuthHandler(testLog)
+
+	store := setupTestStore()
+	handler := CheckRoute(store)
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{
+		"Stargate-Password": "test123",
+		"Accept":            "application/json",
+	}, "")
+	defer app.ReleaseCtx(ctx)
+
+	testza.AssertNoError(t, handler(ctx))
+	testza.AssertEqual(t, fiber.StatusUnauthorized, ctx.Response().StatusCode())
 }

--- a/src/internal/handlers/request_protection.go
+++ b/src/internal/handlers/request_protection.go
@@ -52,3 +52,17 @@ func LoginRateLimit() fiber.Handler {
 func VerificationRateLimit() fiber.Handler {
 	return endpointRateLimit(5, time.Minute)
 }
+
+
+// PasswordHeaderRateLimit applies a dedicated brute-force budget only when the
+// explicitly enabled legacy password header is present. Session checks remain
+// unaffected.
+func PasswordHeaderRateLimit() fiber.Handler {
+	limit := endpointRateLimit(10, time.Minute)
+	return func(ctx fiber.Ctx) error {
+		if ctx.Get("Stargate-Password") == "" {
+			return ctx.Next()
+		}
+		return limit(ctx)
+	}
+}


### PR DESCRIPTION
## Summary

- add `PASSWORD_HEADER_AUTH_ENABLED`, defaulting to `false`
- require an explicit opt-in before `Stargate-Password` participates in ForwardAuth
- apply a dedicated 10/minute/IP limit to opt-in password-header attempts
- leave ordinary session checks outside that limiter
- cover the secure default with a regression test

## Security impact

The shared login password previously authenticated every `/_auth` request without the login endpoint's rate limit. It could also remain on the original proxy request unless operators stripped it before the backend. The safe default is now session-only ForwardAuth.

## Compatibility

Deployments that intentionally use the legacy API header must set `PASSWORD_HEADER_AUTH_ENABLED=true` and should remove `Stargate-Password` before proxying to applications. A later documentation PR updates the public contract.