### PR TITLE
fix(config): reject removed Warden OTP settings

### DIFF
--- a/src/internal/auth/auth.go
+++ b/src/internal/auth/auth.go
@@ -464,9 +464,3 @@ func VerifyOTP(secret, code string) bool {
 	log.Debug().Msg("OTP code verified successfully")
 	return true
 }
-
-// GetOTPSecret returns the OTP secret key from configuration.
-// This can be extended to fetch from remote API if needed.
-func GetOTPSecret() string {
-	return config.WardenOTPSecretKey.String()
-}

--- a/src/internal/auth/auth_test.go
+++ b/src/internal/auth/auth_test.go
@@ -1450,16 +1450,6 @@ func TestSafeContext_Invalid(t *testing.T) {
 	})
 }
 
-func TestGetOTPSecret_LegacyConfigIsIgnored(t *testing.T) {
-	t.Setenv("AUTH_HOST", "auth.example.com")
-	t.Setenv("PASSWORDS", "plaintext:test123")
-	t.Setenv("WARDEN_OTP_SECRET_KEY", "secret-key")
-	err := config.Initialize(testLogger())
-	testza.AssertNoError(t, err)
-
-	testza.AssertEqual(t, "", GetOTPSecret())
-}
-
 func TestVerifyOTP_Valid(t *testing.T) {
 	secret := "JBSWY3DPEHPK3PXP"
 	code, err := totp.GenerateCode(secret, time.Now().UTC())

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -214,25 +216,6 @@ var (
 		DefaultValue:   "300",
 		PossibleValues: []string{"*"},
 		Validator:      ValidateAny,
-	}
-
-	// WardenVerifyCodeURL has been removed - verification codes are now handled by Herald service
-
-	WardenOTPEnabled = EnvVariable{
-		Name:           "WARDEN_OTP_ENABLED",
-		Required:       false,
-		DefaultValue:   "false",
-		PossibleValues: []string{"true", "false"},
-		Validator:      ValidateCaseInsensitivePossibleValues,
-	}
-
-	WardenOTPSecretKey = EnvVariable{
-		Name:           "WARDEN_OTP_SECRET_KEY",
-		Required:       false,
-		DefaultValue:   "",
-		PossibleValues: []string{"*"},
-		Validator:      ValidateAny,
-		Sensitive:      true,
 	}
 
 	HeraldURL = EnvVariable{
@@ -466,6 +449,12 @@ func Initialize(l *logger.Logger) error {
 		i18n.SetLanguage(i18n.LangKO)
 	default:
 		i18n.SetLanguage(i18n.LangEN)
+	}
+
+	for _, name := range []string{"WARDEN_OTP_ENABLED", "WARDEN_OTP_SECRET_KEY"} {
+		if _, configured := os.LookupEnv(name); configured {
+			return fmt.Errorf("%s has been removed; use Herald-backed TOTP with HERALD_TOTP_ENABLED", name)
+		}
 	}
 
 	// Then validate all other configuration variables

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -18,6 +18,21 @@ func testLogger() *logger.Logger {
 	})
 }
 
+func TestInitializeRejectsRemovedWardenOTPSettings(t *testing.T) {
+	for _, name := range []string{"WARDEN_OTP_ENABLED", "WARDEN_OTP_SECRET_KEY"} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("AUTH_HOST", "auth.example.com")
+			t.Setenv("PASSWORDS", "plaintext:test123")
+			t.Setenv(name, "legacy-value")
+
+			err := Initialize(testLogger())
+			testza.AssertNotNil(t, err)
+			testza.AssertContains(t, err.Error(), name)
+			testza.AssertContains(t, err.Error(), "has been removed")
+		})
+	}
+}
+
 func TestEnvVariable_String(t *testing.T) {
 	v := EnvVariable{
 		Value: "test-value",


### PR DESCRIPTION
## Summary

- remove the unused `WARDEN_OTP_ENABLED` and `WARDEN_OTP_SECRET_KEY` configuration declarations
- remove the legacy global OTP secret accessor
- fail startup with a migration message when either removed environment variable is still configured
- add regression tests for both removed settings

## Why

The v1 migration guide states that the legacy Warden global OTP fallback has been removed, but the old settings remained declared and were silently ignored. Failing explicitly prevents an apparently valid configuration from starting with different authentication behavior.

## Testing

- `git diff --check`
- Go tests are delegated to the repository PR workflow because the local review environment does not include the Go toolchain.