### PR TITLE
docs: add a dedicated v1.0.0 migration guide

### DIFF
--- a/docs/enUS/MIGRATION_V1.md
+++ b/docs/enUS/MIGRATION_V1.md
@@ -1,0 +1,115 @@
+# Migrating from v0.12.0 to v1.0.0
+
+Stargate v1.0.0 establishes the first stable deployment and HTTP contracts. It also changes several security defaults. Test the upgrade in a staging environment before changing production traffic.
+
+## Before upgrading
+
+1. Record the current image, environment variables, proxy routes, callback hosts, and health probes.
+2. Back up the deployment configuration and keep the v0.12.0 image available for rollback.
+3. Identify every caller of `/_logout`, `/totp/enroll`, and the cross-domain session exchange route.
+4. If more than one Stargate replica is running, prepare Redis-backed session storage before upgrading.
+
+## Required deployment changes
+
+### Official container port and user
+
+| Contract | v0.12.0 | v1.0.0 |
+| --- | --- | --- |
+| Official container port | `80` | `8080` |
+| Runtime user | root | UID/GID `10001` |
+| Liveness probe | `/health` | `/healthz` |
+| Dependency readiness probe | `/health` | `/readyz` |
+
+Update reverse-proxy targets and container health checks together. A minimal Compose service is:
+
+```yaml
+services:
+  stargate:
+    image: ghcr.io/soulteary/stargate:v1.0.0
+    ports:
+      - "8080:8080"
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8080/healthz"]
+```
+
+When Stargate is used as Traefik ForwardAuth, change the target to `http://stargate:8080/_auth`.
+
+### Cross-domain session exchange
+
+v1.0.0 replaces the raw `?id=` session transfer with an encrypted, short-lived, single-use `?ticket=` value that is bound to the destination host.
+
+- Configure `CALLBACK_ALLOWED_HOSTS` with every permitted callback host.
+- Configure the same `SESSION_EXCHANGE_SECRET` on all replicas. It must contain at least 32 characters when cross-domain callbacks are enabled.
+- Keep `COOKIE_SECURE=true` for HTTPS deployments.
+- Do not construct exchange URLs in downstream applications. Follow the redirect returned by Stargate.
+- Use Redis-backed session storage when tickets or sessions must be accepted by multiple replicas.
+
+Old `?id=` exchange links are not compatible with v1.0.0.
+
+### Proxy trust
+
+Forwarded headers are ignored unless the immediate peer matches `TRUSTED_PROXIES`. Set this allowlist to the IP addresses or CIDRs of the reverse proxies that connect directly to Stargate. Use `PROXY_HEADER` to select the client-IP header; its default is `X-Forwarded-For`.
+
+Do not place arbitrary client networks in `TRUSTED_PROXIES`.
+
+### Authentication modes
+
+- The login form remains available through `POST /_login`.
+- Authentication through the `Stargate-Password` request header is disabled by default. Set `PASSWORD_HEADER_AUTH_ENABLED=true` only for a trusted proxy integration, and make the proxy remove any client-supplied copy of that header.
+- Trusted identity headers require `HEADER_AUTH_ENABLED=true`, a matching `HEADER_AUTH_SHARED_SECRET`, and Warden. The proxy must remove client-supplied identity and secret headers before adding its own values.
+- Invalid Warden or Herald client configuration now fails at startup instead of producing a partially working service.
+- The legacy Warden global OTP fallback has been removed. Use Herald-backed TOTP enrollment and verification.
+
+## HTTP contract changes
+
+| Previous contract | v1.0.0 contract | Action |
+| --- | --- | --- |
+| `GET /_logout` | `POST /_logout` | Update links and clients to submit a POST request. |
+| `GET /totp/enroll` | `POST /totp/enroll` | Start enrollment with POST. |
+| `GET /health` for all probes | `GET /healthz` and `GET /readyz` | Separate liveness from dependency readiness. |
+| No metrics endpoint | `GET /metrics` | Point Prometheus-compatible scraping here. |
+| Session exchange `?id=` | Session exchange `?ticket=` | Follow Stargate redirects; do not expose session IDs. |
+
+`GET /health` remains as a deprecated compatibility alias for readiness. New deployments should not use it. Browser requests that change authentication state are subject to same-origin checks and endpoint-specific rate limits.
+
+## Configuration behavior changes
+
+- `AUTH_REFRESH_ENABLED` now defaults to `true`. Set it to `false` only when delayed Warden revocation is acceptable.
+- `COOKIE_SECURE` defaults to `true`; local HTTP testing must opt out explicitly.
+- Startup validation now rejects malformed URLs, ports, durations, Redis database values, undersized exchange secrets, incomplete TLS certificate/key pairs, and incomplete HMAC key ID/secret pairs.
+- `CALLBACK_ALLOWED_HOSTS` is required to permit explicit cross-domain callback destinations.
+- Warden and Herald HMAC/TLS settings must be complete when enabled. Herald HMAC authentication also requires `HERALD_HMAC_KEY_ID`.
+
+Run the v1.0.0 image with the production environment before cutover and resolve every startup validation error rather than bypassing it.
+
+## Rollout procedure
+
+1. Deploy v1.0.0 to a separate pool with the updated port and probes.
+2. For multiple replicas, enable and verify shared Redis session storage before sending user traffic.
+3. Exercise password, Warden, header, and TOTP flows that are enabled in the deployment.
+4. Verify same-domain and every allowed cross-domain callback.
+5. Move traffic only after `/healthz` and `/readyz` both succeed.
+6. Keep v0.12.0 and v1.0.0 in separate pools during the transition; their session-exchange contracts must not be mixed.
+
+## Verification checklist
+
+```bash
+curl --fail http://127.0.0.1:8080/healthz
+curl --fail http://127.0.0.1:8080/readyz
+curl --fail http://127.0.0.1:8080/metrics
+```
+
+- The container runs as UID/GID `10001` and does not require a writable root filesystem.
+- The reverse proxy reaches `http://stargate:8080/_auth`.
+- Login succeeds and logout uses `POST /_logout`.
+- TOTP enrollment, confirmation, verification, and revocation succeed when Herald is configured.
+- An unlisted callback host and a reused or expired exchange ticket are rejected.
+- A client-supplied password or identity header cannot bypass the trusted proxy.
+- Dependency failure keeps `/healthz` live while `/readyz` reports not ready.
+
+## Rollback
+
+Restore the v0.12.0 image, proxy port, and old probe together. A v1.0.0 exchange ticket cannot be consumed by v0.12.0, so invalidate in-flight cross-domain exchanges and require a fresh login after rollback. Do not assume active sessions are portable between mixed-version pools.

