### PR TITLE
ci: fix broken checks and tier Actions workloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,291 +1,71 @@
-name: CI
+name: PR checks
 
 on:
-  push:
-    branches: [ main, master, develop ]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [main]
 
 permissions:
   contents: read
 
-env:
-  DOCKER_BUILDKIT: 1
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  # 代码格式检查
-  fmt:
-    name: 代码格式检查
+  pr-checks:
+    name: Format, lint, and unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - name: 检出代码
+      - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
-      - name: 设置 Go 环境
+      - name: Detect code changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          code_changed=false
+          while IFS= read -r file; do
+            case "$file" in
+              *.md|docs/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE*) ;;
+              *) code_changed=true; break ;;
+            esac
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "code=$code_changed" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        if: steps.changes.outputs.code == 'true'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version-file: 'go.mod'
-          cache: false
+          go-version-file: go.mod
+          cache: true
 
-      - name: 检查代码格式
+      - name: Check formatting
+        if: steps.changes.outputs.code == 'true'
         run: |
-          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
-            echo "以下文件格式不正确:"
+          files=$(gofmt -s -l .)
+          if [ -n "$files" ]; then
+            echo "$files"
             gofmt -s -d .
             exit 1
           fi
 
-  # 代码静态检查
-  vet:
-    name: 代码静态检查
-    runs-on: ubuntu-latest
-    steps:
-      - name: 检出代码
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: 设置 Go 环境
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-
-      - name: 缓存 Go 模块
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: 下载依赖
-        run: go mod download
-
-      - name: 运行 go vet
-        run: go vet ./...
-
-  # 代码测试
-  test:
-    name: 代码测试
-    runs-on: ubuntu-latest
-    steps:
-      - name: 检出代码
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: 设置 Go 环境
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-
-      - name: 缓存 Go 模块
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: 下载依赖
-        run: go mod download
-
-      - name: 启动测试用 Redis
-        run: |
-          docker run -d --name stargate-redis-test -p 6379:6379 redis:8.2.1-alpine3.22
-          echo "等待 Redis 就绪..."
-          for i in $(seq 1 30); do
-            if docker exec stargate-redis-test redis-cli ping 2>/dev/null | grep -q PONG; then
-              echo "Redis 已就绪"
-              break
-            fi
-            echo "等待 Redis 启动... ($i/30)"
-            sleep 1
-          done
-          docker exec stargate-redis-test redis-cli ping || (echo "Redis 启动超时"; exit 1)
-
-      - name: 运行测试
-        run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
-
-      - name: 停止 Redis
-        if: always()
-        run: docker rm -f stargate-redis-test 2>/dev/null || true
-
-      - name: 生成覆盖率报告
-        run: go tool cover -html=coverage.out -o coverage.html
-
-      - name: 上传覆盖率报告
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: coverage-report
-          path: coverage.html
-
-      - name: 显示并检查覆盖率
-        run: |
-          go tool cover -func=coverage.out
-          total=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub(/%/, "", $3); print $3}')
-          awk -v total="$total" 'BEGIN { if (total < 70) { printf "coverage %.1f%% is below 70%%\n", total; exit 1 } }'
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.out
-          disable_search: true
-          flags: unittests
-          name: codecov-umbrella
-          # The local 70% coverage gate above remains authoritative. Codecov is
-          # reporting infrastructure and must not block PRs when it is unavailable.
-          fail_ci_if_error: false
-
-  # 代码质量检查（使用 golangci-lint）
-  lint:
-    name: 代码质量检查
-    runs-on: ubuntu-latest
-    steps:
-      - name: 检出代码
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: 设置 Go 环境
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-
-      - name: 运行 golangci-lint
+      - name: Run golangci-lint
+        if: steps.changes.outputs.code == 'true'
         uses: golangci/golangci-lint-action@db9de0fc1a667e1a49d2291a1a042dff081d78f6 # v9
         with:
           version: v2.13.1
           args: --timeout=5m
           only-new-issues: false
 
-  # 依赖项安全扫描
-  security-scan:
-    name: 依赖项安全扫描
-    runs-on: ubuntu-latest
-    steps:
-      - name: 检出代码
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run unit tests
+        if: steps.changes.outputs.code == 'true'
+        run: go test -short ./...
 
