### PR TITLE
build(container): pin versions and add runtime probes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: 启动测试用 Redis
         run: |
-          docker run -d --name stargate-redis-test -p 6379:6379 redis:8-alpine
+          docker run -d --name stargate-redis-test -p 6379:6379 redis:8.2.1-alpine3.22
           echo "等待 Redis 就绪..."
           for i in $(seq 1 30); do
             if docker exec stargate-redis-test redis-cli ping 2>/dev/null | grep -q PONG; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stargate: # Your Stargate forward auth service
-    image: ghcr.io/soulteary/stargate:latest
+    image: ghcr.io/soulteary/stargate:v0.12.0
     # Local development port mapping: host port 8080 -> container port 8080
     # Purpose: Direct access to service during local development without traefik
     # Production: Uses port 8080 via traefik proxy (not mapped to host)
@@ -14,6 +14,19 @@ services:
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
       - COOKIE_SECURE=false # Local HTTP only. Keep the default true in HTTPS deployments.
       - PORT=8080
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
     networks:
       - traefik
     labels:
@@ -24,7 +37,7 @@ services:
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   whoami: # A demo whoami service that is protected with Stargate
-    image: traefik/whoami
+    image: traefik/whoami:v1.11.0
     networks:
       - traefik
     labels:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN if command -v upx > /dev/null 2>&1; then \
 FROM alpine:3.23
 COPY --from=builder /app/stargate /bin/stargate
 COPY --from=builder /app/src/internal/web/templates /app/web/templates
-RUN apk add --no-cache curl && \
+RUN apk add --no-cache ca-certificates && \
     addgroup -S stargate && \
     adduser -S -D -H -u 10001 -G stargate stargate && \
     chown -R stargate:stargate /app
@@ -36,4 +36,6 @@ WORKDIR /app
 ENV PORT=8080
 USER 10001:10001
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -q -O - "http://127.0.0.1:${PORT:-8080}/healthz" >/dev/null || exit 1
 CMD ["stargate"]

--- a/docker/Dockerfile.manual
+++ b/docker/Dockerfile.manual
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine3.23 AS Builder
+FROM golang:1.26.6-alpine3.23 AS Builder
 RUN echo '' > /etc/apk/repositories && \
     echo "https://mirror.tuna.tsinghua.edu.cn/alpine/v3.23/main"         >> /etc/apk/repositories && \
     echo "https://mirror.tuna.tsinghua.edu.cn/alpine/v3.23/community"    >> /etc/apk/repositories && \
@@ -39,14 +39,15 @@ COPY --from=Builder /app/stargate /bin/stargate
 COPY --from=Builder /app/src/internal/web/templates /app/web/templates
 ENV TZ=Asia/Shanghai
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories
-RUN apk add tzdata curl && \
+RUN apk add --no-cache tzdata ca-certificates && \
     addgroup -S stargate && \
     adduser -S -D -H -u 10001 -G stargate stargate && \
     cp /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    rm -rf /var/cache/apk/* && \
     chown -R stargate:stargate /app
 WORKDIR /app
 ENV PORT=8080
 USER 10001:10001
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -q -O - "http://127.0.0.1:${PORT:-8080}/healthz" >/dev/null || exit 1
 CMD ["stargate"]


### PR DESCRIPTION
## Summary

- align the manual builder with the Go 1.26.6 version declared by `go.mod`
- add OCI health checks to both runtime images using BusyBox `wget`
- replace the unnecessary runtime `curl` package with CA certificates
- pin Redis integration tests and Compose example images to explicit versions
- run the Compose service read-only with no Linux capabilities and no-new-privileges
- enable weekly Dependabot updates for Go modules, Actions, Dockerfiles, and Compose

## Why

The manual image had already drifted from the project toolchain, container health was invisible to orchestrators, and floating CI/example tags made builds non-reproducible. Explicit pins plus automated update PRs make changes reviewable instead of silent.

All CI remains on GitHub-hosted runners.