--- a/docs/enUS/README.md
+++ b/docs/enUS/README.md
@@ -12,6 +12,7 @@ Welcome to the Stargate Forward Auth Service documentation.
 
 - **[README.md](../../README.md)** - Project overview and quick start guide
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - Technical architecture and design decisions
+- **[MIGRATION_V1.md](MIGRATION_V1.md)** - Upgrade guide from v0.12.0 to v1.0.0
 
 ### Detailed Documents
 
@@ -71,12 +72,14 @@ stargate/
 │   │   ├── ARCHITECTURE.md # Architecture document (English)
 │   │   ├── API.md          # API document (English)
 │   │   ├── CONFIG.md       # Configuration reference (English)
+│   │   ├── MIGRATION_V1.md # v1.0.0 migration guide (English)
 │   │   └── DEPLOYMENT.md   # Deployment guide (English)
 │   └── zhCN/
 │       ├── README.md       # Documentation index (Chinese)
 │       ├── ARCHITECTURE.md # Architecture document (Chinese)
 │       ├── API.md          # API document (Chinese)
 │       ├── CONFIG.md       # Configuration reference (Chinese)
+│       ├── MIGRATION_V1.md # v1.0.0 migration guide (Chinese)
 │       └── DEPLOYMENT.md   # Deployment guide (Chinese)
 └── ...
 ```

--- a/docs/zhCN/MIGRATION_V1.md
+++ b/docs/zhCN/MIGRATION_V1.md
@@ -1,0 +1,115 @@
+# 从 v0.12.0 迁移到 v1.0.0
+
+Stargate v1.0.0 确立了首个稳定的部署与 HTTP 契约，同时调整了多项安全默认值。生产切流前，请先在预发布环境完成升级验证。
+
+## 升级前准备
+
+1. 记录当前镜像、环境变量、反向代理路由、回调域名和健康检查配置。
+2. 备份部署配置，并保留 v0.12.0 镜像以便回滚。
+3. 找出所有调用 `/_logout`、`/totp/enroll` 和跨域会话交换路由的客户端。
+4. 如果运行多个 Stargate 副本，请在升级前准备 Redis 会话存储。
+
+## 必须调整的部署配置
+
+### 官方容器端口与运行用户
+
+| 契约 | v0.12.0 | v1.0.0 |
+| --- | --- | --- |
+| 官方容器端口 | `80` | `8080` |
+| 运行用户 | root | UID/GID `10001` |
+| 存活探针 | `/health` | `/healthz` |
+| 依赖就绪探针 | `/health` | `/readyz` |
+
+反向代理目标和容器健康检查需要同时更新。最小 Compose 服务示例：
+
+```yaml
+services:
+  stargate:
+    image: ghcr.io/soulteary/stargate:v1.0.0
+    ports:
+      - "8080:8080"
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8080/healthz"]
+```
+
+使用 Traefik ForwardAuth 时，将目标改为 `http://stargate:8080/_auth`。
+
+### 跨域会话交换
+
+v1.0.0 使用加密、短时、单次有效且绑定目标域名的 `?ticket=` 替代直接传递会话 ID 的 `?id=`。
+
+- 在 `CALLBACK_ALLOWED_HOSTS` 中列出所有允许的回调域名。
+- 所有副本必须使用相同的 `SESSION_EXCHANGE_SECRET`；启用跨域回调时，其长度至少为 32 个字符。
+- HTTPS 部署保持 `COOKIE_SECURE=true`。
+- 下游应用不要自行拼接交换 URL，应直接跟随 Stargate 返回的重定向。
+- 当票据或会话需要被多个副本接受时，使用 Redis 会话存储。
+
+旧的 `?id=` 交换链接与 v1.0.0 不兼容。
+
+### 代理信任边界
+
+只有直接上游地址匹配 `TRUSTED_PROXIES` 时，Stargate 才接受转发请求头。该配置应仅包含直接连接 Stargate 的反向代理 IP 或 CIDR。`PROXY_HEADER` 用于选择客户端 IP 请求头，默认值为 `X-Forwarded-For`。
+
+不要将任意客户端网段加入 `TRUSTED_PROXIES`。
+
+### 认证模式
+
+- 登录表单仍通过 `POST /_login` 提交。
+- `Stargate-Password` 请求头认证默认关闭。仅在可信代理集成中设置 `PASSWORD_HEADER_AUTH_ENABLED=true`，并确保代理先删除客户端传入的同名请求头。
+- 可信身份请求头需要同时启用 `HEADER_AUTH_ENABLED=true`、配置匹配的 `HEADER_AUTH_SHARED_SECRET` 并接入 Warden。代理必须先删除客户端传入的身份和密钥请求头，再写入可信值。
+- Warden 或 Herald 客户端配置无效时，服务现在会在启动阶段直接失败，而不是以不完整状态运行。
+- 已移除旧版 Warden 全局 OTP 回退逻辑，请使用 Herald 支持的 TOTP 注册与校验。
+
+## HTTP 契约变化
+
+| 旧契约 | v1.0.0 契约 | 迁移动作 |
+| --- | --- | --- |
+| `GET /_logout` | `POST /_logout` | 将链接或客户端改为提交 POST 请求。 |
+| `GET /totp/enroll` | `POST /totp/enroll` | 使用 POST 发起注册。 |
+| 所有探针使用 `GET /health` | `GET /healthz` 与 `GET /readyz` | 区分进程存活和依赖就绪。 |
+| 无指标端点 | `GET /metrics` | 将 Prometheus 兼容采集目标指向此端点。 |
+| 会话交换 `?id=` | 会话交换 `?ticket=` | 跟随 Stargate 重定向，不再暴露会话 ID。 |
+
+`GET /health` 仅作为已弃用的就绪检查兼容别名保留，新部署不应继续使用。浏览器中改变认证状态的请求会受到同源检查和端点级限流保护。
+
+## 配置行为变化
+
+- `AUTH_REFRESH_ENABLED` 默认值改为 `true`。只有能够接受 Warden 撤权延迟时才应关闭。
+- `COOKIE_SECURE` 默认值为 `true`；本地 HTTP 测试需要显式关闭。
+- 启动校验会拒绝格式错误的 URL、端口、时间间隔、Redis DB、过短的交换密钥，以及不完整的 TLS 证书/私钥和 HMAC Key ID/Secret 组合。
+- 只有在 `CALLBACK_ALLOWED_HOSTS` 中显式允许，才能使用跨域回调目标。
+- 启用 Warden 或 Herald 的 HMAC/TLS 后必须提供完整配置；Herald HMAC 认证还需要 `HERALD_HMAC_KEY_ID`。
+
+切流前，使用生产环境变量启动 v1.0.0 镜像，并逐项修复所有启动校验错误。
+
+## 发布步骤
+
+1. 使用新端口和探针将 v1.0.0 部署到独立实例池。
+2. 多副本部署先启用并验证共享 Redis 会话存储，再接收用户流量。
+3. 验证部署实际启用的密码、Warden、请求头和 TOTP 认证流程。
+4. 验证同域以及所有允许域名的跨域回调。
+5. 仅在 `/healthz` 和 `/readyz` 均成功后切换流量。
+6. 迁移期间将 v0.12.0 与 v1.0.0 保持在不同实例池，不要混用两种会话交换契约。
+
+## 验证清单
+
+```bash
+curl --fail http://127.0.0.1:8080/healthz
+curl --fail http://127.0.0.1:8080/readyz
+curl --fail http://127.0.0.1:8080/metrics
+```
+
+- 容器以 UID/GID `10001` 运行，且不依赖可写根文件系统。
+- 反向代理可以访问 `http://stargate:8080/_auth`。
+- 登录成功，登出使用 `POST /_logout`。
+- 配置 Herald 后，TOTP 注册、确认、验证和撤销均正常。
+- 未允许的回调域名，以及重复使用或过期的交换票据会被拒绝。
+- 客户端自行传入密码或身份请求头不能绕过可信代理。
+- 依赖故障时 `/healthz` 仍表示存活，而 `/readyz` 返回未就绪。
+
+## 回滚
+
+同时恢复 v0.12.0 镜像、代理端口和旧探针。v0.12.0 无法消费 v1.0.0 的交换票据，因此回滚后应作废尚未完成的跨域交换，并要求用户重新登录。不要假设活动会话可以在混合版本实例池之间迁移。

