### PR TITLE
fix(observability): redact query parameters from traces

### DIFF
--- a/src/internal/tracing/middleware.go
+++ b/src/internal/tracing/middleware.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gofiber/fiber/v3"
 	common_tracing "github.com/soulteary/tracing-kit"
@@ -11,6 +12,14 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 )
+
+func sanitizeTraceURL(rawURL string) string {
+	path, _, _ := strings.Cut(rawURL, "?")
+	if path == "" {
+		return "/"
+	}
+	return path
+}
 
 // TracingMiddleware creates a Fiber middleware for OpenTelemetry tracing
 func TracingMiddleware(serviceName string) fiber.Handler {
@@ -31,7 +40,7 @@ func TracingMiddleware(serviceName string) fiber.Handler {
 			spanName = c.Path()
 		}
 		if spanName == "" {
-			spanName = c.Method() + " " + c.OriginalURL()
+			spanName = c.Method() + " " + sanitizeTraceURL(c.OriginalURL())
 		}
 
 		// Start span
@@ -41,7 +50,7 @@ func TracingMiddleware(serviceName string) fiber.Handler {
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
 				semconv.HTTPMethod(c.Method()),
-				semconv.HTTPURL(c.OriginalURL()),
+				semconv.HTTPURL(sanitizeTraceURL(c.OriginalURL())),
 				attribute.String("http.user_agent", c.Get("User-Agent")),
 				attribute.String("http.remote_addr", c.IP()),
 			),

--- a/src/internal/tracing/middleware_test.go
+++ b/src/internal/tracing/middleware_test.go
@@ -80,3 +80,12 @@ func TestHeaderCarrier_Keys(t *testing.T) {
 	assert.Contains(t, keys, "b")
 	assert.Contains(t, keys, "c")
 }
+
+func TestSanitizeTraceURLRemovesSensitiveQueryValues(t *testing.T) {
+	raw := "/_session/exchange?ticket=secret-ticket&callback=app.example.com"
+	sanitized := sanitizeTraceURL(raw)
+
+	assert.Equal(t, "/_session/exchange", sanitized)
+	assert.NotContains(t, sanitized, "secret-ticket")
+	assert.Equal(t, "/", sanitizeTraceURL("?ticket=secret-ticket"))
+}


### PR DESCRIPTION
## Summary

- strip the complete query string before recording the `http.url` span attribute
- use the sanitized path in the fallback span name as well
- add a regression test using a session-exchange ticket

## Why

Stargate passes short-lived session exchange tickets and callback data in query parameters. Recording `OriginalURL()` copied those values into OpenTelemetry backends, expanding access to authentication secrets through trace storage.

The change keeps route/path visibility while preventing all query values—not just known parameter names—from entering spans.