### PR TITLE
build(compose): target Stargate v1.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stargate: # Your Stargate forward auth service
-    image: ghcr.io/soulteary/stargate:v0.12.0
+    image: ghcr.io/soulteary/stargate:v1.0.0
     # Local development port mapping: host port 8080 -> container port 8080
     # Purpose: Direct access to service during local development without traefik
     # Production: Uses port 8080 via traefik proxy (not mapped to host)


### PR DESCRIPTION
## Summary

- update the pinned Stargate image in `docker-compose.yml` from `v0.12.0` to `v1.0.0`
- keep the example reproducible by using an immutable release tag instead of `latest`

## Why

The repository is being prepared for the v1.0.0 release, but the checked-in Compose example still deploys v0.12.0. Users following the quick-start path would therefore run the previous release rather than the version documented by the repository.

## Validation

- `git diff --check`
- verified that only the Stargate image tag changes