### PR TITLE
fix(auth): preserve disabled verification-channel response

### DIFF
--- a/src/internal/handlers/send_verify_code.go
+++ b/src/internal/handlers/send_verify_code.go
@@ -129,6 +129,12 @@ func SendVerifyCodeAPI() func(c fiber.Ctx) error {
 
 		var channel, destination string
 		deliverVia := ctx.FormValue("deliver_via")
+		if deliverVia == "sms" && !config.LoginSMSEnabled.ToBool() {
+			return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.login_sms_disabled"), "channel_disabled")
+		}
+		if deliverVia == "email" && !config.LoginEmailEnabled.ToBool() {
+			return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.login_email_disabled"), "channel_disabled")
+		}
 		switch deliverVia {
 		case "dingtalk":
 			if canonicalDingTalkID != "" {


### PR DESCRIPTION
## Summary

- return `channel_disabled` when a caller explicitly selects a disabled SMS or email channel
- use the existing localized channel-specific error messages
- preserve canonical Warden destinations and the secure alternate-channel fallback for enabled channels

## Why

The canonical-destination security fix correctly removed request-supplied fallback destinations, but it also changed the established disabled-channel response to `destination_unavailable`. That breaks the existing regression test and the login UI's tailored handling.

This is the focused follow-up to the P1 review on #71.