### PR TITLE
fix(config): align strict validation with runtime parsing

### DIFF
--- a/src/internal/config/strict_validation.go
+++ b/src/internal/config/strict_validation.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -40,7 +41,8 @@ func validateCallbackHostList(variable *EnvVariable) error {
 		}
 		parsed, err := url.Parse("//" + raw)
 		if err != nil || parsed.Host == "" || parsed.User != nil || parsed.Path != "" ||
-			parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Hostname() == "" {
+			parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Hostname() == "" ||
+			net.ParseIP(parsed.Hostname()) != nil {
 			return strictValidationError(variable, "must contain only comma-separated host[:port] values")
 		}
 	}
@@ -68,8 +70,9 @@ func validateStrictSettings() error {
 	if _, err := time.ParseDuration(AuthRefreshInterval.Value); err != nil || AuthRefreshInterval.ToDuration() <= 0 {
 		return strictValidationError(&AuthRefreshInterval, "must be a positive Go duration")
 	}
-	redisDB, err := strconv.Atoi(strings.TrimSpace(SessionStorageRedisDB.Value))
-	if err != nil || redisDB < 0 {
+	redisDBValue := SessionStorageRedisDB.Value
+	redisDB, err := strconv.Atoi(redisDBValue)
+	if err != nil || redisDB < 0 || strings.TrimSpace(redisDBValue) != redisDBValue {
 		return strictValidationError(&SessionStorageRedisDB, "must be a non-negative integer")
 	}
 	if SessionStorageEnabled.ToBool() && strings.TrimSpace(SessionStorageRedisAddr.Value) == "" {

--- a/src/internal/config/strict_validation.go
+++ b/src/internal/config/strict_validation.go
@@ -42,7 +42,7 @@ func validateCallbackHostList(variable *EnvVariable) error {
 		parsed, err := url.Parse("//" + raw)
 		if err != nil || parsed.Host == "" || parsed.User != nil || parsed.Path != "" ||
 			parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Hostname() == "" ||
-			net.ParseIP(parsed.Hostname()) != nil {
+			net.ParseIP(strings.TrimSuffix(parsed.Hostname(), ".")) != nil {
 			return strictValidationError(variable, "must contain only comma-separated host[:port] values")
 		}
 	}

--- a/src/internal/config/strict_validation_test.go
+++ b/src/internal/config/strict_validation_test.go
@@ -81,3 +81,22 @@ func TestValidateStrictSettingsRejectsUnsafeServiceURL(t *testing.T) {
 	testza.AssertNotNil(t, err)
 	testza.AssertEqual(t, WardenURL.Name, err.(*ValidationError).KeyName)
 }
+
+func TestValidateStrictSettingsRejectsPaddedRedisDB(t *testing.T) {
+	setValidStrictTestValues(t)
+	SessionStorageRedisDB.Value = " 2 "
+
+	err := validateStrictSettings()
+	testza.AssertNotNil(t, err)
+	testza.AssertEqual(t, SessionStorageRedisDB.Name, err.(*ValidationError).KeyName)
+}
+
+func TestValidateStrictSettingsRejectsIPCallbackHost(t *testing.T) {
+	setValidStrictTestValues(t)
+	CallbackAllowedHosts.Value = "127.0.0.1"
+	SessionExchangeSecret.Value = "0123456789abcdef0123456789abcdef"
+
+	err := validateStrictSettings()
+	testza.AssertNotNil(t, err)
+	testza.AssertEqual(t, CallbackAllowedHosts.Name, err.(*ValidationError).KeyName)
+}

--- a/src/internal/config/strict_validation_test.go
+++ b/src/internal/config/strict_validation_test.go
@@ -92,11 +92,15 @@ func TestValidateStrictSettingsRejectsPaddedRedisDB(t *testing.T) {
 }
 
 func TestValidateStrictSettingsRejectsIPCallbackHost(t *testing.T) {
-	setValidStrictTestValues(t)
-	CallbackAllowedHosts.Value = "127.0.0.1"
-	SessionExchangeSecret.Value = "0123456789abcdef0123456789abcdef"
+	for _, host := range []string{"127.0.0.1", "127.0.0.1."} {
+		t.Run(host, func(t *testing.T) {
+			setValidStrictTestValues(t)
+			CallbackAllowedHosts.Value = host
+			SessionExchangeSecret.Value = "0123456789abcdef0123456789abcdef"
 
-	err := validateStrictSettings()
-	testza.AssertNotNil(t, err)
-	testza.AssertEqual(t, CallbackAllowedHosts.Name, err.(*ValidationError).KeyName)
+			err := validateStrictSettings()
+			testza.AssertNotNil(t, err)
+			testza.AssertEqual(t, CallbackAllowedHosts.Name, err.(*ValidationError).KeyName)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- reject whitespace-padded Redis DB indexes instead of accepting a value the runtime later parses as DB 0
- reject IP literals in callback allowlists, matching the runtime callback parser's DNS-only rule
- add regression coverage for both mismatches

## Why

Startup validation and request/runtime parsing must accept the same language. Otherwise a deployment can pass validation but silently use the wrong Redis database or configure a callback target that can never be selected.

This follows up the two P2 review findings on #75.