-      - name: 设置 Go 环境
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-
-      - name: 缓存 Go 模块
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: 下载依赖
-        run: go mod download
-
-      - name: 安装 govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
-
-      - name: 运行安全扫描
-        run: govulncheck ./...
-
-  # 完整构建检查
-  build:
-    name: 构建检查
-    runs-on: ubuntu-latest
-    steps:
-      - name: 检出代码
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: 设置 Go 环境
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-
-      - name: 缓存 Go 模块
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: 下载依赖
-        run: go mod download
-
-      - name: 获取版本信息
-        id: version
-        run: |
-          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev-$(git rev-parse --short HEAD)")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: 构建项目
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          COMMIT=${{ github.sha }}
-          BUILD_DATE=$(date +%FT%T%z)
-          LDFLAGS="-s -w -X 'github.com/soulteary/version-kit/v2.Version=${VERSION}' -X 'github.com/soulteary/version-kit/v2.Commit=${COMMIT}' -X 'github.com/soulteary/version-kit/v2.BuildDate=${BUILD_DATE}'"
-          CGO_ENABLED=0 go build -ldflags "${LDFLAGS}" -o ./bin/stargate ./src/cmd/stargate
-
-      - name: 验证构建产物
-        run: |
-          if [ -f ./bin/stargate ]; then
-            echo "构建成功，文件存在"
-            ls -lh ./bin/stargate
-            file ./bin/stargate
-          else
-            echo "构建失败，文件不存在"
-            exit 1
-          fi
-
-      - name: 上传构建产物
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: stargate-binary
-          path: ./bin/stargate
-          retention-days: 7
-
-  # Docker 构建
-  docker-build:
-    name: Docker 构建
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - name: 检出代码
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: 设置 Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: 获取版本信息
-        id: version
-        run: |
-          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev-$(git rev-parse --short HEAD)")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "最近版本: $VERSION"
-
-      - name: 构建 Docker 镜像
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: false
-          load: true
-          tags: stargate:test
-          build-args: |
-            VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: 验证镜像
-        run: |
-          docker images stargate:test
-          docker inspect stargate:test
+      - name: Skip full checks for documentation-only changes
+        if: steps.changes.outputs.code != 'true'
+        run: echo "Only documentation files changed; build checks are not required."

--- a/.github/workflows/go-reportcard.yml
+++ b/.github/workflows/go-reportcard.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   report-card:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,67 @@
+name: Main validation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main-validation:
+    name: Race, coverage, and integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      redis:
+        image: redis:8.2.1-alpine3.22
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 12
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run race, coverage, and integration tests
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Enforce coverage threshold
+        run: |
+          go tool cover -func=coverage.out
+          total=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub(/%/, "", $3); print $3}')
+          awk -v total="$total" 'BEGIN { if (total < 70) { printf "coverage %.1f%% is below 70%%\n", total; exit 1 } }'
+
+      - name: Generate coverage report
+        run: go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: coverage-report
+          path: coverage.html
+          retention-days: 3
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.out
+          disable_search: true
+          flags: integration
+          name: main
+          fail_ci_if_error: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,99 @@
+name: Nightly compatibility
+
+on:
+  schedule:
+    - cron: '23 18 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compatibility:
+    name: ${{ matrix.os }} / Go ${{ matrix.go-version }} / ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            go-version: 1.27.0
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            go-version: 1.27.0
+            arch: arm64
+          - os: windows-latest
+            go-version: 1.27.0
+            arch: amd64
+          - os: macos-15-intel
+            go-version: 1.27.0
+            arch: amd64
+          - os: macos-latest
+            go-version: 1.27.0
+            arch: arm64
+          - os: ubuntu-latest
+            go-version: 1.27.x
+            arch: amd64
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Run cross-platform unit tests
+        run: go test -short ./...
+
+  docker:
+    name: Multi-architecture Docker build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build multi-architecture image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: false
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=nightly-docker
+          cache-to: type=gha,mode=max,scope=nightly-docker
+
+  security:
+    name: Go dependency vulnerability scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
+
+      - name: Scan Go dependencies
+        run: govulncheck ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,60 @@ on:
     tags:
       - 'v*.*.*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  compatibility:
