### PR TITLE
fix(auth): rate-limit password failures instead of requests

### DIFF
--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -221,7 +221,7 @@ func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *he
 	app.Post("/totp/revoke", sameOrigin, handlers.VerificationRateLimit(), handlers.TOTPRevokeConfirmAPI(store))
 	app.Post(RouteLogout, sameOrigin, handlers.LogoutRoute(store))
 	app.Get(RouteSessionExchange, handlers.SessionShareRoute(store, replayStore))
-	app.Get(RouteAuth, handlers.PasswordHeaderRateLimit(), handlers.CheckRoute(store))
+	app.Get(RouteAuth, handlers.CheckRoute(store))
 	app.Get(RouteStepUp, handlers.StepUpRoute(store))
 	app.Post(RouteStepUp, sameOrigin, handlers.LoginRateLimit(), handlers.StepUpAPI(store))
 	// Prometheus metrics endpoint

--- a/src/internal/handlers/check.go
+++ b/src/internal/handlers/check.go
@@ -116,7 +116,12 @@ func CheckRoute(store SessionStoreForCheck) func(c fiber.Ctx) error {
 			forwardAuthSpan.SetAttributes(attribute.Bool("auth.authenticated", false))
 
 			switch err {
-			case forwardauth.ErrNotAuthenticated, forwardauth.ErrInvalidPassword, forwardauth.ErrUserNotFound:
+			case forwardauth.ErrInvalidPassword:
+				if limitErr := rateLimitPasswordHeaderFailure(ctx); limitErr != nil {
+					return limitErr
+				}
+				return handler.HandleNotAuthenticated(faCtx)
+			case forwardauth.ErrNotAuthenticated, forwardauth.ErrUserNotFound:
 				return handler.HandleNotAuthenticated(faCtx)
 			case forwardauth.ErrStepUpRequired:
 				return handler.HandleStepUpRequired(faCtx)

--- a/src/internal/handlers/request_protection.go
+++ b/src/internal/handlers/request_protection.go
@@ -87,7 +87,6 @@ func VerificationRateLimit() fiber.Handler {
 	return endpointRateLimit(5, time.Minute)
 }
 
-
 type passwordFailureBucket struct {
 	count  int
 	resets time.Time

--- a/src/internal/handlers/request_protection.go
+++ b/src/internal/handlers/request_protection.go
@@ -94,14 +94,16 @@ type passwordFailureBucket struct {
 }
 
 var (
-	passwordFailureMu      sync.Mutex
-	passwordFailureBuckets = make(map[string]passwordFailureBucket)
+	passwordFailureMu          sync.Mutex
+	passwordFailureBuckets     = make(map[string]passwordFailureBucket)
+	passwordFailureLastCleanup time.Time
 )
 
 func resetPasswordFailureBucketsForTesting() {
 	passwordFailureMu.Lock()
 	defer passwordFailureMu.Unlock()
 	passwordFailureBuckets = make(map[string]passwordFailureBucket)
+	passwordFailureLastCleanup = time.Time{}
 }
 
 func rateLimitPasswordHeaderFailure(ctx fiber.Ctx) error {
@@ -112,6 +114,14 @@ func rateLimitPasswordHeaderFailure(ctx fiber.Ctx) error {
 	now := time.Now()
 	key := ctx.IP()
 	passwordFailureMu.Lock()
+	if passwordFailureLastCleanup.IsZero() || now.Sub(passwordFailureLastCleanup) >= time.Minute {
+		for bucketKey, candidate := range passwordFailureBuckets {
+			if !now.Before(candidate.resets) {
+				delete(passwordFailureBuckets, bucketKey)
+			}
+		}
+		passwordFailureLastCleanup = now
+	}
 	bucket := passwordFailureBuckets[key]
 	if bucket.resets.IsZero() || !now.Before(bucket.resets) {
 		bucket = passwordFailureBucket{resets: now.Add(time.Minute)}

--- a/src/internal/handlers/request_protection.go
+++ b/src/internal/handlers/request_protection.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -86,15 +88,45 @@ func VerificationRateLimit() fiber.Handler {
 }
 
 
-// PasswordHeaderRateLimit applies a dedicated brute-force budget only when the
-// explicitly enabled legacy password header is present. Session checks remain
-// unaffected.
-func PasswordHeaderRateLimit() fiber.Handler {
-	limit := endpointRateLimit(10, time.Minute)
-	return func(ctx fiber.Ctx) error {
-		if ctx.Get("Stargate-Password") == "" {
-			return ctx.Next()
-		}
-		return limit(ctx)
+type passwordFailureBucket struct {
+	count  int
+	resets time.Time
+}
+
+var (
+	passwordFailureMu      sync.Mutex
+	passwordFailureBuckets = make(map[string]passwordFailureBucket)
+)
+
+func resetPasswordFailureBucketsForTesting() {
+	passwordFailureMu.Lock()
+	defer passwordFailureMu.Unlock()
+	passwordFailureBuckets = make(map[string]passwordFailureBucket)
+}
+
+func rateLimitPasswordHeaderFailure(ctx fiber.Ctx) error {
+	if strings.TrimSpace(ctx.Get("Stargate-Password")) == "" {
+		return nil
 	}
+
+	now := time.Now()
+	key := ctx.IP()
+	passwordFailureMu.Lock()
+	bucket := passwordFailureBuckets[key]
+	if bucket.resets.IsZero() || !now.Before(bucket.resets) {
+		bucket = passwordFailureBucket{resets: now.Add(time.Minute)}
+	}
+	bucket.count++
+	passwordFailureBuckets[key] = bucket
+	passwordFailureMu.Unlock()
+
+	if bucket.count <= 10 {
+		return nil
+	}
+	retryAfter := int(time.Until(bucket.resets).Seconds())
+	if retryAfter < 1 {
+		retryAfter = 1
+	}
+	ctx.Set(fiber.HeaderRetryAfter, fmt.Sprintf("%d", retryAfter))
+	return SendErrorResponse(ctx, fiber.StatusTooManyRequests, "too many failed password attempts")
 }

--- a/src/internal/handlers/request_protection_test.go
+++ b/src/internal/handlers/request_protection_test.go
@@ -100,3 +100,26 @@ func TestLoginRateLimitRejectsBurst(t *testing.T) {
 	}
 	testza.AssertEqual(t, fiber.StatusTooManyRequests, resp.StatusCode)
 }
+
+func TestPasswordHeaderFailureRateLimit(t *testing.T) {
+	resetPasswordFailureBucketsForTesting()
+	t.Cleanup(resetPasswordFailureBucketsForTesting)
+
+	for i := 0; i < 10; i++ {
+		ctx, app := createTestContext(fiber.MethodGet, "/_auth", map[string]string{
+			"Stargate-Password": "wrong-password",
+		}, "")
+		err := rateLimitPasswordHeaderFailure(ctx)
+		app.ReleaseCtx(ctx)
+		testza.AssertNoError(t, err)
+	}
+
+	ctx, app := createTestContext(fiber.MethodGet, "/_auth", map[string]string{
+		"Stargate-Password": "wrong-password",
+	}, "")
+	defer app.ReleaseCtx(ctx)
+	err := rateLimitPasswordHeaderFailure(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusTooManyRequests, ctx.Response().StatusCode())
+	testza.AssertNotEqual(t, "", string(ctx.Response().Header.Peek(fiber.HeaderRetryAfter)))
+}


### PR DESCRIPTION
## Summary

- remove the pre-authentication limiter from `/_auth`
- increment the per-IP budget only when password verification returns `ErrInvalidPassword`
- return 429 with a bounded `Retry-After` value after 10 failures per minute
- keep valid password-header requests and cookie/session checks outside the failure budget
- add focused threshold coverage

## Why

The opt-in legacy header is sent on every protected request. Limiting all requests meant the 11th valid API call in a minute was rejected, turning brute-force protection into a normal-traffic throttle.

This is the focused follow-up to the P1 review on #72.