--- a/docs/zhCN/README.md
+++ b/docs/zhCN/README.md
@@ -12,6 +12,7 @@
 
 - **[README.md](../../README.zhCN.md)** - 项目概述和快速开始指南
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - 技术架构和设计决策
+- **[MIGRATION_V1.md](MIGRATION_V1.md)** - 从 v0.12.0 升级到 v1.0.0 的迁移指南
 
 ### 详细文档
 
@@ -71,12 +72,14 @@ stargate/
 │   │   ├── ARCHITECTURE.md # 架构文档（英文）
 │   │   ├── API.md          # API 文档（英文）
 │   │   ├── CONFIG.md       # 配置参考（英文）
+│   │   ├── MIGRATION_V1.md # v1.0.0 迁移指南（英文）
 │   │   └── DEPLOYMENT.md   # 部署指南（英文）
 │   └── zhCN/
 │       ├── README.md       # 文档索引（中文，本文件）
 │       ├── ARCHITECTURE.md # 架构文档（中文）
 │       ├── API.md          # API 文档（中文）
 │       ├── CONFIG.md       # 配置参考（中文）
+│       ├── MIGRATION_V1.md # v1.0.0 迁移指南（中文）
 │       └── DEPLOYMENT.md   # 部署指南（中文）
 └── ...
 ```


### PR DESCRIPTION
## Summary

- add dedicated English and Chinese migration guides for v0.12.0 to v1.0.0
- document the official container port and runtime-user changes
- cover health/readiness probes, cross-domain session tickets, proxy trust, and authentication defaults
- provide rollout, verification, and rollback checklists
- link the guides from both documentation indexes

## Validation

- `git diff --check`
- verified documented routes and container settings against the v1.0.0 implementation