+    name: ${{ matrix.os }} / Go ${{ matrix.go-version }} / ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            go-version: 1.27.0
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            go-version: 1.27.0
+            arch: arm64
+          - os: windows-latest
+            go-version: 1.27.0
+            arch: amd64
+          - os: macos-15-intel
+            go-version: 1.27.0
+            arch: amd64
+          - os: macos-latest
+            go-version: 1.27.0
+            arch: arm64
+          - os: ubuntu-latest
+            go-version: 1.27.x
+            arch: amd64
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Run cross-platform unit tests
+        run: go test -short ./...
+
   release:
     name: Release
     runs-on: ubuntu-latest
+    needs: compatibility
     permissions:
       contents: write
       packages: write
@@ -35,16 +81,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: 'go.mod'
-
-      - name: Cache Go modules
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
 
       - name: Download dependencies
         run: go mod download
@@ -185,7 +222,7 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
             COMMIT=${{ steps.version.outputs.commit }}
             BUILD_DATE=${{ steps.version.outputs.build_date }}
-          cache-from: type=gha
+          cache-from: type=gha,scope=release-docker
           platforms: linux/amd64
 
       - name: Scan amd64 image for high and critical vulnerabilities
@@ -210,7 +247,7 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
             COMMIT=${{ steps.version.outputs.commit }}
             BUILD_DATE=${{ steps.version.outputs.build_date }}
-          cache-from: type=gha
+          cache-from: type=gha,scope=release-docker
           platforms: linux/arm64
 
       - name: Scan arm64 image for high and critical vulnerabilities
