### PR TITLE
feat(config): fail fast on invalid operational settings

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -535,6 +535,10 @@ func Initialize(l *logger.Logger) error {
 		}
 	}
 
+	if err := validateStrictSettings(); err != nil {
+		return err
+	}
+
 	// Log language setting
 	if Language.Value != "" {
 		log.Info().Str("name", Language.Name).Str("value", Language.Value).Msg("Config loaded")

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -389,6 +389,7 @@ func TestInitialize_AllConfigVariables(t *testing.T) {
 	t.Setenv("LOGIN_PAGE_FOOTER_TEXT", "Custom Footer")
 	t.Setenv("USER_HEADER_NAME", "X-Custom-User")
 	t.Setenv("COOKIE_DOMAIN", ".example.com")
+	t.Setenv("SESSION_EXCHANGE_SECRET", "0123456789abcdef0123456789abcdef")
 	t.Setenv("LANGUAGE", "zh")
 
 	err := Initialize(testLogger())

--- a/src/internal/config/strict_validation.go
+++ b/src/internal/config/strict_validation.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func strictValidationError(variable *EnvVariable, reason string) error {
+	return NewValidationError(variable.Name, reason, variable.PossibleValues)
+}
+
+func validatePositiveInteger(variable *EnvVariable) error {
+	value, err := strconv.Atoi(strings.TrimSpace(variable.Value))
+	if err != nil || value <= 0 {
+		return strictValidationError(variable, "must be a positive integer")
+	}
+	return nil
+}
+
+func validateHTTPServiceURL(variable *EnvVariable) error {
+	if strings.TrimSpace(variable.Value) == "" {
+		return nil
+	}
+	parsed, err := url.Parse(variable.Value)
+	if err != nil || parsed.Host == "" || parsed.User != nil ||
+		(parsed.Scheme != "http" && parsed.Scheme != "https") ||
+		parsed.RawQuery != "" || parsed.Fragment != "" {
+		return strictValidationError(variable, "must be an HTTP(S) service URL without credentials, query, or fragment")
+	}
+	return nil
+}
+
+func validateCallbackHostList(variable *EnvVariable) error {
+	for _, raw := range strings.Split(variable.Value, ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		parsed, err := url.Parse("//" + raw)
+		if err != nil || parsed.Host == "" || parsed.User != nil || parsed.Path != "" ||
+			parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Hostname() == "" {
+			return strictValidationError(variable, "must contain only comma-separated host[:port] values")
+		}
+	}
+	return nil
+}
+
+func validateStrictSettings() error {
+	if strings.TrimSpace(CookieDomain.Value) != "" || strings.TrimSpace(CallbackAllowedHosts.Value) != "" {
+		if len(SessionExchangeSecret.Value) < 32 {
+			return strictValidationError(&SessionExchangeSecret, "must contain at least 32 characters when cross-domain callbacks are enabled")
+		}
+	}
+	if err := validateCallbackHostList(&CallbackAllowedHosts); err != nil {
+		return err
+	}
+	if Port.Value != "" {
+		port, err := strconv.Atoi(strings.TrimPrefix(strings.TrimSpace(Port.Value), ":"))
+		if err != nil || port < 1 || port > 65535 {
+			return strictValidationError(&Port, "must be a TCP port between 1 and 65535")
+		}
+	}
+	if err := validatePositiveInteger(&WardenCacheTTL); err != nil {
+		return err
+	}
+	if _, err := time.ParseDuration(AuthRefreshInterval.Value); err != nil || AuthRefreshInterval.ToDuration() <= 0 {
+		return strictValidationError(&AuthRefreshInterval, "must be a positive Go duration")
+	}
+	redisDB, err := strconv.Atoi(strings.TrimSpace(SessionStorageRedisDB.Value))
+	if err != nil || redisDB < 0 {
+		return strictValidationError(&SessionStorageRedisDB, "must be a non-negative integer")
+	}
+	if SessionStorageEnabled.ToBool() && strings.TrimSpace(SessionStorageRedisAddr.Value) == "" {
+		return strictValidationError(&SessionStorageRedisAddr, "must be set when Redis session storage is enabled")
+	}
+	if err := validateHTTPServiceURL(&WardenURL); err != nil {
+		return err
+	}
+	if err := validateHTTPServiceURL(&HeraldURL); err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/internal/config/strict_validation_test.go
+++ b/src/internal/config/strict_validation_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/MarvinJWendt/testza"
+)
+
+func setValidStrictTestValues(t *testing.T) {
+	t.Helper()
+	variables := []*EnvVariable{
+		&CookieDomain, &CallbackAllowedHosts, &SessionExchangeSecret, &Port,
+		&WardenCacheTTL, &AuthRefreshInterval, &SessionStorageRedisDB,
+		&SessionStorageEnabled, &SessionStorageRedisAddr, &WardenURL, &HeraldURL,
+	}
+	values := make([]string, len(variables))
+	for i, variable := range variables {
+		values[i] = variable.Value
+	}
+	t.Cleanup(func() {
+		for i, variable := range variables {
+			variable.Value = values[i]
+		}
+	})
+
+	CookieDomain.Value = ""
+	CallbackAllowedHosts.Value = ""
+	SessionExchangeSecret.Value = ""
+	Port.Value = ""
+	WardenCacheTTL.Value = "300"
+	AuthRefreshInterval.Value = "5m"
+	SessionStorageRedisDB.Value = "0"
+	SessionStorageEnabled.Value = "false"
+	SessionStorageRedisAddr.Value = "localhost:6379"
+	WardenURL.Value = ""
+	HeraldURL.Value = ""
+}
+
+func TestValidateStrictSettingsAcceptsOperationalDefaults(t *testing.T) {
+	setValidStrictTestValues(t)
+	testza.AssertNoError(t, validateStrictSettings())
+}
+
+func TestValidateStrictSettingsRequiresCrossDomainExchangeSecret(t *testing.T) {
+	setValidStrictTestValues(t)
+	CallbackAllowedHosts.Value = "app.example.com"
+	SessionExchangeSecret.Value = "too-short"
+
+	err := validateStrictSettings()
+	testza.AssertNotNil(t, err)
+	testza.AssertEqual(t, SessionExchangeSecret.Name, err.(*ValidationError).KeyName)
+}
+
+func TestValidateStrictSettingsRejectsInvalidNumbers(t *testing.T) {
+	tests := []struct {
+		name     string
+		configure func()
+		key      string
+	}{
+		{"port", func() { Port.Value = "70000" }, Port.Name},
+		{"cache ttl", func() { WardenCacheTTL.Value = "0" }, WardenCacheTTL.Name},
+		{"redis db", func() { SessionStorageRedisDB.Value = "-1" }, SessionStorageRedisDB.Name},
+		{"refresh duration", func() { AuthRefreshInterval.Value = "soon" }, AuthRefreshInterval.Name},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setValidStrictTestValues(t)
+			test.configure()
+			err := validateStrictSettings()
+			testza.AssertNotNil(t, err)
+			testza.AssertEqual(t, test.key, err.(*ValidationError).KeyName)
+		})
+	}
+}
+
+func TestValidateStrictSettingsRejectsUnsafeServiceURL(t *testing.T) {
+	setValidStrictTestValues(t)
+	WardenURL.Value = "https://user:password@warden.example.com?token=secret"
+
+	err := validateStrictSettings()
+	testza.AssertNotNil(t, err)
+	testza.AssertEqual(t, WardenURL.Name, err.(*ValidationError).KeyName)
+}


### PR DESCRIPTION
## Summary

- require a 32-character session exchange secret when shared-cookie or callback hosts enable cross-domain login
- validate callback host lists and HTTP(S) dependency URLs
- reject invalid ports, non-positive cache TTLs and refresh intervals, and negative Redis DB indexes
- require a Redis address when Redis-backed sessions are enabled
- cover defaults and failure cases with focused unit tests

## Why

Several malformed settings were silently converted to zero/default values or failed only while handling traffic. Failing during startup makes deployment errors deterministic and prevents cross-domain session exchange from reaching a runtime 500 because its signing secret is absent.