### PR TITLE
docs: align documentation with v1 contracts

### DIFF
--- a/README.deDE.md
+++ b/README.deDE.md
@@ -1,7 +1,7 @@
 # Stargate - Forward Auth Service
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/go-1.26+-blue.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/go-1.27+-blue.svg)](https://golang.org)
 [![codecov](https://codecov.io/gh/soulteary/stargate/branch/main/graph/badge.svg)](https://codecov.io/gh/soulteary/stargate)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
 
@@ -83,7 +83,7 @@ Stargate in **weniger als 2 Minuten** zum Laufen bringen!
 
 **Schritt 1:** Repository klonen
 ```bash
-git clone <repository-url>
+git clone https://github.com/soulteary/stargate.git
 cd stargate
 ```
 

--- a/README.frFR.md
+++ b/README.frFR.md
@@ -1,7 +1,7 @@
 # Stargate - Forward Auth Service
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/go-1.26+-blue.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/go-1.27+-blue.svg)](https://golang.org)
 [![codecov](https://codecov.io/gh/soulteary/stargate/branch/main/graph/badge.svg)](https://codecov.io/gh/soulteary/stargate)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
 
@@ -83,7 +83,7 @@ Mettez Stargate en route en **moins de 2 minutes** !
 
 **Étape 1 :** Cloner le dépôt
 ```bash
-git clone <repository-url>
+git clone https://github.com/soulteary/stargate.git
 cd stargate
 ```
 

--- a/README.itIT.md
+++ b/README.itIT.md
@@ -1,7 +1,7 @@
 # Stargate - Forward Auth Service
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/go-1.26+-blue.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/go-1.27+-blue.svg)](https://golang.org)
 [![codecov](https://codecov.io/gh/soulteary/stargate/branch/main/graph/badge.svg)](https://codecov.io/gh/soulteary/stargate)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
 
@@ -83,7 +83,7 @@ Metti Stargate in funzione in **meno di 2 minuti**!
 
 **Passo 1:** Clona il repository
 ```bash
-git clone <repository-url>
+git clone https://github.com/soulteary/stargate.git
 cd stargate
 ```
 

--- a/README.jaJP.md
+++ b/README.jaJP.md
@@ -1,7 +1,7 @@
 # Stargate - Forward Auth Service
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/go-1.26+-blue.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/go-1.27+-blue.svg)](https://golang.org)
 [![codecov](https://codecov.io/gh/soulteary/stargate/branch/main/graph/badge.svg)](https://codecov.io/gh/soulteary/stargate)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
 
@@ -83,7 +83,7 @@ Stargate は以下に最適です：
 
 **ステップ 1：** リポジトリをクローン
 ```bash
-git clone <repository-url>
+git clone https://github.com/soulteary/stargate.git
 cd stargate
 ```
 

--- a/README.koKR.md
+++ b/README.koKR.md
@@ -1,7 +1,7 @@
 # Stargate - Forward Auth Service
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/go-1.26+-blue.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/go-1.27+-blue.svg)](https://golang.org)
 [![codecov](https://codecov.io/gh/soulteary/stargate/branch/main/graph/badge.svg)](https://codecov.io/gh/soulteary/stargate)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
 
@@ -83,7 +83,7 @@ Stargate는 다음에 완벽합니다:
 
 **1단계:** 저장소 복제
 ```bash
-git clone <repository-url>
+git clone https://github.com/soulteary/stargate.git
 cd stargate
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Stargate - Forward Auth Service
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/go-1.26+-blue.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/go-1.27+-blue.svg)](https://golang.org)
 [![codecov](https://codecov.io/gh/soulteary/stargate/branch/main/graph/badge.svg)](https://codecov.io/gh/soulteary/stargate)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
 
@@ -79,7 +79,7 @@ Get Stargate up and running in **under 2 minutes**!
 
 **Step 1:** Clone the repository
 ```bash
-git clone <repository-url>
+git clone https://github.com/soulteary/stargate.git
 cd stargate
 ```
 

--- a/README.zhCN.md
+++ b/README.zhCN.md
@@ -1,7 +1,7 @@
 # Stargate - Forward Auth Service
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/go-1.26+-blue.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/go-1.27+-blue.svg)](https://golang.org)
 [![codecov](https://codecov.io/gh/soulteary/stargate/branch/main/graph/badge.svg)](https://codecov.io/gh/soulteary/stargate)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
 
@@ -79,7 +79,7 @@ Stargate 非常适合以下场景：
 
 **步骤 1：** 克隆项目
 ```bash
-git clone <repository-url>
+git clone https://github.com/soulteary/stargate.git
 cd stargate
 ```
 

--- a/docs/deDE/API.md
+++ b/docs/deDE/API.md
@@ -298,6 +298,16 @@ Das Sitzungs-Cookie wird gelöscht.
 curl -X POST -b cookies.txt http://auth.example.com/_logout
 ```
 
+## Step-up-Authentifizierungs-Endpunkt
+
+### `GET /_step_up`
+
+Zeigt für eine authentifizierte Sitzung ein Formular zur erneuten Passwortprüfung. Der optionale Query-Parameter `callback` muss ein lokaler Pfad sein; unsichere Werte werden durch `/` ersetzt.
+
+### `POST /_step_up`
+
+Prüft das Passwort erneut und speichert die erfolgreiche Step-up-Authentifizierung für 10 Minuten in der Sitzung. Formularfelder: `password` und optionaler lokaler `callback`. Die Route ist durch Same-Origin-Prüfung und Rate-Limit geschützt.
+
 ## Sitzungsaustausch-Endpunkt
 
 ### `GET /_session_exchange`
@@ -348,31 +358,54 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 4. Weiterleitung zu `app.example.com/`
 5. Der Benutzer kann diese Sitzung auf allen Subdomains `*.example.com` verwenden
 
-## Gesundheitsprüfungs-Endpunkt
+## TOTP-Endpunkte
 
-### `GET /health`
+Diese Endpunkte sind verfügbar, wenn Herald und Herald-TOTP aktiviert sind. Sie erfordern eine authentifizierte Sitzung.
 
-Gesundheitsprüfungs-Endpunkt des Dienstes. Wird verwendet, um den Status des Dienstes zu überwachen.
+### `POST /totp/enroll`
 
-#### Antwort
+Startet die Registrierung und zeigt die TOTP-Bindungsseite an.
 
-**Erfolgreiche Antwort (200 OK)**
+### `POST /totp/enroll/confirm`
 
-```
-HTTP/1.1 200 OK
-```
+Bestätigt die Registrierung mit dem sechsstelligen TOTP-Code im Feld `code`.
 
-#### Beispiel
+### `GET /totp/revoke`
+
+Zeigt die Bestätigungsseite zum Entfernen der TOTP-Bindung an.
+
+### `POST /totp/revoke`
+
+Entfernt die TOTP-Bindung nach Bestätigung mit `password` oder einem aktuellen `code`.
+
+## Gesundheitsprüfungs-Endpunkte
+
+### `GET /healthz`
+
+Prozess-Liveness ohne Abfrage von Redis, Warden oder Herald. Verwenden Sie diesen Endpunkt für Container- und Kubernetes-Liveness-Proben.
+
+### `GET /readyz`
+
+Aggregierte Bereitschaft der konfigurierten Redis-, Warden- und Herald-Abhängigkeiten. Verwenden Sie diesen Endpunkt für Load-Balancer und Kubernetes-Readiness-Proben.
 
 ```bash
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
+curl http://auth.example.com/readyz
 ```
 
-**Typische Verwendungen:**
+`GET /health` bleibt als veralteter Kompatibilitätsalias für `GET /readyz` erhalten.
 
-- Docker-Gesundheitsprüfungen
-- Kubernetes-Liveness-Proben
-- Load-Balancer-Gesundheitsprüfungen
+## Metrik-Endpunkt
+
+### `GET /metrics`
+
+Liefert Prometheus-Metriken im Textformat. Der Endpunkt erfordert keine Authentifizierung und sollte über Netzwerk- oder Proxy-Regeln geschützt werden.
+
+## Endpunkt für die Laufzeit-Protokollstufe
+
+### `GET /log/level`
+
+Gibt die aktuelle Protokollstufe zurück. `PUT /log/level` oder `POST /log/level` ändert sie mit dem JSON-Body `{"level":"debug"}` oder dem Query-Parameter `?level=debug`. Stargate beschränkt diesen Endpunkt auf `127.0.0.1`; er darf nicht über den öffentlichen Reverse Proxy erreichbar sein.
 
 ## Root-Endpunkt
 

--- a/docs/deDE/ARCHITECTURE.md
+++ b/docs/deDE/ARCHITECTURE.md
@@ -78,7 +78,7 @@ Die Handler sind verantwortlich für die Verarbeitung von HTTP-Anfragen:
 - **TOTPRevokeRoute / TOTPRevokeConfirmAPI**: TOTP-Unbind-Seite und Bestätigung (über Herald TOTP)
 - **LogoutRoute**: Logout-Verarbeitung
 - **SessionShareRoute**: Cross-Domain-Sitzungsfreigabe
-- **HealthRoute**: Gesundheitsprüfung (inkl. Warden- und Herald-Status)
+- **Health-Routen**: `/healthz` für Prozess-Liveness und `/readyz` für den aggregierten Status von Redis, Warden und Herald
 - **IndexRoute**: Root-Pfad-Verarbeitung
 - **GET /metrics**: Prometheus-Metriken (metrics-kit)
 
@@ -345,7 +345,7 @@ Template-Datei `internal/web/templates/login.html` ändern.
 - Verwendet Zerolog (über logger-kit) für strukturierte Protokollierung
 - Unterstützt Debug-Modus (DEBUG=true)
 - Alle kritischen Operationen werden protokolliert
-- Gesundheitsprüfungs-Endpunkt (`GET /health`) und Prometheus-Metriken (`GET /metrics`) für die Überwachung verfügbar
+- Prozess-Liveness (`GET /healthz`), Abhängigkeitsbereitschaft (`GET /readyz`) und Prometheus-Metriken (`GET /metrics`) für die Überwachung verfügbar
 
 ## Tests
 

--- a/docs/deDE/CONFIG.md
+++ b/docs/deDE/CONFIG.md
@@ -26,7 +26,7 @@ export PASSWORDS=plaintext:yourpassword
 **Docker:**
 
 ```bash
-docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword stargate:latest
+docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 **Docker Compose:**
@@ -369,7 +369,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       # Erforderliche Konfiguration
       - AUTH_HOST=auth.example.com

--- a/docs/deDE/DEPLOYMENT.md
+++ b/docs/deDE/DEPLOYMENT.md
@@ -104,7 +104,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=plaintext:yourpassword \
   stargate:latest
@@ -115,7 +115,7 @@ docker run -d \
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
   -e DEBUG=false \
@@ -131,7 +131,7 @@ docker run -d \
 
 - `-d`: Im Hintergrund ausführen
 - `--name stargate`: Containername
-- `-p 80:80`: Port-Mapping (Host-Port:Container-Port)
+- `-p 8080:8080`: Port-Mapping (Host-Port:Container-Port)
 - `-e`: Umgebungsvariable
 - `--restart unless-stopped`: Automatische Neustart-Richtlinie
 
@@ -167,7 +167,7 @@ Das Projekt stellt eine Beispiel-Datei `docker-compose.yml` bereit:
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
@@ -178,7 +178,7 @@ services:
       - traefik.docker.network=proxy
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
-      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth
+      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   whoami:
     image: traefik/whoami
@@ -225,7 +225,7 @@ Bearbeiten Sie `docker-compose.yml` und ändern Sie die Umgebungsvariablen:
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -247,7 +247,7 @@ Konfigurieren Sie Stargate in `docker-compose.yml`:
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -258,7 +258,7 @@ services:
       - "traefik.docker.network=traefik"
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
-      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
 ```
 
@@ -427,12 +427,12 @@ services:
 
 #### 2. Gesundheitsprüfungs-Endpunkt
 
-Verwenden Sie den Endpunkt `/health` für die Überwachung:
+Verwenden Sie `/healthz` für die Prozess-Liveness und `/readyz` für die Bereitschaft der Abhängigkeiten. `/health` ist nur ein veralteter Bereitschafts-Alias.
 
 ```bash
 # Gesundheitsprüfungs-Skript
 #!/bin/bash
-if curl -f http://localhost/health > /dev/null 2>&1; then
+if curl -f http://localhost/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -571,7 +571,7 @@ COOKIE_DOMAIN=.example.com
 
 ```yaml
 # Sicherstellen, dass die Middleware-Adresse korrekt ist
-- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
 ```
 
 ### Debug-Tipps
@@ -632,7 +632,7 @@ docker stop stargate
 3. **Neues Image herunterladen:**
 
 ```bash
-docker pull stargate:latest
+docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 4. **Neuen Container starten:**
@@ -641,7 +641,7 @@ docker pull stargate:latest
 docker run -d \
   --name stargate \
   ...(gespeicherte Konfiguration verwenden)
-  stargate:latest
+  ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 5. **Dienst überprüfen:**

--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -339,6 +339,16 @@ The session cookie will be cleared.
 curl -X POST -b cookies.txt http://auth.example.com/_logout
 ```
 
+## Step-up Authentication Endpoint
+
+### `GET /_step_up`
+
+Displays a password re-verification form for an authenticated session. The optional `callback` query parameter must be a local path; unsafe values fall back to `/`.
+
+### `POST /_step_up`
+
+Re-verifies the password and records successful step-up authentication in the session for 10 minutes. Submit form fields `password` and optional local-path `callback`. This route is same-origin protected and rate limited.
+
 ## Session Exchange Endpoint
 
 ### `GET /_session_exchange`
@@ -455,6 +465,12 @@ Prometheus metrics in text exposition format. Used for monitoring authentication
 
 - Prometheus scrape target
 - Grafana dashboards
+
+## Runtime Log Level Endpoint
+
+### `GET /log/level`
+
+Returns the current log level. `PUT /log/level` or `POST /log/level` changes it using JSON body `{"level":"debug"}` or query parameter `?level=debug`. Stargate restricts this endpoint to `127.0.0.1`; it must not be exposed through the public reverse proxy.
 
 ## Root Endpoint
 

--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -27,7 +27,7 @@ export PASSWORDS=plaintext:yourpassword
 **Docker:**
 
 ```bash
-docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword stargate:latest
+docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 **Docker Compose:**
@@ -48,6 +48,7 @@ Below are all environment variables used in code. "Required" means the service w
 |----------|-------------|---------|----------|
 | `AUTH_HOST` | String | — | Yes |
 | `PASSWORDS` | See password config | — | Yes when Warden disabled |
+| `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | No |
 | `DEBUG` | true/false | false | No |
 | `LOGIN_PAGE_TITLE` | String | Stargate - Login | No |
 | `LOGIN_PAGE_FOOTER_TEXT` | String | Copyright © 2024 - Stargate | No |
@@ -69,6 +70,9 @@ Below are all environment variables used in code. "Required" means the service w
 | `WARDEN_TLS_CLIENT_CERT_FILE` | path | empty | No |
 | `WARDEN_TLS_CLIENT_KEY_FILE` | path | empty | No |
 | `WARDEN_TLS_SERVER_NAME` | String | empty | No |
+| `HEADER_AUTH_ENABLED` | true/false | false | No |
+| `HEADER_AUTH_SHARED_SECRET` | Secret string | empty | Yes when header auth enabled |
+| `HEADER_AUTH_SECRET_HEADER` | HTTP header name | X-Stargate-Header-Auth | No |
 | `WARDEN_CACHE_TTL` | String | 300 | No |
 | `WARDEN_OTP_ENABLED` | true/false | false | No |
 | `WARDEN_OTP_SECRET_KEY` | String | empty | No |
@@ -1031,7 +1035,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       # Required configuration
       - AUTH_HOST=auth.example.com
@@ -1050,7 +1054,7 @@ services:
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       # Required configuration
       - AUTH_HOST=auth.example.com
@@ -1211,3 +1215,20 @@ PASSWORDS=bcrypt:<hash>
 ```
 
 Treat the header as a credential: require HTTPS, apply rate limits, and configure the reverse proxy to remove `Stargate-Password` before forwarding the request to the backend. Cookie sessions remain the recommended browser authentication method.
+
+## Trusted Identity Header Authentication
+
+Trusted identity headers are disabled by default. This mode requires Warden and is intended only for a reverse proxy that authenticates the caller before forwarding the request.
+
+```bash
+WARDEN_ENABLED=true
+WARDEN_URL=http://warden:8080
+HEADER_AUTH_ENABLED=true
+HEADER_AUTH_SHARED_SECRET=<random-shared-secret>
+# Optional; this is the default header name:
+HEADER_AUTH_SECRET_HEADER=X-Stargate-Header-Auth
+```
+
+The proxy sends `X-User-Phone` or `X-User-Mail` together with the configured secret header. Stargate removes the secret header before forwarding and discards the identity headers when the secret does not match.
+
+Treat all three headers as trust-boundary inputs: use HTTPS, generate a strong shared secret, and configure the edge proxy to remove any client-supplied `X-User-Phone`, `X-User-Mail`, and header named by `HEADER_AUTH_SECRET_HEADER` before adding its own. Never expose this mode directly to untrusted clients.

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -104,7 +104,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=plaintext:yourpassword \
   stargate:latest
@@ -115,7 +115,7 @@ docker run -d \
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
   -e DEBUG=false \
@@ -131,7 +131,7 @@ docker run -d \
 
 - `-d`: Run in background
 - `--name stargate`: Container name
-- `-p 80:80`: Port mapping (host port:container port)
+- `-p 8080:8080`: Port mapping (host port:container port)
 - `-e`: Environment variable
 - `--restart unless-stopped`: Auto-restart policy
 
@@ -167,7 +167,7 @@ The project provides a `docker-compose.yml` example file in the project root. St
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
@@ -181,7 +181,7 @@ services:
       - traefik.docker.network=proxy
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
-      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth
+      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   whoami:
     image: traefik/whoami
@@ -228,7 +228,7 @@ Edit `docker-compose.yml` and modify environment variables:
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -250,7 +250,7 @@ Configure Stargate in `docker-compose.yml`:
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -261,7 +261,7 @@ services:
       - "traefik.docker.network=traefik"
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
-      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
 ```
 
@@ -574,7 +574,7 @@ COOKIE_DOMAIN=.example.com
 
 ```yaml
 # Ensure middleware address is correct
-- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
 ```
 
 ### Debugging Tips
@@ -635,7 +635,7 @@ docker stop stargate
 3. **Pull New Image:**
 
 ```bash
-docker pull stargate:latest
+docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 4. **Start New Container:**
@@ -644,7 +644,7 @@ docker pull stargate:latest
 docker run -d \
   --name stargate \
   ...(use backed up configuration)
-  stargate:latest
+  ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 5. **Verify Service:**

--- a/docs/frFR/API.md
+++ b/docs/frFR/API.md
@@ -299,6 +299,16 @@ Le cookie de session sera effacé.
 curl -X POST -b cookies.txt http://auth.example.com/_logout
 ```
 
+## Point de Terminaison d'Authentification Renforcée
+
+### `GET /_step_up`
+
+Affiche un formulaire de revérification du mot de passe pour une session authentifiée. Le paramètre de requête facultatif `callback` doit être un chemin local ; les valeurs non sûres sont remplacées par `/`.
+
+### `POST /_step_up`
+
+Revérifie le mot de passe et enregistre l'authentification renforcée dans la session pendant 10 minutes. Champs du formulaire : `password` et `callback` local facultatif. La route est protégée par un contrôle same-origin et une limitation de débit.
+
 ## Point de Terminaison d'Échange de Session
 
 ### `GET /_session_exchange`
@@ -349,31 +359,54 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 4. Redirige vers `app.example.com/`
 5. L'utilisateur peut utiliser cette session sur tous les sous-domaines `*.example.com`
 
-## Point de Terminaison de Vérification de Santé
+## Points de Terminaison TOTP
 
-### `GET /health`
+Ces points de terminaison sont disponibles lorsque Herald et Herald TOTP sont activés. Ils nécessitent une session authentifiée.
 
-Point de terminaison de vérification de santé du service. Utilisé pour surveiller le statut du service.
+### `POST /totp/enroll`
 
-#### Réponse
+Démarre l'inscription et affiche la page d'association TOTP.
 
-**Réponse de Succès (200 OK)**
+### `POST /totp/enroll/confirm`
 
-```
-HTTP/1.1 200 OK
-```
+Confirme l'inscription avec le code TOTP à six chiffres dans le champ `code`.
 
-#### Exemple
+### `GET /totp/revoke`
+
+Affiche la page de confirmation de suppression de l'association TOTP.
+
+### `POST /totp/revoke`
+
+Supprime l'association TOTP après confirmation avec `password` ou un `code` actuel.
+
+## Points de Terminaison de Santé
+
+### `GET /healthz`
+
+Sonde de liveness du processus sans interroger Redis, Warden ou Herald. Utilisez-la pour les vérifications de conteneur et les sondes de liveness Kubernetes.
+
+### `GET /readyz`
+
+État de disponibilité agrégé des dépendances Redis, Warden et Herald configurées. Utilisez-le pour les répartiteurs de charge et les sondes de readiness Kubernetes.
 
 ```bash
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
+curl http://auth.example.com/readyz
 ```
 
-**Utilisations Typiques :**
+`GET /health` reste un alias de compatibilité obsolète de `GET /readyz`.
 
-- Vérifications de santé Docker
-- Sondes de liveness Kubernetes
-- Vérifications de santé de répartiteur de charge
+## Point de Terminaison des Métriques
+
+### `GET /metrics`
+
+Renvoie les métriques Prometheus au format texte. Ce point de terminaison ne requiert pas d'authentification et doit être protégé par des règles réseau ou de proxy.
+
+## Point de Terminaison du Niveau de Journalisation
+
+### `GET /log/level`
+
+Renvoie le niveau de journalisation actuel. `PUT /log/level` ou `POST /log/level` le modifie avec le corps JSON `{"level":"debug"}` ou le paramètre `?level=debug`. Stargate limite ce point de terminaison à `127.0.0.1` ; il ne doit pas être exposé par le reverse proxy public.
 
 ## Point de Terminaison Racine
 

--- a/docs/frFR/ARCHITECTURE.md
+++ b/docs/frFR/ARCHITECTURE.md
@@ -78,7 +78,7 @@ Les gestionnaires sont responsables du traitement des requêtes HTTP :
 - **TOTPRevokeRoute / TOTPRevokeConfirmAPI** : Page de révocation TOTP et confirmation (via Herald TOTP)
 - **LogoutRoute** : Traitement de déconnexion
 - **SessionShareRoute** : Partage de session cross-domain
-- **HealthRoute** : Vérification de santé (inclut statut Warden et Herald)
+- **Routes de santé** : `/healthz` pour la liveness du processus et `/readyz` pour l'état agrégé de Redis, Warden et Herald
 - **IndexRoute** : Traitement du chemin racine
 - **GET /metrics** : Métriques Prometheus (metrics-kit)
 
@@ -345,7 +345,7 @@ Modifier le fichier template `internal/web/templates/login.html`.
 - Utilise Zerolog (via logger-kit) pour la journalisation structurée
 - Supporte le mode débogage (DEBUG=true)
 - Toutes les opérations critiques sont journalisées
-- Endpoint de santé (`GET /health`) et métriques Prometheus (`GET /metrics`) disponibles pour la surveillance
+- Liveness du processus (`GET /healthz`), disponibilité des dépendances (`GET /readyz`) et métriques Prometheus (`GET /metrics`) disponibles pour la surveillance
 
 ## Tests
 

--- a/docs/frFR/CONFIG.md
+++ b/docs/frFR/CONFIG.md
@@ -26,7 +26,7 @@ export PASSWORDS=plaintext:yourpassword
 **Docker :**
 
 ```bash
-docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword stargate:latest
+docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 **Docker Compose :**
@@ -369,7 +369,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       # Configuration requise
       - AUTH_HOST=auth.example.com

--- a/docs/frFR/DEPLOYMENT.md
+++ b/docs/frFR/DEPLOYMENT.md
@@ -104,7 +104,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=plaintext:yourpassword \
   stargate:latest
@@ -115,7 +115,7 @@ docker run -d \
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
   -e DEBUG=false \
@@ -131,7 +131,7 @@ docker run -d \
 
 - `-d` : Exécuter en arrière-plan
 - `--name stargate` : Nom du conteneur
-- `-p 80:80` : Mappage de port (port hôte:port conteneur)
+- `-p 8080:8080` : Mappage de port (port hôte:port conteneur)
 - `-e` : Variable d'environnement
 - `--restart unless-stopped` : Politique de redémarrage automatique
 
@@ -167,7 +167,7 @@ Le projet fournit un fichier d'exemple `docker-compose.yml` :
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
@@ -178,7 +178,7 @@ services:
       - traefik.docker.network=proxy
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
-      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth
+      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   whoami:
     image: traefik/whoami
@@ -225,7 +225,7 @@ Modifier `docker-compose.yml` et modifier les variables d'environnement :
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -247,7 +247,7 @@ Configurer Stargate dans `docker-compose.yml` :
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -258,7 +258,7 @@ services:
       - "traefik.docker.network=traefik"
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
-      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
 ```
 
@@ -427,12 +427,12 @@ services:
 
 #### 2. Point de Terminaison de Vérification de Santé
 
-Utiliser le point de terminaison `/health` pour la surveillance :
+Utilisez `/healthz` pour la liveness du processus et `/readyz` pour la disponibilité des dépendances. `/health` n'est plus qu'un alias de disponibilité obsolète.
 
 ```bash
 # Script de vérification de santé
 #!/bin/bash
-if curl -f http://localhost/health > /dev/null 2>&1; then
+if curl -f http://localhost/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -571,7 +571,7 @@ COOKIE_DOMAIN=.example.com
 
 ```yaml
 # S'assurer que l'adresse du middleware est correcte
-- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
 ```
 
 ### Conseils de Débogage
@@ -632,7 +632,7 @@ docker stop stargate
 3. **Télécharger la Nouvelle Image :**
 
 ```bash
-docker pull stargate:latest
+docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 4. **Démarrer le Nouveau Conteneur :**
@@ -641,7 +641,7 @@ docker pull stargate:latest
 docker run -d \
   --name stargate \
   ...(utiliser la configuration sauvegardée)
-  stargate:latest
+  ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 5. **Vérifier le Service :**

--- a/docs/itIT/API.md
+++ b/docs/itIT/API.md
@@ -298,6 +298,16 @@ Il cookie di sessione sarà cancellato.
 curl -X POST -b cookies.txt http://auth.example.com/_logout
 ```
 
+## Endpoint di Autenticazione Step-up
+
+### `GET /_step_up`
+
+Mostra un modulo di riverifica della password per una sessione autenticata. Il parametro di query facoltativo `callback` deve essere un percorso locale; i valori non sicuri vengono sostituiti con `/`.
+
+### `POST /_step_up`
+
+Riverifica la password e registra l'autenticazione step-up nella sessione per 10 minuti. Campi del modulo: `password` e `callback` locale facoltativo. La route è protetta dal controllo same-origin e dal rate limit.
+
 ## Endpoint Scambio Sessione
 
 ### `GET /_session_exchange`
@@ -348,31 +358,54 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 4. Reindirizza a `app.example.com/`
 5. L'utente può utilizzare questa sessione su tutti i sottodomini `*.example.com`
 
-## Endpoint Verifica Salute
+## Endpoint TOTP
 
-### `GET /health`
+Questi endpoint sono disponibili quando Herald e Herald TOTP sono abilitati. Richiedono una sessione autenticata.
 
-Endpoint verifica salute del servizio. Utilizzato per monitorare lo stato del servizio.
+### `POST /totp/enroll`
 
-#### Risposta
+Avvia la registrazione e mostra la pagina di associazione TOTP.
 
-**Risposta di Successo (200 OK)**
+### `POST /totp/enroll/confirm`
 
-```
-HTTP/1.1 200 OK
-```
+Conferma la registrazione con il codice TOTP a sei cifre nel campo `code`.
 
-#### Esempio
+### `GET /totp/revoke`
+
+Mostra la pagina di conferma per rimuovere l'associazione TOTP.
+
+### `POST /totp/revoke`
+
+Rimuove l'associazione TOTP dopo la conferma con `password` o con un `code` corrente.
+
+## Endpoint di Salute
+
+### `GET /healthz`
+
+Sonda di liveness del processo senza interrogare Redis, Warden o Herald. Usarla per i controlli del container e le sonde di liveness Kubernetes.
+
+### `GET /readyz`
+
+Stato di readiness aggregato delle dipendenze Redis, Warden e Herald configurate. Usarlo per bilanciatori di carico e sonde di readiness Kubernetes.
 
 ```bash
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
+curl http://auth.example.com/readyz
 ```
 
-**Utilizzi Tipici:**
+`GET /health` rimane un alias di compatibilità deprecato per `GET /readyz`.
 
-- Verifiche salute Docker
-- Sonde liveness Kubernetes
-- Verifiche salute bilanciatore di carico
+## Endpoint Metriche
+
+### `GET /metrics`
+
+Restituisce metriche Prometheus in formato testo. L'endpoint non richiede autenticazione e deve essere protetto tramite regole di rete o del proxy.
+
+## Endpoint del Livello di Log a Runtime
+
+### `GET /log/level`
+
+Restituisce il livello di log corrente. `PUT /log/level` o `POST /log/level` lo modifica con il corpo JSON `{"level":"debug"}` o il parametro `?level=debug`. Stargate limita questo endpoint a `127.0.0.1`; non deve essere esposto tramite il reverse proxy pubblico.
 
 ## Endpoint Root
 

--- a/docs/itIT/ARCHITECTURE.md
+++ b/docs/itIT/ARCHITECTURE.md
@@ -78,7 +78,7 @@ I gestori sono responsabili dell'elaborazione delle richieste HTTP:
 - **TOTPRevokeRoute / TOTPRevokeConfirmAPI**: Pagina revoca TOTP e conferma (via Herald TOTP)
 - **LogoutRoute**: Elaborazione logout
 - **SessionShareRoute**: Condivisione sessione cross-domain
-- **HealthRoute**: Verifica salute (include stato Warden e Herald)
+- **Route di salute**: `/healthz` per la liveness del processo e `/readyz` per lo stato aggregato di Redis, Warden e Herald
 - **IndexRoute**: Elaborazione percorso root
 - **GET /metrics**: Metriche Prometheus (metrics-kit)
 
@@ -344,7 +344,7 @@ Modificare il file template `internal/web/templates/login.html`.
 - Utilizza Zerolog (via logger-kit) per registrazione strutturata
 - Supporta modalità debug (DEBUG=true)
 - Tutte le operazioni critiche sono registrate
-- Endpoint salute (`GET /health`) e metriche Prometheus (`GET /metrics`) disponibili per monitoraggio
+- Liveness del processo (`GET /healthz`), readiness delle dipendenze (`GET /readyz`) e metriche Prometheus (`GET /metrics`) disponibili per il monitoraggio
 
 ## Test
 

--- a/docs/itIT/CONFIG.md
+++ b/docs/itIT/CONFIG.md
@@ -26,7 +26,7 @@ export PASSWORDS=plaintext:yourpassword
 **Docker:**
 
 ```bash
-docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword stargate:latest
+docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 **Docker Compose:**
@@ -369,7 +369,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       # Configurazione richiesta
       - AUTH_HOST=auth.example.com

--- a/docs/itIT/DEPLOYMENT.md
+++ b/docs/itIT/DEPLOYMENT.md
@@ -104,7 +104,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=plaintext:yourpassword \
   stargate:latest
@@ -115,7 +115,7 @@ docker run -d \
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
   -e DEBUG=false \
@@ -131,7 +131,7 @@ docker run -d \
 
 - `-d`: Eseguire in background
 - `--name stargate`: Nome del container
-- `-p 80:80`: Mapping porta (porta host:porta container)
+- `-p 8080:8080`: Mapping porta (porta host:porta container)
 - `-e`: Variabile d'ambiente
 - `--restart unless-stopped`: Politica di riavvio automatico
 
@@ -167,7 +167,7 @@ Il progetto fornisce un file di esempio `docker-compose.yml`:
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
@@ -178,7 +178,7 @@ services:
       - traefik.docker.network=proxy
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
-      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth
+      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   whoami:
     image: traefik/whoami
@@ -225,7 +225,7 @@ Modificare `docker-compose.yml` e modificare le variabili d'ambiente:
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -247,7 +247,7 @@ Configurare Stargate in `docker-compose.yml`:
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -258,7 +258,7 @@ services:
       - "traefik.docker.network=traefik"
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
-      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
 ```
 
@@ -427,12 +427,12 @@ services:
 
 #### 2. Endpoint Verifica Salute
 
-Utilizzare l'endpoint `/health` per il monitoraggio:
+Usare `/healthz` per la liveness del processo e `/readyz` per la readiness delle dipendenze. `/health` è solo un alias di readiness deprecato.
 
 ```bash
 # Script verifica salute
 #!/bin/bash
-if curl -f http://localhost/health > /dev/null 2>&1; then
+if curl -f http://localhost/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -571,7 +571,7 @@ COOKIE_DOMAIN=.example.com
 
 ```yaml
 # Assicurarsi che l'indirizzo middleware sia corretto
-- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
 ```
 
 ### Suggerimenti Debug
@@ -632,7 +632,7 @@ docker stop stargate
 3. **Scaricare Nuova Immagine:**
 
 ```bash
-docker pull stargate:latest
+docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 4. **Avviare Nuovo Container:**
@@ -641,7 +641,7 @@ docker pull stargate:latest
 docker run -d \
   --name stargate \
   ...(utilizzare configurazione salvata)
-  stargate:latest
+  ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 5. **Verificare il Servizio:**

--- a/docs/jaJP/API.md
+++ b/docs/jaJP/API.md
@@ -298,6 +298,16 @@ Logged out
 curl -X POST -b cookies.txt http://auth.example.com/_logout
 ```
 
+## Step-up 認証エンドポイント
+
+### `GET /_step_up`
+
+認証済みセッションにパスワード再確認フォームを表示します。任意の `callback` クエリパラメータはローカルパスである必要があり、安全でない値は `/` に置き換えられます。
+
+### `POST /_step_up`
+
+パスワードを再確認し、成功した Step-up 認証をセッションに 10 分間記録します。フォームフィールドは `password` と任意のローカル `callback` です。同一オリジン検証とレート制限で保護されています。
+
 ## セッション交換エンドポイント
 
 ### `GET /_session_exchange`
@@ -348,31 +358,54 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 4. `app.example.com/` にリダイレクト
 5. ユーザーはすべてのサブドメイン `*.example.com` でこのセッションを使用できます
 
+## TOTP エンドポイント
+
+Herald と Herald TOTP が有効な場合に利用できます。すべて認証済みセッションが必要です。
+
+### `POST /totp/enroll`
+
+登録を開始し、TOTP の関連付けページを表示します。
+
+### `POST /totp/enroll/confirm`
+
+`code` フィールドの 6 桁の TOTP コードで登録を確定します。
+
+### `GET /totp/revoke`
+
+TOTP の関連付けを解除する確認ページを表示します。
+
+### `POST /totp/revoke`
+
+`password` または現在の `code` で確認した後、TOTP の関連付けを解除します。
+
 ## ヘルスチェックエンドポイント
 
-### `GET /health`
+### `GET /healthz`
 
-サービスのヘルスチェックエンドポイント。サービスの状態を監視するために使用されます。
+Redis、Warden、Herald を確認しないプロセスの liveness エンドポイントです。コンテナのヘルスチェックと Kubernetes の liveness プローブに使用します。
 
-#### レスポンス
+### `GET /readyz`
 
-**成功レスポンス（200 OK）**
-
-```
-HTTP/1.1 200 OK
-```
-
-#### 例
+設定済みの Redis、Warden、Herald 依存関係を集約した readiness エンドポイントです。ロードバランサーと Kubernetes の readiness プローブに使用します。
 
 ```bash
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
+curl http://auth.example.com/readyz
 ```
 
-**典型的な使用例：**
+`GET /health` は `GET /readyz` の非推奨互換エイリアスとして残されています。
 
-- Docker ヘルスチェック
-- Kubernetes の liveness プローブ
-- ロードバランサーのヘルスチェック
+## メトリクスエンドポイント
+
+### `GET /metrics`
+
+Prometheus メトリクスをテキスト形式で返します。認証は不要なため、ネットワークまたはプロキシのルールで保護してください。
+
+## 実行時ログレベルエンドポイント
+
+### `GET /log/level`
+
+現在のログレベルを返します。`PUT /log/level` または `POST /log/level` に JSON 本文 `{"level":"debug"}` かクエリパラメータ `?level=debug` を渡して変更します。Stargate はこのエンドポイントを `127.0.0.1` に制限しているため、公開リバースプロキシで露出させないでください。
 
 ## ルートエンドポイント
 

--- a/docs/jaJP/ARCHITECTURE.md
+++ b/docs/jaJP/ARCHITECTURE.md
@@ -78,7 +78,7 @@ src/
 - **TOTPRevokeRoute / TOTPRevokeConfirmAPI**: TOTP 解除画面・確認（Herald TOTP 経由）
 - **LogoutRoute**: ログアウト処理
 - **SessionShareRoute**: クロスドメインセッション共有
-- **HealthRoute**: ヘルスチェック（Warden・Herald 状態含む）
+- **ヘルスルート**: プロセスの liveness は `/healthz`、Redis・Warden・Herald の集約 readiness は `/readyz`
 - **IndexRoute**: ルートパスの処理
 - **GET /metrics**: Prometheus メトリクス（metrics-kit）
 
@@ -344,7 +344,7 @@ WardenおよびHerald統合が有効な場合、OTP認証を使用できます�
 - Zerolog（logger-kit 経由）で構造化ログ
 - デバッグモードをサポート（DEBUG=true）
 - すべての重要な操作がログに記録される
-- ヘルスチェック（`GET /health`）と Prometheus メトリクス（`GET /metrics`）で監視可能
+- プロセスの liveness（`GET /healthz`）、依存関係の readiness（`GET /readyz`）、Prometheus メトリクス（`GET /metrics`）で監視可能
 
 ## テスト
 

--- a/docs/jaJP/CONFIG.md
+++ b/docs/jaJP/CONFIG.md
@@ -26,7 +26,7 @@ export PASSWORDS=plaintext:yourpassword
 **Docker:**
 
 ```bash
-docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword stargate:latest
+docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 **Docker Compose:**
@@ -369,7 +369,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       # 必須設定
       - AUTH_HOST=auth.example.com

--- a/docs/jaJP/DEPLOYMENT.md
+++ b/docs/jaJP/DEPLOYMENT.md
@@ -104,7 +104,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=plaintext:yourpassword \
   stargate:latest
@@ -115,7 +115,7 @@ docker run -d \
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
   -e DEBUG=false \
@@ -131,7 +131,7 @@ docker run -d \
 
 - `-d`: バックグラウンドで実行
 - `--name stargate`: コンテナ名
-- `-p 80:80`: ポートマッピング（ホストポート:コンテナポート）
+- `-p 8080:8080`: ポートマッピング（ホストポート:コンテナポート）
 - `-e`: 環境変数
 - `--restart unless-stopped`: 自動再起動ポリシー
 
@@ -167,7 +167,7 @@ docker rm -f stargate
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
@@ -178,7 +178,7 @@ services:
       - traefik.docker.network=proxy
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
-      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth
+      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   whoami:
     image: traefik/whoami
@@ -225,7 +225,7 @@ docker-compose logs -f stargate
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -247,7 +247,7 @@ Stargate は Traefik と統合するように設計されており、Forward Aut
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -258,7 +258,7 @@ services:
       - "traefik.docker.network=traefik"
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
-      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
 ```
 
@@ -427,12 +427,12 @@ services:
 
 #### 2. ヘルスチェックエンドポイント
 
-監視に `/health` エンドポイントを使用：
+プロセスの liveness には `/healthz`、依存関係の readiness には `/readyz` を使用します。`/health` は非推奨の readiness 互換エイリアスです。
 
 ```bash
 # ヘルスチェックスクリプト
 #!/bin/bash
-if curl -f http://localhost/health > /dev/null 2>&1; then
+if curl -f http://localhost/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -571,7 +571,7 @@ COOKIE_DOMAIN=.example.com
 
 ```yaml
 # ミドルウェアのアドレスが正しいことを確認
-- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
 ```
 
 ### デバッグのヒント
@@ -632,7 +632,7 @@ docker stop stargate
 3. **新しいイメージのダウンロード:**
 
 ```bash
-docker pull stargate:latest
+docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 4. **新しいコンテナの起動:**
@@ -641,7 +641,7 @@ docker pull stargate:latest
 docker run -d \
   --name stargate \
   ...(保存された設定を使用)
-  stargate:latest
+  ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 5. **サービスの確認:**

--- a/docs/koKR/API.md
+++ b/docs/koKR/API.md
@@ -298,6 +298,16 @@ Logged out
 curl -X POST -b cookies.txt http://auth.example.com/_logout
 ```
 
+## Step-up 인증 엔드포인트
+
+### `GET /_step_up`
+
+인증된 세션에 비밀번호 재확인 양식을 표시합니다. 선택적 `callback` 쿼리 매개변수는 로컬 경로여야 하며 안전하지 않은 값은 `/`로 대체됩니다.
+
+### `POST /_step_up`
+
+비밀번호를 다시 확인하고 성공한 Step-up 인증을 세션에 10분 동안 기록합니다. 양식 필드는 `password`와 선택적 로컬 `callback`입니다. 동일 출처 검사와 속도 제한으로 보호됩니다.
+
 ## 세션 교환 엔드포인트
 
 ### `GET /_session_exchange`
@@ -348,31 +358,54 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 4. `app.example.com/`로 리디렉션
 5. 사용자는 모든 하위 도메인 `*.example.com`에서 이 세션을 사용할 수 있습니다
 
+## TOTP 엔드포인트
+
+Herald와 Herald TOTP가 활성화된 경우 사용할 수 있습니다. 모든 엔드포인트에 인증된 세션이 필요합니다.
+
+### `POST /totp/enroll`
+
+등록을 시작하고 TOTP 연결 페이지를 표시합니다.
+
+### `POST /totp/enroll/confirm`
+
+`code` 필드의 6자리 TOTP 코드로 등록을 확인합니다.
+
+### `GET /totp/revoke`
+
+TOTP 연결 해제 확인 페이지를 표시합니다.
+
+### `POST /totp/revoke`
+
+`password` 또는 현재 `code`로 확인한 후 TOTP 연결을 해제합니다.
+
 ## 헬스 체크 엔드포인트
 
-### `GET /health`
+### `GET /healthz`
 
-서비스의 헬스 체크 엔드포인트. 서비스 상태를 모니터링하는 데 사용됩니다.
+Redis, Warden, Herald를 조회하지 않는 프로세스 liveness 엔드포인트입니다. 컨테이너 헬스 체크와 Kubernetes liveness 프로브에 사용합니다.
 
-#### 응답
+### `GET /readyz`
 
-**성공 응답 (200 OK)**
-
-```
-HTTP/1.1 200 OK
-```
-
-#### 예제
+설정된 Redis, Warden, Herald 의존성의 집계 readiness 엔드포인트입니다. 로드 밸런서와 Kubernetes readiness 프로브에 사용합니다.
 
 ```bash
-curl http://auth.example.com/health
+curl http://auth.example.com/healthz
+curl http://auth.example.com/readyz
 ```
 
-**일반적인 사용 예:**
+`GET /health`는 `GET /readyz`의 더 이상 권장되지 않는 호환 별칭으로 유지됩니다.
 
-- Docker 헬스 체크
-- Kubernetes liveness 프로브
-- 로드 밸런서 헬스 체크
+## 메트릭 엔드포인트
+
+### `GET /metrics`
+
+Prometheus 메트릭을 텍스트 형식으로 반환합니다. 인증이 필요하지 않으므로 네트워크 또는 프록시 규칙으로 보호해야 합니다.
+
+## 런타임 로그 레벨 엔드포인트
+
+### `GET /log/level`
+
+현재 로그 레벨을 반환합니다. `PUT /log/level` 또는 `POST /log/level`에 JSON 본문 `{"level":"debug"}`나 쿼리 매개변수 `?level=debug`를 전달해 변경합니다. Stargate는 이 엔드포인트를 `127.0.0.1`로 제한하므로 공개 리버스 프록시를 통해 노출하면 안 됩니다.
 
 ## 루트 엔드포인트
 

--- a/docs/koKR/ARCHITECTURE.md
+++ b/docs/koKR/ARCHITECTURE.md
@@ -78,7 +78,7 @@ src/
 - **TOTPRevokeRoute / TOTPRevokeConfirmAPI**: TOTP 해제·확인(Herald TOTP 경유)
 - **LogoutRoute**: 로그아웃 처리
 - **SessionShareRoute**: 크로스 도메인 세션 공유
-- **HealthRoute**: 헬스 체크(Warden·Herald 상태 포함)
+- **헬스 라우트**: 프로세스 liveness는 `/healthz`, Redis·Warden·Herald의 집계 readiness는 `/readyz`
 - **IndexRoute**: 루트 경로 처리
 - **GET /metrics**: Prometheus 메트릭(metrics-kit)
 
@@ -344,7 +344,7 @@ Warden 및 Herald 통합이 활성화된 경우 OTP 인증을 사용할 수 있�
 - Zerolog(logger-kit 경유)로 구조화 로깅
 - 디버그 모드 지원 (DEBUG=true)
 - 모든 중요한 작업이 로깅됨
-- 헬스 체크(`GET /health`) 및 Prometheus 메트릭(`GET /metrics`)으로 모니터링 가능
+- 프로세스 liveness(`GET /healthz`), 의존성 readiness(`GET /readyz`), Prometheus 메트릭(`GET /metrics`)으로 모니터링 가능
 
 ## 테스트
 

--- a/docs/koKR/CONFIG.md
+++ b/docs/koKR/CONFIG.md
@@ -26,7 +26,7 @@ export PASSWORDS=plaintext:yourpassword
 **Docker:**
 
 ```bash
-docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword stargate:latest
+docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 **Docker Compose:**
@@ -369,7 +369,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       # 필수 설정
       - AUTH_HOST=auth.example.com

--- a/docs/koKR/DEPLOYMENT.md
+++ b/docs/koKR/DEPLOYMENT.md
@@ -104,7 +104,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=plaintext:yourpassword \
   stargate:latest
@@ -115,7 +115,7 @@ docker run -d \
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
   -e DEBUG=false \
@@ -131,7 +131,7 @@ docker run -d \
 
 - `-d`: 백그라운드에서 실행
 - `--name stargate`: 컨테이너 이름
-- `-p 80:80`: 포트 매핑 (호스트 포트:컨테이너 포트)
+- `-p 8080:8080`: 포트 매핑 (호스트 포트:컨테이너 포트)
 - `-e`: 환경 변수
 - `--restart unless-stopped`: 자동 재시작 정책
 
@@ -167,7 +167,7 @@ docker rm -f stargate
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
@@ -178,7 +178,7 @@ services:
       - traefik.docker.network=proxy
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
-      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth
+      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   whoami:
     image: traefik/whoami
@@ -225,7 +225,7 @@ docker-compose logs -f stargate
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -247,7 +247,7 @@ Stargate는 Traefik과 통합하도록 설계되어 있으며, Forward Auth 미�
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -258,7 +258,7 @@ services:
       - "traefik.docker.network=traefik"
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
-      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
 ```
 
@@ -427,12 +427,12 @@ services:
 
 #### 2. 헬스 체크 엔드포인트
 
-모니터링에 `/health` 엔드포인트 사용:
+프로세스 liveness에는 `/healthz`, 의존성 readiness에는 `/readyz`를 사용합니다. `/health`는 더 이상 권장되지 않는 readiness 호환 별칭입니다.
 
 ```bash
 # 헬스 체크 스크립트
 #!/bin/bash
-if curl -f http://localhost/health > /dev/null 2>&1; then
+if curl -f http://localhost/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -571,7 +571,7 @@ COOKIE_DOMAIN=.example.com
 
 ```yaml
 # 미들웨어의 주소가 올바른지 확인
-- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
 ```
 
 ### 디버깅 팁
@@ -632,7 +632,7 @@ docker stop stargate
 3. **새 이미지 다운로드:**
 
 ```bash
-docker pull stargate:latest
+docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 4. **새 컨테이너 시작:**
@@ -641,7 +641,7 @@ docker pull stargate:latest
 docker run -d \
   --name stargate \
   ...(저장된 설정 사용)
-  stargate:latest
+  ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 5. **서비스 확인:**

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -333,6 +333,16 @@ Logged out
 curl -X POST -b cookies.txt http://auth.example.com/_logout
 ```
 
+## Step-up 二次认证端点
+
+### `GET /_step_up`
+
+为已认证会话展示密码复核表单。可选的 `callback` 查询参数必须是本地路径；不安全的值会回退到 `/`。
+
+### `POST /_step_up`
+
+复核密码，并在会话中记录 10 分钟有效的 Step-up 认证状态。表单字段为 `password` 和可选的本地路径 `callback`。该路由受同源校验和限流保护。
+
 ## 会话交换端点
 
 ### `GET /_session_exchange`
@@ -449,6 +459,12 @@ Prometheus 指标，文本展示格式。用于监控认证请求、会话创建
 
 - Prometheus 抓取目标
 - Grafana 仪表盘
+
+## 运行时日志级别端点
+
+### `GET /log/level`
+
+返回当前日志级别。使用 `PUT /log/level` 或 `POST /log/level`，通过 JSON 请求体 `{"level":"debug"}` 或查询参数 `?level=debug` 修改日志级别。Stargate 将该端点限制为仅 `127.0.0.1` 可访问，不得通过公网反向代理暴露。
 
 ## 根端点
 

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -27,7 +27,7 @@ export PASSWORDS=plaintext:yourpassword
 **Docker：**
 
 ```bash
-docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword stargate:latest
+docker run -e AUTH_HOST=auth.example.com -e PASSWORDS=plaintext:yourpassword ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 **Docker Compose：**
@@ -48,6 +48,7 @@ services:
 |----------|-------------|--------|------|
 | `AUTH_HOST` | String | — | 是 |
 | `PASSWORDS` | 见密码配置 | — | 未启用 Warden 时为是 |
+| `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | 否 |
 | `DEBUG` | true/false | false | 否 |
 | `LOGIN_PAGE_TITLE` | String | Stargate - Login | 否 |
 | `LOGIN_PAGE_FOOTER_TEXT` | String | Copyright © 2024 - Stargate | 否 |
@@ -69,6 +70,9 @@ services:
 | `WARDEN_TLS_CLIENT_CERT_FILE` | 路径 | 空 | 否 |
 | `WARDEN_TLS_CLIENT_KEY_FILE` | 路径 | 空 | 否 |
 | `WARDEN_TLS_SERVER_NAME` | String | 空 | 否 |
+| `HEADER_AUTH_ENABLED` | true/false | false | 否 |
+| `HEADER_AUTH_SHARED_SECRET` | 密钥字符串 | 空 | 启用请求头认证时为是 |
+| `HEADER_AUTH_SECRET_HEADER` | HTTP 头名称 | X-Stargate-Header-Auth | 否 |
 | `WARDEN_CACHE_TTL` | String | 300 | 否 |
 | `WARDEN_OTP_ENABLED` | true/false | false | 否 |
 | `WARDEN_OTP_SECRET_KEY` | String | 空 | 否 |
@@ -1045,7 +1049,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       # 必需配置
       - AUTH_HOST=auth.example.com
@@ -1064,7 +1068,7 @@ services:
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       # 必需配置
       - AUTH_HOST=auth.example.com
@@ -1225,3 +1229,20 @@ PASSWORDS=bcrypt:<哈希>
 ```
 
 该请求头属于凭据：必须使用 HTTPS、配置限流，并让反向代理在转发到后端前删除 `Stargate-Password`。浏览器认证仍推荐使用 Cookie 会话。
+
+## 可信身份请求头认证
+
+可信身份请求头认证默认关闭。该模式依赖 Warden，只应由已完成调用方认证的反向代理使用。
+
+```bash
+WARDEN_ENABLED=true
+WARDEN_URL=http://warden:8080
+HEADER_AUTH_ENABLED=true
+HEADER_AUTH_SHARED_SECRET=<随机共享密钥>
+# 可选；以下为默认请求头名称：
+HEADER_AUTH_SECRET_HEADER=X-Stargate-Header-Auth
+```
+
+代理需要同时发送 `X-User-Phone` 或 `X-User-Mail` 以及配置的密钥请求头。Stargate 在转发前会删除密钥请求头；密钥不匹配时会丢弃身份请求头。
+
+这三个请求头都属于信任边界输入：必须使用 HTTPS 和高强度共享密钥，并让边缘代理先删除客户端传入的 `X-User-Phone`、`X-User-Mail` 以及由 `HEADER_AUTH_SECRET_HEADER` 指定名称的请求头，再写入代理自己的值。切勿把该模式直接暴露给不受信任的客户端。

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -104,7 +104,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=plaintext:yourpassword \
   stargate:latest
@@ -115,7 +115,7 @@ docker run -d \
 ```bash
 docker run -d \
   --name stargate \
-  -p 80:80 \
+  -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
   -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
   -e DEBUG=false \
@@ -131,7 +131,7 @@ docker run -d \
 
 - `-d`：后台运行
 - `--name stargate`：容器名称
-- `-p 80:80`：端口映射（主机端口:容器端口）
+- `-p 8080:8080`：端口映射（主机端口:容器端口）
 - `-e`：环境变量
 - `--restart unless-stopped`：自动重启策略
 
@@ -167,7 +167,7 @@ docker rm -f stargate
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
@@ -181,7 +181,7 @@ services:
       - traefik.docker.network=proxy
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
-      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth
+      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   whoami:
     image: traefik/whoami
@@ -207,7 +207,7 @@ networks:
 services:
   # Stargate 认证服务
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - WARDEN_ENABLED=true
@@ -231,7 +231,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.auth.entrypoints=http,https
       - traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)
-      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth
+      - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
 
   # Warden 用户白名单服务
   warden:
@@ -336,7 +336,7 @@ docker-compose logs -f stargate
 ```yaml
 services:
   stargate:
-    image: stargate
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -358,7 +358,7 @@ Stargate 设计用于与 Traefik 集成，通过 Forward Auth 中间件提供认
 ```yaml
 services:
   stargate:
-    image: stargate:latest
+    image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$2a$10$...
@@ -369,7 +369,7 @@ services:
       - "traefik.docker.network=traefik"
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
-      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+      - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
 ```
 
@@ -682,7 +682,7 @@ COOKIE_DOMAIN=.example.com
 
 ```yaml
 # 确保中间件地址正确
-- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
 ```
 
 #### 5. Warden 服务问题
@@ -818,7 +818,7 @@ docker stop stargate
 3. **拉取新镜像**：
 
 ```bash
-docker pull stargate:latest
+docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 4. **启动新容器**：
@@ -827,7 +827,7 @@ docker pull stargate:latest
 docker run -d \
   --name stargate \
   ...（使用备份的配置）
-  stargate:latest
+  ghcr.io/soulteary/stargate:v1.0.0
 ```
 
 5. **验证服务**：


### PR DESCRIPTION
## Summary

- align all root README files with Go 1.27 and the real clone URL
- pin published deployment examples to `ghcr.io/soulteary/stargate:v1.0.0`
- update container mappings and Traefik targets to the official `8080` port
- document password-header and trusted identity-header configuration in English and Chinese
- bring all seven API references in line with the implemented TOTP, step-up, liveness, readiness, metrics, and runtime log-level routes
- distinguish `/healthz` liveness from `/readyz` dependency readiness in localized architecture and deployment docs

## Validation

- `git diff --check`
- verified every localized API document contains all implemented public/operational routes
- verified all localized deployment documents contain no stale `80:80`, portless ForwardAuth target, unqualified image, or `stargate:latest` pull command
- verified the English and Chinese configuration quick-reference tables cover every environment variable declared by the config package