@@ -236,8 +273,8 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
             COMMIT=${{ steps.version.outputs.commit }}
             BUILD_DATE=${{ steps.version.outputs.build_date }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=release-docker
+          cache-to: type=gha,mode=max,scope=release-docker
           platforms: linux/amd64,linux/arm64
           provenance: mode=max
           sbom: true

--- a/src/internal/auth/auth_test.go
+++ b/src/internal/auth/auth_test.go
@@ -452,7 +452,7 @@ func TestInitWardenClient_CustomTTL(t *testing.T) {
 	// We're testing that custom TTL is parsed correctly
 }
 
-// TestInitWardenClient_InvalidTTL tests that InitWardenClient uses default TTL when invalid TTL is provided
+// TestInitWardenClient_InvalidTTL tests that startup rejects an invalid cache TTL.
 func TestInitWardenClient_InvalidTTL(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
@@ -461,16 +461,11 @@ func TestInitWardenClient_InvalidTTL(t *testing.T) {
 	t.Setenv("WARDEN_CACHE_TTL", "invalid")
 
 	err := config.Initialize(testLogger())
-	testza.AssertNoError(t, err)
-
-	// Reset client to nil for this test
-	wardenClient = nil
-
-	testza.AssertNoError(t, InitWardenClient(testLogger()))
-	// Should not panic even with invalid TTL (should use default)
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "WARDEN_CACHE_TTL")
 }
 
-// TestInitWardenClient_NegativeTTL tests that InitWardenClient uses default TTL when negative TTL is provided
+// TestInitWardenClient_NegativeTTL tests that startup rejects a negative cache TTL.
 func TestInitWardenClient_NegativeTTL(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
@@ -479,16 +474,11 @@ func TestInitWardenClient_NegativeTTL(t *testing.T) {
 	t.Setenv("WARDEN_CACHE_TTL", "-10")
 
 	err := config.Initialize(testLogger())
-	testza.AssertNoError(t, err)
-
-	// Reset client to nil for this test
-	wardenClient = nil
-
-	testza.AssertNoError(t, InitWardenClient(testLogger()))
-	// Should not panic even with negative TTL (should use default)
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "WARDEN_CACHE_TTL")
 }
 
-// TestInitWardenClient_ZeroTTL tests that InitWardenClient uses default TTL when zero TTL is provided
+// TestInitWardenClient_ZeroTTL tests that startup rejects a zero cache TTL.
 func TestInitWardenClient_ZeroTTL(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
@@ -497,13 +487,8 @@ func TestInitWardenClient_ZeroTTL(t *testing.T) {
 	t.Setenv("WARDEN_CACHE_TTL", "0")
 
 	err := config.Initialize(testLogger())
-	testza.AssertNoError(t, err)
-
-	// Reset client to nil for this test
-	wardenClient = nil
-
-	testza.AssertNoError(t, InitWardenClient(testLogger()))
-	// Should not panic even with zero TTL (should use default)
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "WARDEN_CACHE_TTL")
 }
 
 // TestGetWardenClient_NotInitialized tests that getWardenClient returns nil when client is not initialized

--- a/src/internal/config/strict_validation_test.go
+++ b/src/internal/config/strict_validation_test.go
@@ -53,9 +53,9 @@ func TestValidateStrictSettingsRequiresCrossDomainExchangeSecret(t *testing.T) {
 
 func TestValidateStrictSettingsRejectsInvalidNumbers(t *testing.T) {
 	tests := []struct {
-		name     string
+		name      string
 		configure func()
-		key      string
+		key       string
 	}{
 		{"port", func() { Port.Value = "70000" }, Port.Name},
 		{"cache ttl", func() { WardenCacheTTL.Value = "0" }, WardenCacheTTL.Name},

--- a/src/internal/handlers/e2e_integration_test.go
+++ b/src/internal/handlers/e2e_integration_test.go
@@ -36,6 +36,11 @@ func testLoggerE2E() *logger.Logger {
 
 // setupTestRedis creates a test Redis client using redis-kit
 func setupTestRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("requires Redis integration service")
+	}
+
 	cfg := client.DefaultConfig().
 		WithAddr("localhost:6379").
 		WithDB(14) // Use DB 14 for integration testing

--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -155,6 +155,7 @@ func TestCheckRoute_HeaderAuth_Valid(t *testing.T) {
 	t.Setenv("PASSWORD_HEADER_AUTH_ENABLED", "true")
 	err := config.Initialize(testLogger())
 	testza.AssertNoError(t, err)
+	InitForwardAuthHandler(testLogger())
 
 	store := setupTestStore()
 	handler := CheckRoute(store)
@@ -2142,7 +2143,6 @@ func TestCheckRoute_WardenAuth_WithCustomUserHeader(t *testing.T) {
 	userHeader := string(ctx.Response().Header.Peek("X-Custom-User"))
 	testza.AssertEqual(t, "user1", userHeader)
 }
-
 
 func TestCheckRoute_PasswordHeaderDisabledByDefault(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")

--- a/src/internal/handlers/send_verify_code_test.go
+++ b/src/internal/handlers/send_verify_code_test.go
@@ -585,12 +585,12 @@ func TestSendVerifyCodeAPI_HeraldRateLimited(t *testing.T) {
 	testza.AssertContains(t, bodyStr, "success")
 }
 
-
 func TestSendVerifyCodeAPIRejectsUntrustedFallbackDestination(t *testing.T) {
 	setupSendVerifyCodeBaseEnv(t)
 	t.Setenv("HERALD_ENABLED", "true")
 	t.Setenv("HERALD_API_KEY", "api-key")
 	t.Setenv("WARDEN_ENABLED", "true")
+	t.Setenv("LOGIN_SMS_ENABLED", "false")
 
 	// Warden recognizes the victim by phone but has no canonical email.
 	wardenServer := newWardenUserServer(t, "13800138000", "")


### PR DESCRIPTION
## Summary

- fix the failures from [Actions run 32990881909](https://github.com/soulteary/stargate/actions/runs/32990881909) by aligning tests with strict TTL validation, reinitializing opt-in password-header authentication, and disabling the safe SMS fallback in the untrusted-destination test
- make Redis-backed tests honor `go test -short` so pull requests run unit tests without an integration service
- split Actions into PR, main, nightly, and tag/release tiers
- skip Go setup, lint, and tests for documentation-only pull requests
- keep Dependabot and fork pull requests on one read-only Ubuntu job without a platform matrix
- add cancellation concurrency to non-release workflows and serialize releases without canceling them
- retain coverage artifacts for 3 days and keep release binaries in GitHub Releases
- use setup-go caches for Go and scoped BuildKit caches for Docker without caching build artifacts

## Validation

- `go test -short ./...`
- `go test -short -race ./...`
- targeted reruns of all five tests that failed in run 32990881909
- `go vet ./...`
- `golangci-lint run --timeout=5m` (0 issues)
- `gofmt -s -l .`
- `actionlint`

Only `.github/workflows/release.yml` responds to version tags, preventing duplicate release workflows.