### PR TITLE
fix(security): validate complete request origin

### DIFF
--- a/src/internal/handlers/request_protection.go
+++ b/src/internal/handlers/request_protection.go
@@ -9,6 +9,37 @@ import (
 	"github.com/gofiber/fiber/v3/middleware/limiter"
 )
 
+type requestOrigin struct {
+	scheme   string
+	hostname string
+	port     string
+}
+
+func canonicalRequestOrigin(raw string) (requestOrigin, bool) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.User != nil || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path != "" {
+		return requestOrigin{}, false
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return requestOrigin{}, false
+	}
+	hostname := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if hostname == "" {
+		return requestOrigin{}, false
+	}
+	port := parsed.Port()
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return requestOrigin{scheme: scheme, hostname: hostname, port: port}, true
+}
+
 // RequireSameOrigin blocks browser cross-site writes while preserving clients
 // such as curl that do not send browser Origin or Fetch Metadata headers.
 func RequireSameOrigin() fiber.Handler {
@@ -23,8 +54,9 @@ func RequireSameOrigin() fiber.Handler {
 		if origin == "" {
 			return ctx.Next()
 		}
-		parsed, err := url.Parse(origin)
-		if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" || !strings.EqualFold(parsed.Hostname(), ctx.Hostname()) {
+		suppliedOrigin, suppliedOK := canonicalRequestOrigin(origin)
+		requestOrigin, requestOK := canonicalRequestOrigin(GetForwardedProto(ctx) + "://" + GetForwardedHost(ctx))
+		if !suppliedOK || !requestOK || suppliedOrigin != requestOrigin {
 			return SendErrorResponse(ctx, fiber.StatusForbidden, "cross-site request rejected")
 		}
 		return ctx.Next()

--- a/src/internal/handlers/request_protection_test.go
+++ b/src/internal/handlers/request_protection_test.go
@@ -36,7 +36,44 @@ func TestRequireSameOriginAllowsMatchingOrigin(t *testing.T) {
 		return c.SendStatus(fiber.StatusNoContent)
 	})
 	req := newRequestProtectionTestRequest(fiber.MethodPost, "/write")
-	req.Header.Set("Origin", "https://auth.example.com")
+	req.Header.Set("Origin", "http://auth.example.com")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("execute request: %v", err)
+	}
+	testza.AssertEqual(t, fiber.StatusNoContent, resp.StatusCode)
+}
+
+func TestRequireSameOriginRejectsSchemeAndPortMismatch(t *testing.T) {
+	app := fiber.New()
+	app.Post("/write", RequireSameOrigin(), func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	for _, origin := range []string{
+		"https://auth.example.com",
+		"http://auth.example.com:8080",
+		"http://auth.example.com/path",
+	} {
+		req := newRequestProtectionTestRequest(fiber.MethodPost, "/write")
+		req.Header.Set("Origin", origin)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("execute request with origin %q: %v", origin, err)
+		}
+		testza.AssertEqual(t, fiber.StatusForbidden, resp.StatusCode)
+	}
+}
+
+func TestRequireSameOriginNormalizesDefaultPort(t *testing.T) {
+	app := fiber.New()
+	app.Post("/write", RequireSameOrigin(), func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+	req := newRequestProtectionTestRequest(fiber.MethodPost, "/write")
+	req.Host = "auth.example.com:80"
+	req.Header.Set("Origin", "http://auth.example.com")
 
 	resp, err := app.Test(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

- compare the complete browser Origin tuple: scheme, hostname, and effective port
- derive the externally visible request origin through Stargate's trusted-proxy-aware helpers
- reject malformed origins, URL paths, query strings, userinfo, and fragments
- normalize host case, trailing dots, and default HTTP/HTTPS ports

## Why

The previous middleware compared only hostnames. A request with the correct hostname but a different scheme or port was incorrectly treated as same-origin, which weakens CSRF protection.

## Tests

Adds regression coverage for scheme mismatch, port mismatch, invalid origin paths, and default-port normalization.