### PR TITLE
docs: correct remaining v1 contracts and examples

### DIFF
--- a/README.deDE.md
+++ b/README.deDE.md
@@ -161,16 +161,16 @@ Stargate verwendet Umgebungsvariablen für die Konfiguration. Hier sind die häu
 ```bash
 # Einfache Passwort-Authentifizierung
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # BCrypt-Hash verwenden
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Cross-Domain-Sitzungsteilung
 COOKIE_DOMAIN=.example.com
 
 # Login-Seite anpassen
-LOGIN_PAGE_TITLE=Mein Auth-Service
+LOGIN_PAGE_TITLE='Mein Auth-Service'
 LANGUAGE=de  # oder 'en'
 ```
 

--- a/README.frFR.md
+++ b/README.frFR.md
@@ -161,16 +161,16 @@ Stargate utilise des variables d'environnement pour la configuration. Voici les 
 ```bash
 # Authentification par mot de passe simple
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # Utilisation du hash BCrypt
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Partage de session cross-domain
 COOKIE_DOMAIN=.example.com
 
 # Personnaliser la page de connexion
-LOGIN_PAGE_TITLE=Mon Service d'Authentification
+LOGIN_PAGE_TITLE="Mon Service d'Authentification"
 LANGUAGE=fr  # ou 'en'
 ```
 

--- a/README.itIT.md
+++ b/README.itIT.md
@@ -161,16 +161,16 @@ Stargate utilizza variabili d'ambiente per la configurazione. Ecco le impostazio
 ```bash
 # Autenticazione password semplice
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # Utilizzo hash BCrypt
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Condivisione sessioni cross-domain
 COOKIE_DOMAIN=.example.com
 
 # Personalizza pagina di login
-LOGIN_PAGE_TITLE=Il Mio Servizio di Autenticazione
+LOGIN_PAGE_TITLE='Il Mio Servizio di Autenticazione'
 LANGUAGE=it  # o 'en'
 ```
 

--- a/README.jaJP.md
+++ b/README.jaJP.md
@@ -161,16 +161,16 @@ Stargate は環境変数を使用して設定します。以下は最も一般�
 ```bash
 # シンプルなパスワード認証
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # BCrypt ハッシュを使用
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # クロスドメインセッション共有
 COOKIE_DOMAIN=.example.com
 
 # ログインページをカスタマイズ
-LOGIN_PAGE_TITLE=私の認証サービス
+LOGIN_PAGE_TITLE='私の認証サービス'
 LANGUAGE=ja  # または 'en'
 ```
 

--- a/README.koKR.md
+++ b/README.koKR.md
@@ -161,16 +161,16 @@ Stargate는 환경 변수를 사용하여 구성을 수행합니다. 다음은 �
 ```bash
 # 간단한 비밀번호 인증
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # BCrypt 해시 사용
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # 크로스 도메인 세션 공유
 COOKIE_DOMAIN=.example.com
 
 # 로그인 페이지 사용자 정의
-LOGIN_PAGE_TITLE=내 인증 서비스
+LOGIN_PAGE_TITLE='내 인증 서비스'
 LANGUAGE=ko  # 또는 'en'
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Stargate is perfect for:
 - **Internal Tools & Dashboards**: Quickly add authentication to internal services and admin panels
 - **API Gateway Integration**: Use with Traefik, Nginx, or other reverse proxies as a unified auth layer
 - **Development & Testing**: Simple password-based auth for development environments
-- **Enterprise Authentication**: Integration with Warden (user whitelist) and Herald (OTP/verification codes) for production-grade authentication
+- **Integrated Authentication**: Integration with Warden (user whitelist) and Herald (OTP/verification codes)
 
 ## ✨ Features
 
-### 🔐 Enterprise-Grade Security
+### 🔐 Security Controls
 - **Explicit Password Verification Modes**: Use bcrypt in production or plaintext only for local testing
 - **Secure Session Management**: Cookie-based sessions with customizable domain and expiration
 - **Flexible Authentication**: Support for both password-based and session-based authentication
@@ -55,7 +55,7 @@ Stargate is perfect for:
 ### 🚀 Performance & Reliability
 - **Lightweight & Fast**: Built on Go and Fiber framework for exceptional performance
 - **Minimal Resource Usage**: Low memory footprint, perfect for containerized environments
-- **Production Ready**: Battle-tested architecture designed for reliability
+- **Deployment Focused**: Health probes, metrics, structured logs, and hardened container defaults
 
 ### 📦 Developer Experience
 - **Docker First**: Complete Docker image and docker-compose configuration out of the box
@@ -157,16 +157,16 @@ Stargate uses environment variables for configuration. Here are the most common 
 ```bash
 # Simple password authentication
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # Using BCrypt hash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Cross-domain session sharing
 COOKIE_DOMAIN=.example.com
 
 # Customize login page
-LOGIN_PAGE_TITLE=My Auth Service
+LOGIN_PAGE_TITLE='My Auth Service'
 LANGUAGE=zh  # or 'en'
 ```
 

--- a/README.zhCN.md
+++ b/README.zhCN.md
@@ -157,16 +157,16 @@ Stargate 使用环境变量进行配置。以下是最常用的配置项：
 ```bash
 # 简单密码认证
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # 使用 BCrypt 哈希
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # 跨域会话共享
 COOKIE_DOMAIN=.example.com
 
 # 自定义登录页面
-LOGIN_PAGE_TITLE=我的认证服务
+LOGIN_PAGE_TITLE='我的认证服务'
 LANGUAGE=zh  # 或 'en'
 ```
 

--- a/docs/deDE/ARCHITECTURE.md
+++ b/docs/deDE/ARCHITECTURE.md
@@ -5,7 +5,7 @@ Dieses Dokument beschreibt die technische Architektur und Designentscheidungen d
 ## Technologie-Stack
 
 - **Sprache**: Go 1.27
-- **Web-Framework**: [Fiber v2.52.x](https://github.com/gofiber/fiber)
+- **Web-Framework**: [Fiber v3.5.0](https://github.com/gofiber/fiber)
 - **Template-Engine**: [Fiber Template v1.7.5](https://github.com/gofiber/template)
 - **Sitzungsverwaltung**: session-kit (Fiber-kompatibler Store; unterstützt Speicher und Redis)
 - **Protokollierung**: [Zerolog](https://github.com/rs/zerolog) über logger-kit
@@ -329,7 +329,7 @@ Template-Datei `internal/web/templates/login.html` ändern.
 ### Docker-Bereitstellung
 
 - Multi-Stage-Build zur Reduzierung der Image-Größe
-- Build-Stufe: `golang:1.27.0-alpine3.24`; Ausführungsstufe: `alpine:3.24` (mit curl für Health-Checks)
+- Build-Stufe: `golang:1.27.0-alpine3.24`; Ausführungsstufe: `alpine:3.24` (Health-Checks verwenden BusyBox wget)
 - Template-Dateien von `src/internal/web/templates` nach `/app/web/templates` im Image kopiert
 - Verwendet `-ldflags "-s -w"` beim Kompilieren, um die Binärgröße zu reduzieren
 - Die Anwendung findet automatisch Template-Pfade (unterstützt `./internal/web/templates` für lokale Entwicklung und `./web/templates` für Produktion)

--- a/docs/deDE/CONFIG.md
+++ b/docs/deDE/CONFIG.md
@@ -20,7 +20,7 @@ Stargate wird über Umgebungsvariablen konfiguriert. Alle Konfigurationselemente
 
 ```bash
 export AUTH_HOST=auth.example.com
-export PASSWORDS=plaintext:yourpassword
+export PASSWORDS='plaintext:yourpassword'
 ```
 
 **Docker:**
@@ -88,13 +88,13 @@ Passwort-Konfiguration, die den Verschlüsselungsalgorithmus und die Liste der P
 
 ```bash
 # Einzelnes Klartext-Passwort
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # Mehrere Klartext-Passwörter
-PASSWORDS=plaintext:test123|admin456|user789
+PASSWORDS='plaintext:test123|admin456|user789'
 
 # BCrypt-Hash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 ```
 
@@ -165,7 +165,7 @@ Titel der Anmeldeseite.
 **Beispiel:**
 
 ```bash
-LOGIN_PAGE_TITLE=Mein Authentifizierungsdienst
+LOGIN_PAGE_TITLE='Mein Authentifizierungsdienst'
 ```
 
 ### `LOGIN_PAGE_FOOTER_TEXT`
@@ -186,7 +186,7 @@ Fußzeilentext der Anmeldeseite.
 **Beispiel:**
 
 ```bash
-LOGIN_PAGE_FOOTER_TEXT=© 2024 Meine Firma
+LOGIN_PAGE_FOOTER_TEXT='© 2024 Meine Firma'
 ```
 
 ### `USER_HEADER_NAME`
@@ -281,6 +281,8 @@ Die folgende Tabelle ist mit den tatsächlich in `internal/config` registrierten
 | `COOKIE_SECURE` | true/false | true | Secure-Attribut der Sitzungs-Cookies |
 | `CALLBACK_ALLOWED_HOSTS` | Host-Liste | leer | Explizite Ziele für Rückleitungen |
 | `SESSION_EXCHANGE_SECRET` | Geheimnis, mind. 32 Zeichen | leer | Signiert kurzlebige domänenübergreifende Tickets |
+| `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | Aktiviert den vertrauenswürdigen Legacy-Passwort-Header |
+| `LOG_LEVEL` | debug/info/warn/error | info | Start-Protokollstufe |
 | `HEADER_AUTH_ENABLED` | true/false | false | Vertrauenswürdige Header-Authentifizierung |
 | `HEADER_AUTH_SHARED_SECRET` | Geheimnis | leer | Gemeinsames Geheimnis für Header-Authentifizierung |
 | `HEADER_AUTH_SECRET_HEADER` | Headername | `X-Stargate-Header-Auth` | Transportiert das gemeinsame Geheimnis |
@@ -294,8 +296,6 @@ Die folgende Tabelle ist mit den tatsächlich in `internal/config` registrierten
 | `WARDEN_TLS_CLIENT_KEY_FILE` | Pfad | leer | mTLS-Clientschlüssel |
 | `WARDEN_TLS_SERVER_NAME` | String | leer | Erwarteter TLS-Servername |
 | `WARDEN_CACHE_TTL` | Sekunden | 300 | Warden-Cache-Laufzeit |
-| `WARDEN_OTP_ENABLED` | true/false | false | Legacy-OTP-Integration |
-| `WARDEN_OTP_SECRET_KEY` | Geheimnis | leer | Legacy-OTP-Geheimnis |
 | `HERALD_ENABLED` | true/false | false | Herald-Integration |
 | `HERALD_URL` | URL | leer | Herald-Endpunkt |
 | `HERALD_API_KEY` | Geheimnis | leer | API-Key-Authentifizierung |
@@ -329,9 +329,9 @@ HMAC Key ID und Secret müssen gemeinsam gesetzt werden. mTLS-Clientzertifikat u
 Stargate akzeptiert `bcrypt` für Produktionsumgebungen und `plaintext` ausschließlich für lokale Tests. MD5 und ungesalzenes SHA-512 werden bei der Konfigurationsprüfung abgelehnt. Passwortwerte sind groß-/kleinschreibungssensitiv; Leerzeichen bleiben erhalten.
 
 ```bash
-PASSWORDS=bcrypt:<bcrypt-hash>
+PASSWORDS='bcrypt:<bcrypt-hash>'
 # Nur lokal:
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 ```
 
 ## Konfigurationsbeispiele
@@ -341,7 +341,7 @@ PASSWORDS=plaintext:test123
 ```bash
 # Erforderliche Konfiguration
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # Optionale Konfiguration
 DEBUG=false
@@ -353,13 +353,13 @@ LANGUAGE=en
 ```bash
 # Erforderliche Konfiguration
 AUTH_HOST=auth.example.com
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Optionale Konfiguration
 DEBUG=false
 LANGUAGE=de
-LOGIN_PAGE_TITLE=Mein Authentifizierungsdienst
-LOGIN_PAGE_FOOTER_TEXT=© 2024 Meine Firma
+LOGIN_PAGE_TITLE='Mein Authentifizierungsdienst'
+LOGIN_PAGE_FOOTER_TEXT='© 2024 Meine Firma'
 USER_HEADER_NAME=X-Forwarded-User
 COOKIE_DOMAIN=.example.com
 ```
@@ -373,7 +373,7 @@ services:
     environment:
       # Erforderliche Konfiguration
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+      - PASSWORDS=bcrypt:$$2a$$10$$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
       
       # Optionale Konfiguration
       - DEBUG=false
@@ -388,7 +388,7 @@ services:
 ```bash
 # Erforderliche Konfiguration
 AUTH_HOST=localhost
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # Optionale Konfiguration
 DEBUG=true

--- a/docs/deDE/DEPLOYMENT.md
+++ b/docs/deDE/DEPLOYMENT.md
@@ -106,7 +106,7 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=plaintext:yourpassword \
+  -e 'PASSWORDS=plaintext:yourpassword' \
   stargate:latest
 ```
 
@@ -117,11 +117,11 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
+  -e 'PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy' \
   -e DEBUG=false \
   -e LANGUAGE=de \
-  -e LOGIN_PAGE_TITLE=Mein Authentifizierungsdienst \
-  -e LOGIN_PAGE_FOOTER_TEXT=© 2024 Meine Firma \
+  -e 'LOGIN_PAGE_TITLE=Mein Authentifizierungsdienst' \
+  -e 'LOGIN_PAGE_FOOTER_TEXT=© 2024 Meine Firma' \
   -e COOKIE_DOMAIN=.example.com \
   --restart unless-stopped \
   stargate:latest
@@ -228,7 +228,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
       - DEBUG=false
       - LANGUAGE=de
       - COOKIE_DOMAIN=.example.com
@@ -250,7 +250,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
     networks:
       - traefik
     labels:
@@ -335,13 +335,13 @@ services:
 **Nicht empfohlen:**
 
 ```bash
-PASSWORDS=plaintext:yourpassword
+PASSWORDS='plaintext:yourpassword'
 ```
 
 **Empfohlen:**
 
 ```bash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 ```
 
 #### 2. HTTPS aktivieren

--- a/docs/enUS/ARCHITECTURE.md
+++ b/docs/enUS/ARCHITECTURE.md
@@ -5,7 +5,7 @@ This document describes the technical architecture and design decisions of the S
 ## Technology Stack
 
 - **Language**: Go 1.27
-- **Web Framework**: [Fiber v2.52.x](https://github.com/gofiber/fiber)
+- **Web Framework**: [Fiber v3.5.0](https://github.com/gofiber/fiber)
 - **Template Engine**: [Fiber Template v1.7.5](https://github.com/gofiber/template)
 - **Session Management**: session-kit (Fiber-compatible store; supports in-memory and Redis)
 - **Logging**: [Zerolog](https://github.com/rs/zerolog) via logger-kit
@@ -374,7 +374,7 @@ Modify the `internal/web/templates/login.html` template file.
 ### Docker Deployment
 
 - Multi-stage build to reduce image size
-- Build stage: `golang:1.27.0-alpine3.24`; runtime stage: `alpine:3.24` (includes curl for health checks)
+- Build stage: `golang:1.27.0-alpine3.24`; runtime stage: `alpine:3.24` (health checks use BusyBox wget)
 - Template files copied from `src/internal/web/templates` to `/app/web/templates` in image
 - Uses `-ldflags "-s -w"` during compilation to reduce binary size
 - Application automatically finds template paths (supports `./internal/web/templates` for local development and `./web/templates` for production)

--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -21,7 +21,7 @@ Stargate is configured via environment variables. All configuration items are se
 
 ```bash
 export AUTH_HOST=auth.example.com
-export PASSWORDS=plaintext:yourpassword
+export PASSWORDS='plaintext:yourpassword'
 ```
 
 **Docker:**
@@ -50,6 +50,7 @@ Below are all environment variables used in code. "Required" means the service w
 | `PASSWORDS` | See password config | — | Yes when Warden disabled |
 | `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | No |
 | `DEBUG` | true/false | false | No |
+| `LOG_LEVEL` | debug/info/warn/error | info | No |
 | `LOGIN_PAGE_TITLE` | String | Stargate - Login | No |
 | `LOGIN_PAGE_FOOTER_TEXT` | String | Copyright © 2024 - Stargate | No |
 | `USER_HEADER_NAME` | String | X-Forwarded-User | No |
@@ -74,8 +75,6 @@ Below are all environment variables used in code. "Required" means the service w
 | `HEADER_AUTH_SHARED_SECRET` | Secret string | empty | Yes when header auth enabled |
 | `HEADER_AUTH_SECRET_HEADER` | HTTP header name | X-Stargate-Header-Auth | No |
 | `WARDEN_CACHE_TTL` | String | 300 | No |
-| `WARDEN_OTP_ENABLED` | true/false | false | No |
-| `WARDEN_OTP_SECRET_KEY` | String | empty | No |
 | `HERALD_ENABLED` | true/false | false | No |
 | `HERALD_URL` | String | empty | No |
 | `HERALD_API_KEY` | String | empty | No |
@@ -151,13 +150,13 @@ Password configuration, specifying the password encryption algorithm and passwor
 
 ```bash
 # Single plain text password
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # Multiple plain text passwords
-PASSWORDS=plaintext:test123|admin456|user789
+PASSWORDS='plaintext:test123|admin456|user789'
 
 # BCrypt hash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 ```
 
@@ -228,7 +227,7 @@ Login page title.
 **Example:**
 
 ```bash
-LOGIN_PAGE_TITLE=My Auth Service
+LOGIN_PAGE_TITLE='My Auth Service'
 ```
 
 ### `LOGIN_PAGE_FOOTER_TEXT`
@@ -249,7 +248,7 @@ Login page footer text.
 **Example:**
 
 ```bash
-LOGIN_PAGE_FOOTER_TEXT=© 2024 My Company
+LOGIN_PAGE_FOOTER_TEXT='© 2024 My Company'
 ```
 
 ### `USER_HEADER_NAME`
@@ -473,43 +472,7 @@ TTL (Time To Live) for Warden user information cache.
 WARDEN_CACHE_TTL=300
 ```
 
-#### `WARDEN_OTP_ENABLED`
-
-Enable Warden-built-in OTP verification (distinct from Herald OTP; legacy/built-in capability).
-
-| Attribute | Value |
-|-----------|-------|
-| **Type** | Boolean |
-| **Required** | No |
-| **Default** | `false` |
-| **Possible Values** | `true`, `false` |
-
-**Description:**
-
-- When `true`, uses Warden-side OTP verification (requires `WARDEN_OTP_SECRET_KEY`)
-- Independent from Herald verification code service (`HERALD_ENABLED`); use one or both as needed
-
-**Example:**
-
-```bash
-WARDEN_OTP_ENABLED=true
-```
-
-#### `WARDEN_OTP_SECRET_KEY`
-
-Secret key for Warden OTP verification (only when `WARDEN_OTP_ENABLED=true`).
-
-| Attribute | Value |
-|-----------|-------|
-| **Type** | String |
-| **Required** | No |
-| **Default** | Empty |
-
-**Example:**
-
-```bash
-WARDEN_OTP_SECRET_KEY=your-warden-otp-secret
-```
+The legacy Warden global OTP settings were removed. Use Herald-backed TOTP with `HERALD_TOTP_ENABLED`.
 
 ### Herald Integration (Optional)
 
@@ -877,7 +840,7 @@ Periodically refresh user/authorization info from Warden and update session duri
 |-----------|-------|
 | **Type** | Boolean |
 | **Required** | No |
-| **Default** | `false` |
+| **Default** | `true` |
 | **Possible Values** | `true`, `false` |
 
 #### `AUTH_REFRESH_INTERVAL`
@@ -909,7 +872,7 @@ Stargate supports plaintext (development only) and bcrypt password verification.
 **Example:**
 
 ```bash
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 ```
 
 #### `bcrypt` - BCrypt Hash
@@ -923,16 +886,14 @@ PASSWORDS=plaintext:test123|admin456
 **Generate BCrypt Hash:**
 
 ```bash
-# Using Go
-go run -c 'golang.org/x/crypto/bcrypt' <<< 'password'
-
-# Using online tools or other tools
+# `htpasswd` is provided by apache2-utils on Debian/Ubuntu and Alpine.
+htpasswd -bnBC 10 "" 'password' | tr -d ':\n'
 ```
 
 **Example:**
 
 ```bash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 ```
 
 MD5 and unsalted SHA-512 password hashes are rejected because they are fast, unsalted primitives and are not password hashing functions.
@@ -950,7 +911,7 @@ MD5 and unsalted SHA-512 password hashes are rejected because they are fast, uns
 ```bash
 # Required
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # Session storage in Redis (multi-instance or persistent sessions)
 SESSION_STORAGE_ENABLED=true
@@ -971,7 +932,7 @@ Use when you want password-only login but need sessions in Redis for multiple in
 ```bash
 # Required configuration
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # Optional configuration
 DEBUG=false
@@ -983,13 +944,13 @@ LANGUAGE=en
 ```bash
 # Required configuration
 AUTH_HOST=auth.example.com
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Optional configuration
 DEBUG=false
 LANGUAGE=zh
-LOGIN_PAGE_TITLE=My Auth Service
-LOGIN_PAGE_FOOTER_TEXT=© 2024 My Company
+LOGIN_PAGE_TITLE='My Auth Service'
+LOGIN_PAGE_FOOTER_TEXT='© 2024 My Company'
 USER_HEADER_NAME=X-Forwarded-User
 COOKIE_DOMAIN=.example.com
 ```
@@ -1014,8 +975,8 @@ HERALD_HMAC_SECRET=your-herald-hmac-secret
 # Optional configuration
 DEBUG=false
 LANGUAGE=zh
-LOGIN_PAGE_TITLE=My Auth Service
-LOGIN_PAGE_FOOTER_TEXT=© 2024 My Company
+LOGIN_PAGE_TITLE='My Auth Service'
+LOGIN_PAGE_FOOTER_TEXT='© 2024 My Company'
 USER_HEADER_NAME=X-Forwarded-User
 COOKIE_DOMAIN=.example.com
 ```
@@ -1039,7 +1000,7 @@ services:
     environment:
       # Required configuration
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+      - PASSWORDS=bcrypt:$$2a$$10$$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
       
       # Optional configuration
       - DEBUG=false
@@ -1098,7 +1059,7 @@ services:
 ```bash
 # Required configuration
 AUTH_HOST=localhost
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # Optional configuration
 DEBUG=true
@@ -1135,7 +1096,6 @@ Error: Configuration error: invalid value for environment variable 'PASSWORDS': 
 - **Warden Integration**:
   - When `WARDEN_ENABLED=true`, must set `WARDEN_URL`
   - `WARDEN_API_KEY` is recommended (for service authentication)
-  - If `WARDEN_OTP_ENABLED=true`, set `WARDEN_OTP_SECRET_KEY`
 
 - **Herald Integration (OTP SMS/email)**:
   - When `HERALD_ENABLED=true`, must set `HERALD_URL`
@@ -1211,7 +1171,7 @@ Error: Configuration error: invalid value for environment variable 'PASSWORDS': 
 
 ```bash
 PASSWORD_HEADER_AUTH_ENABLED=true
-PASSWORDS=bcrypt:<hash>
+PASSWORDS='bcrypt:<hash>'
 ```
 
 Treat the header as a credential: require HTTPS, apply rate limits, and configure the reverse proxy to remove `Stargate-Password` before forwarding the request to the backend. Cookie sessions remain the recommended browser authentication method.

--- a/docs/enUS/CONTRIBUTING.md
+++ b/docs/enUS/CONTRIBUTING.md
@@ -58,7 +58,7 @@ chmod +x start-local.sh
 
 # Or manually
 export AUTH_HOST=localhost
-export PASSWORDS=plaintext:test123
+export PASSWORDS='plaintext:test123'
 go run src/cmd/stargate/main.go
 ```
 
@@ -69,7 +69,7 @@ For testing Traefik integration:
 1. **Start Stargate**:
    ```bash
    export AUTH_HOST=auth.example.com
-   export PASSWORDS=plaintext:test123
+   export PASSWORDS='plaintext:test123'
    go run src/cmd/stargate/main.go
    ```
 

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -106,7 +106,7 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=plaintext:yourpassword \
+  -e 'PASSWORDS=plaintext:yourpassword' \
   stargate:latest
 ```
 
@@ -117,11 +117,11 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
+  -e 'PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy' \
   -e DEBUG=false \
   -e LANGUAGE=zh \
-  -e LOGIN_PAGE_TITLE=My Auth Service \
-  -e LOGIN_PAGE_FOOTER_TEXT=© 2024 My Company \
+  -e 'LOGIN_PAGE_TITLE=My Auth Service' \
+  -e 'LOGIN_PAGE_FOOTER_TEXT=© 2024 My Company' \
   -e COOKIE_DOMAIN=.example.com \
   --restart unless-stopped \
   stargate:latest
@@ -231,7 +231,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
       - DEBUG=false
       - LANGUAGE=zh
       - COOKIE_DOMAIN=.example.com
@@ -253,7 +253,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
     networks:
       - traefik
     labels:
@@ -338,13 +338,13 @@ services:
 **Not Recommended:**
 
 ```bash
-PASSWORDS=plaintext:yourpassword
+PASSWORDS='plaintext:yourpassword'
 ```
 
 **Recommended:**
 
 ```bash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 ```
 
 #### 2. Enable HTTPS

--- a/docs/enUS/MIGRATION_V1.md
+++ b/docs/enUS/MIGRATION_V1.md
@@ -81,7 +81,7 @@ Do not place arbitrary client networks in `TRUSTED_PROXIES`.
 - `COOKIE_SECURE` defaults to `true`; local HTTP testing must opt out explicitly.
 - Startup validation now rejects malformed URLs, ports, durations, Redis database values, undersized exchange secrets, incomplete TLS certificate/key pairs, and incomplete HMAC key ID/secret pairs.
 - `CALLBACK_ALLOWED_HOSTS` is required to permit explicit cross-domain callback destinations.
-- Warden and Herald HMAC/TLS settings must be complete when enabled. Herald HMAC authentication also requires `HERALD_HMAC_KEY_ID`.
+- Warden and Herald HMAC/TLS settings must be complete when enabled. `HERALD_HMAC_KEY_ID` may be omitted only when Herald has an effective default key ID; configure it explicitly for multi-key deployments without a suitable default.
 
 Run the v1.0.0 image with the production environment before cutover and resolve every startup validation error rather than bypassing it.
 

--- a/docs/enUS/SECURITY.md
+++ b/docs/enUS/SECURITY.md
@@ -31,7 +31,7 @@ This document explains Stargate's security features, security configuration, and
 **Configuration Example**:
 ```bash
 export AUTH_HOST=auth.example.com
-export PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+export PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 export COOKIE_DOMAIN=.example.com
 export TRUSTED_PROXIES=10.20.0.10
 ```
@@ -160,9 +160,9 @@ Stargate supports multiple session storage backends:
 
 **Redis Configuration**:
 ```bash
-export REDIS_ENABLED=true
-export REDIS_ADDR=redis:6379
-export REDIS_PASSWORD=your-redis-password
+export SESSION_STORAGE_ENABLED=true
+export SESSION_STORAGE_REDIS_ADDR=redis:6379
+export SESSION_STORAGE_REDIS_PASSWORD=your-redis-password
 ```
 
 ### Sensitive Information Management

--- a/docs/frFR/ARCHITECTURE.md
+++ b/docs/frFR/ARCHITECTURE.md
@@ -5,7 +5,7 @@ Ce document décrit l'architecture technique et les décisions de conception du 
 ## Pile Technologique
 
 - **Langage** : Go 1.27
-- **Framework Web** : [Fiber v2.52.x](https://github.com/gofiber/fiber)
+- **Framework Web** : [Fiber v3.5.0](https://github.com/gofiber/fiber)
 - **Moteur de Template** : [Fiber Template v1.7.5](https://github.com/gofiber/template)
 - **Gestion de Session** : session-kit (store compatible Fiber ; mémoire et Redis)
 - **Journalisation** : [Zerolog](https://github.com/rs/zerolog) via logger-kit
@@ -329,7 +329,7 @@ Modifier le fichier template `internal/web/templates/login.html`.
 ### Déploiement Docker
 
 - Build multi-étapes pour réduire la taille de l'image
-- Étape de build : `golang:1.27.0-alpine3.24` ; étape d'exécution : `alpine:3.24` (avec curl pour les health checks)
+- Étape de build : `golang:1.27.0-alpine3.24` ; étape d'exécution : `alpine:3.24` (les health checks utilisent BusyBox wget)
 - Fichiers template copiés de `src/internal/web/templates` vers `/app/web/templates` dans l'image
 - Utilise `-ldflags "-s -w"` lors de la compilation pour réduire la taille du binaire
 - L'application trouve automatiquement les chemins de template (supporte `./internal/web/templates` pour le développement local et `./web/templates` pour la production)

--- a/docs/frFR/CONFIG.md
+++ b/docs/frFR/CONFIG.md
@@ -20,7 +20,7 @@ Stargate est configuré via des variables d'environnement. Tous les éléments d
 
 ```bash
 export AUTH_HOST=auth.example.com
-export PASSWORDS=plaintext:yourpassword
+export PASSWORDS='plaintext:yourpassword'
 ```
 
 **Docker :**
@@ -88,13 +88,13 @@ Configuration du mot de passe, spécifiant l'algorithme de chiffrement du mot de
 
 ```bash
 # Mot de passe en texte brut unique
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # Plusieurs mots de passe en texte brut
-PASSWORDS=plaintext:test123|admin456|user789
+PASSWORDS='plaintext:test123|admin456|user789'
 
 # Hash BCrypt
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 ```
 
@@ -165,7 +165,7 @@ Titre de la page de connexion.
 **Exemple :**
 
 ```bash
-LOGIN_PAGE_TITLE=Mon Service d'Authentification
+LOGIN_PAGE_TITLE="Mon Service d'Authentification"
 ```
 
 ### `LOGIN_PAGE_FOOTER_TEXT`
@@ -186,7 +186,7 @@ Texte du pied de page de la page de connexion.
 **Exemple :**
 
 ```bash
-LOGIN_PAGE_FOOTER_TEXT=© 2024 Ma Société
+LOGIN_PAGE_FOOTER_TEXT='© 2024 Ma Société'
 ```
 
 ### `USER_HEADER_NAME`
@@ -281,6 +281,8 @@ Ce tableau est synchronisé avec les variables de sécurité réellement enregis
 | `COOKIE_SECURE` | true/false | true | Attribut Secure des cookies de session |
 | `CALLBACK_ALLOWED_HOSTS` | liste d'hôtes | vide | Destinations de redirection autorisées |
 | `SESSION_EXCHANGE_SECRET` | secret, 32 caractères min. | vide | Signe les tickets inter-domaines à courte durée |
+| `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | Active l'en-tête de mot de passe historique de confiance |
+| `LOG_LEVEL` | debug/info/warn/error | info | Niveau de journalisation initial |
 | `HEADER_AUTH_ENABLED` | true/false | false | Authentification par en-têtes de confiance |
 | `HEADER_AUTH_SHARED_SECRET` | secret | vide | Secret partagé de l'authentification par en-tête |
 | `HEADER_AUTH_SECRET_HEADER` | nom d'en-tête | `X-Stargate-Header-Auth` | Transporte le secret partagé |
@@ -294,8 +296,6 @@ Ce tableau est synchronisé avec les variables de sécurité réellement enregis
 | `WARDEN_TLS_CLIENT_KEY_FILE` | chemin | vide | Clé client mTLS |
 | `WARDEN_TLS_SERVER_NAME` | chaîne | vide | Nom de serveur TLS attendu |
 | `WARDEN_CACHE_TTL` | secondes | 300 | Durée du cache Warden |
-| `WARDEN_OTP_ENABLED` | true/false | false | Intégration OTP historique |
-| `WARDEN_OTP_SECRET_KEY` | secret | vide | Secret OTP historique |
 | `HERALD_ENABLED` | true/false | false | Intégration Herald |
 | `HERALD_URL` | URL | vide | Point de terminaison Herald |
 | `HERALD_API_KEY` | secret | vide | Authentification par clé API |
@@ -329,9 +329,9 @@ L'identifiant et le secret HMAC doivent être définis ensemble. Le certificat e
 Stargate accepte `bcrypt` en production et `plaintext` uniquement pour les tests locaux. MD5 et SHA-512 non salé sont refusés lors de la validation. Les mots de passe respectent la casse et conservent les espaces.
 
 ```bash
-PASSWORDS=bcrypt:<bcrypt-hash>
+PASSWORDS='bcrypt:<bcrypt-hash>'
 # Tests locaux uniquement :
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 ```
 
 ## Exemples de Configuration
@@ -341,7 +341,7 @@ PASSWORDS=plaintext:test123
 ```bash
 # Configuration requise
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # Configuration optionnelle
 DEBUG=false
@@ -353,13 +353,13 @@ LANGUAGE=en
 ```bash
 # Configuration requise
 AUTH_HOST=auth.example.com
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Configuration optionnelle
 DEBUG=false
 LANGUAGE=fr
-LOGIN_PAGE_TITLE=Mon Service d'Authentification
-LOGIN_PAGE_FOOTER_TEXT=© 2024 Ma Société
+LOGIN_PAGE_TITLE="Mon Service d'Authentification"
+LOGIN_PAGE_FOOTER_TEXT='© 2024 Ma Société'
 USER_HEADER_NAME=X-Forwarded-User
 COOKIE_DOMAIN=.example.com
 ```
@@ -373,7 +373,7 @@ services:
     environment:
       # Configuration requise
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+      - PASSWORDS=bcrypt:$$2a$$10$$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
       
       # Configuration optionnelle
       - DEBUG=false
@@ -388,7 +388,7 @@ services:
 ```bash
 # Configuration requise
 AUTH_HOST=localhost
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # Configuration optionnelle
 DEBUG=true

--- a/docs/frFR/DEPLOYMENT.md
+++ b/docs/frFR/DEPLOYMENT.md
@@ -106,7 +106,7 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=plaintext:yourpassword \
+  -e 'PASSWORDS=plaintext:yourpassword' \
   stargate:latest
 ```
 
@@ -117,11 +117,11 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
+  -e 'PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy' \
   -e DEBUG=false \
   -e LANGUAGE=fr \
-  -e LOGIN_PAGE_TITLE=Mon Service d'Authentification \
-  -e LOGIN_PAGE_FOOTER_TEXT=© 2024 Ma Société \
+  -e "LOGIN_PAGE_TITLE=Mon Service d'Authentification" \
+  -e 'LOGIN_PAGE_FOOTER_TEXT=© 2024 Ma Société' \
   -e COOKIE_DOMAIN=.example.com \
   --restart unless-stopped \
   stargate:latest
@@ -228,7 +228,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
       - DEBUG=false
       - LANGUAGE=fr
       - COOKIE_DOMAIN=.example.com
@@ -250,7 +250,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
     networks:
       - traefik
     labels:
@@ -335,13 +335,13 @@ services:
 **Non Recommandé :**
 
 ```bash
-PASSWORDS=plaintext:yourpassword
+PASSWORDS='plaintext:yourpassword'
 ```
 
 **Recommandé :**
 
 ```bash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 ```
 
 #### 2. Activer HTTPS

--- a/docs/itIT/ARCHITECTURE.md
+++ b/docs/itIT/ARCHITECTURE.md
@@ -5,7 +5,7 @@ Questo documento descrive l'architettura tecnica e le decisioni di progettazione
 ## Stack Tecnologico
 
 - **Linguaggio**: Go 1.27
-- **Framework Web**: [Fiber v2.52.x](https://github.com/gofiber/fiber)
+- **Framework Web**: [Fiber v3.5.0](https://github.com/gofiber/fiber)
 - **Motore Template**: [Fiber Template v1.7.5](https://github.com/gofiber/template)
 - **Gestione Sessioni**: session-kit (store compatibile Fiber; memoria e Redis)
 - **Registrazione**: [Zerolog](https://github.com/rs/zerolog) via logger-kit
@@ -328,7 +328,7 @@ Modificare il file template `internal/web/templates/login.html`.
 ### Deployment Docker
 
 - Build multi-stage per ridurre dimensione immagine
-- Stage di build: `golang:1.27.0-alpine3.24`; stage di esecuzione: `alpine:3.24` (con curl per health check)
+- Stage di build: `golang:1.27.0-alpine3.24`; stage di esecuzione: `alpine:3.24` (gli health check usano BusyBox wget)
 - File template copiati da `src/internal/web/templates` a `/app/web/templates` nell'immagine
 - Utilizza `-ldflags "-s -w"` durante compilazione per ridurre dimensione binario
 - L'applicazione trova automaticamente i percorsi template (supporta `./internal/web/templates` per sviluppo locale e `./web/templates` per produzione)

--- a/docs/itIT/CONFIG.md
+++ b/docs/itIT/CONFIG.md
@@ -20,7 +20,7 @@ Stargate è configurato tramite variabili d'ambiente. Tutti gli elementi di conf
 
 ```bash
 export AUTH_HOST=auth.example.com
-export PASSWORDS=plaintext:yourpassword
+export PASSWORDS='plaintext:yourpassword'
 ```
 
 **Docker:**
@@ -88,13 +88,13 @@ Configurazione password, specificando l'algoritmo di crittografia password e la 
 
 ```bash
 # Password in testo normale unica
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # Più password in testo normale
-PASSWORDS=plaintext:test123|admin456|user789
+PASSWORDS='plaintext:test123|admin456|user789'
 
 # Hash BCrypt
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 ```
 
@@ -165,7 +165,7 @@ Titolo della pagina di login.
 **Esempio:**
 
 ```bash
-LOGIN_PAGE_TITLE=Il Mio Servizio di Autenticazione
+LOGIN_PAGE_TITLE='Il Mio Servizio di Autenticazione'
 ```
 
 ### `LOGIN_PAGE_FOOTER_TEXT`
@@ -186,7 +186,7 @@ Testo del piè di pagina della pagina di login.
 **Esempio:**
 
 ```bash
-LOGIN_PAGE_FOOTER_TEXT=© 2024 La Mia Azienda
+LOGIN_PAGE_FOOTER_TEXT='© 2024 La Mia Azienda'
 ```
 
 ### `USER_HEADER_NAME`
@@ -281,6 +281,8 @@ La tabella è sincronizzata con le variabili di sicurezza realmente registrate i
 | `COOKIE_SECURE` | true/false | true | Attributo Secure dei cookie di sessione |
 | `CALLBACK_ALLOWED_HOSTS` | elenco host | vuoto | Destinazioni di redirect consentite |
 | `SESSION_EXCHANGE_SECRET` | segreto, minimo 32 caratteri | vuoto | Firma ticket cross-domain di breve durata |
+| `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | Abilita l'header password legacy attendibile |
+| `LOG_LEVEL` | debug/info/warn/error | info | Livello di log iniziale |
 | `HEADER_AUTH_ENABLED` | true/false | false | Autenticazione tramite header attendibili |
 | `HEADER_AUTH_SHARED_SECRET` | segreto | vuoto | Segreto condiviso per header auth |
 | `HEADER_AUTH_SECRET_HEADER` | nome header | `X-Stargate-Header-Auth` | Trasporta il segreto condiviso |
@@ -294,8 +296,6 @@ La tabella è sincronizzata con le variabili di sicurezza realmente registrate i
 | `WARDEN_TLS_CLIENT_KEY_FILE` | percorso | vuoto | Chiave client mTLS |
 | `WARDEN_TLS_SERVER_NAME` | stringa | vuoto | Nome server TLS atteso |
 | `WARDEN_CACHE_TTL` | secondi | 300 | Durata cache Warden |
-| `WARDEN_OTP_ENABLED` | true/false | false | Integrazione OTP legacy |
-| `WARDEN_OTP_SECRET_KEY` | segreto | vuoto | Segreto OTP legacy |
 | `HERALD_ENABLED` | true/false | false | Integrazione Herald |
 | `HERALD_URL` | URL | vuoto | Endpoint Herald |
 | `HERALD_API_KEY` | segreto | vuoto | Autenticazione API key |
@@ -329,9 +329,9 @@ Key ID e secret HMAC devono essere impostati insieme. Anche certificato e chiave
 Stargate accetta `bcrypt` in produzione e `plaintext` solo per test locali. MD5 e SHA-512 senza salt vengono rifiutati durante la validazione. Le password distinguono maiuscole e minuscole e conservano gli spazi.
 
 ```bash
-PASSWORDS=bcrypt:<bcrypt-hash>
+PASSWORDS='bcrypt:<bcrypt-hash>'
 # Solo test locali:
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 ```
 
 ## Esempi di Configurazione
@@ -341,7 +341,7 @@ PASSWORDS=plaintext:test123
 ```bash
 # Configurazione richiesta
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # Configurazione opzionale
 DEBUG=false
@@ -353,13 +353,13 @@ LANGUAGE=en
 ```bash
 # Configurazione richiesta
 AUTH_HOST=auth.example.com
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Configurazione opzionale
 DEBUG=false
 LANGUAGE=it
-LOGIN_PAGE_TITLE=Il Mio Servizio di Autenticazione
-LOGIN_PAGE_FOOTER_TEXT=© 2024 La Mia Azienda
+LOGIN_PAGE_TITLE='Il Mio Servizio di Autenticazione'
+LOGIN_PAGE_FOOTER_TEXT='© 2024 La Mia Azienda'
 USER_HEADER_NAME=X-Forwarded-User
 COOKIE_DOMAIN=.example.com
 ```
@@ -373,7 +373,7 @@ services:
     environment:
       # Configurazione richiesta
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+      - PASSWORDS=bcrypt:$$2a$$10$$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
       
       # Configurazione opzionale
       - DEBUG=false
@@ -388,7 +388,7 @@ services:
 ```bash
 # Configurazione richiesta
 AUTH_HOST=localhost
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # Configurazione opzionale
 DEBUG=true

--- a/docs/itIT/DEPLOYMENT.md
+++ b/docs/itIT/DEPLOYMENT.md
@@ -106,7 +106,7 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=plaintext:yourpassword \
+  -e 'PASSWORDS=plaintext:yourpassword' \
   stargate:latest
 ```
 
@@ -117,11 +117,11 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
+  -e 'PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy' \
   -e DEBUG=false \
   -e LANGUAGE=it \
-  -e LOGIN_PAGE_TITLE=Il Mio Servizio di Autenticazione \
-  -e LOGIN_PAGE_FOOTER_TEXT=© 2024 La Mia Azienda \
+  -e 'LOGIN_PAGE_TITLE=Il Mio Servizio di Autenticazione' \
+  -e 'LOGIN_PAGE_FOOTER_TEXT=© 2024 La Mia Azienda' \
   -e COOKIE_DOMAIN=.example.com \
   --restart unless-stopped \
   stargate:latest
@@ -228,7 +228,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
       - DEBUG=false
       - LANGUAGE=it
       - COOKIE_DOMAIN=.example.com
@@ -250,7 +250,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
     networks:
       - traefik
     labels:
@@ -335,13 +335,13 @@ services:
 **Non Consigliato:**
 
 ```bash
-PASSWORDS=plaintext:yourpassword
+PASSWORDS='plaintext:yourpassword'
 ```
 
 **Consigliato:**
 
 ```bash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 ```
 
 #### 2. Abilitare HTTPS

--- a/docs/jaJP/ARCHITECTURE.md
+++ b/docs/jaJP/ARCHITECTURE.md
@@ -5,7 +5,7 @@
 ## 技術スタック
 
 - **言語**: Go 1.27
-- **Web フレームワーク**: [Fiber v2.52.x](https://github.com/gofiber/fiber)
+- **Web フレームワーク**: [Fiber v3.5.0](https://github.com/gofiber/fiber)
 - **テンプレートエンジン**: [Fiber Template v1.7.5](https://github.com/gofiber/template)
 - **セッション管理**: session-kit（Fiber 対応ストア；メモリ・Redis）
 - **ログ**: [Zerolog](https://github.com/rs/zerolog)（logger-kit 経由）
@@ -328,7 +328,7 @@ WardenおよびHerald統合が有効な場合、OTP認証を使用できます�
 ### Docker デプロイメント
 
 - イメージサイズを削減するためのマルチステージビルド
-- ビルドステージ: `golang:1.27.0-alpine3.24`；実行ステージ: `alpine:3.24`（ヘルスチェック用 curl 含む）
+- ビルドステージ: `golang:1.27.0-alpine3.24`；実行ステージ: `alpine:3.24`（ヘルスチェックには BusyBox wget を使用）
 - テンプレートファイルを `src/internal/web/templates` からイメージ内の `/app/web/templates` にコピー
 - バイナリサイズを削減するため、コンパイル時に `-ldflags "-s -w"` を使用
 - アプリケーションは自動的にテンプレートパスを見つける（ローカル開発用に `./internal/web/templates`、本番環境用に `./web/templates` をサポート）

--- a/docs/jaJP/CONFIG.md
+++ b/docs/jaJP/CONFIG.md
@@ -20,7 +20,7 @@ Stargate は環境変数経由で設定されます。すべての設定項目�
 
 ```bash
 export AUTH_HOST=auth.example.com
-export PASSWORDS=plaintext:yourpassword
+export PASSWORDS='plaintext:yourpassword'
 ```
 
 **Docker:**
@@ -88,13 +88,13 @@ AUTH_HOST=auth.example.com
 
 ```bash
 # 単一のプレーンテキストパスワード
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # 複数のプレーンテキストパスワード
-PASSWORDS=plaintext:test123|admin456|user789
+PASSWORDS='plaintext:test123|admin456|user789'
 
 # BCrypt ハッシュ
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 ```
 
@@ -165,7 +165,7 @@ LANGUAGE=ja
 **例:**
 
 ```bash
-LOGIN_PAGE_TITLE=私の認証サービス
+LOGIN_PAGE_TITLE='私の認証サービス'
 ```
 
 ### `LOGIN_PAGE_FOOTER_TEXT`
@@ -186,7 +186,7 @@ LOGIN_PAGE_TITLE=私の認証サービス
 **例:**
 
 ```bash
-LOGIN_PAGE_FOOTER_TEXT=© 2024 私の会社
+LOGIN_PAGE_FOOTER_TEXT='© 2024 私の会社'
 ```
 
 ### `USER_HEADER_NAME`
@@ -281,6 +281,8 @@ PORT=8080
 | `COOKIE_SECURE` | true/false | true | セッション Cookie の Secure 属性 |
 | `CALLBACK_ALLOWED_HOSTS` | ホスト一覧 | 空 | 許可するリダイレクト先 |
 | `SESSION_EXCHANGE_SECRET` | 32 文字以上の秘密値 | 空 | 短命なクロスドメインチケットの署名 |
+| `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | 信頼済みの旧パスワードヘッダーを有効化 |
+| `LOG_LEVEL` | debug/info/warn/error | info | 起動時のログレベル |
 | `HEADER_AUTH_ENABLED` | true/false | false | 信頼済みヘッダー認証 |
 | `HEADER_AUTH_SHARED_SECRET` | 秘密値 | 空 | ヘッダー認証の共有秘密 |
 | `HEADER_AUTH_SECRET_HEADER` | ヘッダー名 | `X-Stargate-Header-Auth` | 共有秘密を運ぶヘッダー |
@@ -294,8 +296,6 @@ PORT=8080
 | `WARDEN_TLS_CLIENT_KEY_FILE` | パス | 空 | mTLS クライアント鍵 |
 | `WARDEN_TLS_SERVER_NAME` | 文字列 | 空 | 期待する TLS サーバー名 |
 | `WARDEN_CACHE_TTL` | 秒 | 300 | Warden キャッシュ時間 |
-| `WARDEN_OTP_ENABLED` | true/false | false | 旧 OTP 連携 |
-| `WARDEN_OTP_SECRET_KEY` | 秘密値 | 空 | 旧 OTP 秘密 |
 | `HERALD_ENABLED` | true/false | false | Herald 連携 |
 | `HERALD_URL` | URL | 空 | Herald エンドポイント |
 | `HERALD_API_KEY` | 秘密値 | 空 | API キー認証 |
@@ -329,9 +329,9 @@ HMAC の Key ID と Secret は必ず同時に設定します。mTLS のクライ
 本番環境では `bcrypt`、ローカルテストでのみ `plaintext` を使用できます。MD5 とソルトなし SHA-512 は設定検証で拒否されます。パスワードは大文字と小文字を区別し、空白も保持します。
 
 ```bash
-PASSWORDS=bcrypt:<bcrypt-hash>
+PASSWORDS='bcrypt:<bcrypt-hash>'
 # ローカルテストのみ:
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 ```
 
 ## 設定例
@@ -341,7 +341,7 @@ PASSWORDS=plaintext:test123
 ```bash
 # 必須設定
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # オプション設定
 DEBUG=false
@@ -353,13 +353,13 @@ LANGUAGE=en
 ```bash
 # 必須設定
 AUTH_HOST=auth.example.com
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # オプション設定
 DEBUG=false
 LANGUAGE=ja
-LOGIN_PAGE_TITLE=私の認証サービス
-LOGIN_PAGE_FOOTER_TEXT=© 2024 私の会社
+LOGIN_PAGE_TITLE='私の認証サービス'
+LOGIN_PAGE_FOOTER_TEXT='© 2024 私の会社'
 USER_HEADER_NAME=X-Forwarded-User
 COOKIE_DOMAIN=.example.com
 ```
@@ -373,7 +373,7 @@ services:
     environment:
       # 必須設定
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+      - PASSWORDS=bcrypt:$$2a$$10$$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
       
       # オプション設定
       - DEBUG=false
@@ -388,7 +388,7 @@ services:
 ```bash
 # 必須設定
 AUTH_HOST=localhost
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # オプション設定
 DEBUG=true

--- a/docs/jaJP/DEPLOYMENT.md
+++ b/docs/jaJP/DEPLOYMENT.md
@@ -106,7 +106,7 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=plaintext:yourpassword \
+  -e 'PASSWORDS=plaintext:yourpassword' \
   stargate:latest
 ```
 
@@ -117,11 +117,11 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
+  -e 'PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy' \
   -e DEBUG=false \
   -e LANGUAGE=ja \
-  -e LOGIN_PAGE_TITLE=私の認証サービス \
-  -e LOGIN_PAGE_FOOTER_TEXT=© 2024 私の会社 \
+  -e 'LOGIN_PAGE_TITLE=私の認証サービス' \
+  -e 'LOGIN_PAGE_FOOTER_TEXT=© 2024 私の会社' \
   -e COOKIE_DOMAIN=.example.com \
   --restart unless-stopped \
   stargate:latest
@@ -228,7 +228,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
       - DEBUG=false
       - LANGUAGE=ja
       - COOKIE_DOMAIN=.example.com
@@ -250,7 +250,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
     networks:
       - traefik
     labels:
@@ -335,13 +335,13 @@ services:
 **推奨されません：**
 
 ```bash
-PASSWORDS=plaintext:yourpassword
+PASSWORDS='plaintext:yourpassword'
 ```
 
 **推奨：**
 
 ```bash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 ```
 
 #### 2. HTTPS を有効化

--- a/docs/koKR/ARCHITECTURE.md
+++ b/docs/koKR/ARCHITECTURE.md
@@ -5,7 +5,7 @@
 ## 기술 스택
 
 - **언어**: Go 1.27
-- **웹 프레임워크**: [Fiber v2.52.x](https://github.com/gofiber/fiber)
+- **웹 프레임워크**: [Fiber v3.5.0](https://github.com/gofiber/fiber)
 - **템플릿 엔진**: [Fiber Template v1.7.5](https://github.com/gofiber/template)
 - **세션 관리**: session-kit(Fiber 호환 스토어; 메모리·Redis)
 - **로깅**: [Zerolog](https://github.com/rs/zerolog)(logger-kit 경유)
@@ -328,7 +328,7 @@ Warden 및 Herald 통합이 활성화된 경우 OTP 인증을 사용할 수 있�
 ### Docker 배포
 
 - 이미지 크기 감소를 위한 다단계 빌드
-- 빌드 단계: `golang:1.27.0-alpine3.24`; 실행 단계: `alpine:3.24`(헬스 체크용 curl 포함)
+- 빌드 단계: `golang:1.27.0-alpine3.24`; 실행 단계: `alpine:3.24`(헬스 체크는 BusyBox wget 사용)
 - 템플릿 파일을 `src/internal/web/templates`에서 이미지 내 `/app/web/templates`로 복사
 - 바이너리 크기 감소를 위해 컴파일 시 `-ldflags "-s -w"` 사용
 - 애플리케이션은 자동으로 템플릿 경로를 찾습니다 (로컬 개발용 `./internal/web/templates`, 프로덕션용 `./web/templates` 지원)

--- a/docs/koKR/CONFIG.md
+++ b/docs/koKR/CONFIG.md
@@ -20,7 +20,7 @@ Stargate는 환경 변수를 통해 설정됩니다. 모든 설정 항목은 환
 
 ```bash
 export AUTH_HOST=auth.example.com
-export PASSWORDS=plaintext:yourpassword
+export PASSWORDS='plaintext:yourpassword'
 ```
 
 **Docker:**
@@ -88,13 +88,13 @@ AUTH_HOST=auth.example.com
 
 ```bash
 # 단일 평문 비밀번호
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # 여러 평문 비밀번호
-PASSWORDS=plaintext:test123|admin456|user789
+PASSWORDS='plaintext:test123|admin456|user789'
 
 # BCrypt 해시
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 ```
 
@@ -165,7 +165,7 @@ LANGUAGE=ko
 **예제:**
 
 ```bash
-LOGIN_PAGE_TITLE=내 인증 서비스
+LOGIN_PAGE_TITLE='내 인증 서비스'
 ```
 
 ### `LOGIN_PAGE_FOOTER_TEXT`
@@ -186,7 +186,7 @@ LOGIN_PAGE_TITLE=내 인증 서비스
 **예제:**
 
 ```bash
-LOGIN_PAGE_FOOTER_TEXT=© 2024 내 회사
+LOGIN_PAGE_FOOTER_TEXT='© 2024 내 회사'
 ```
 
 ### `USER_HEADER_NAME`
@@ -281,6 +281,8 @@ PORT=8080
 | `COOKIE_SECURE` | true/false | true | 세션 쿠키 Secure 속성 |
 | `CALLBACK_ALLOWED_HOSTS` | 호스트 목록 | 비어 있음 | 허용된 리디렉션 대상 |
 | `SESSION_EXCHANGE_SECRET` | 32자 이상 비밀값 | 비어 있음 | 단기 교차 도메인 티켓 서명 |
+| `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | 신뢰된 레거시 비밀번호 헤더 활성화 |
+| `LOG_LEVEL` | debug/info/warn/error | info | 시작 로그 레벨 |
 | `HEADER_AUTH_ENABLED` | true/false | false | 신뢰 헤더 인증 |
 | `HEADER_AUTH_SHARED_SECRET` | 비밀값 | 비어 있음 | 헤더 인증 공유 비밀 |
 | `HEADER_AUTH_SECRET_HEADER` | 헤더 이름 | `X-Stargate-Header-Auth` | 공유 비밀 전달 헤더 |
@@ -294,8 +296,6 @@ PORT=8080
 | `WARDEN_TLS_CLIENT_KEY_FILE` | 경로 | 비어 있음 | mTLS 클라이언트 키 |
 | `WARDEN_TLS_SERVER_NAME` | 문자열 | 비어 있음 | 예상 TLS 서버 이름 |
 | `WARDEN_CACHE_TTL` | 초 | 300 | Warden 캐시 시간 |
-| `WARDEN_OTP_ENABLED` | true/false | false | 레거시 OTP 연동 |
-| `WARDEN_OTP_SECRET_KEY` | 비밀값 | 비어 있음 | 레거시 OTP 비밀 |
 | `HERALD_ENABLED` | true/false | false | Herald 연동 |
 | `HERALD_URL` | URL | 비어 있음 | Herald 엔드포인트 |
 | `HERALD_API_KEY` | 비밀값 | 비어 있음 | API 키 인증 |
@@ -329,9 +329,9 @@ HMAC Key ID와 Secret은 함께 설정해야 합니다. mTLS 클라이언트 인
 운영 환경에서는 `bcrypt`를 사용하며 `plaintext`는 로컬 테스트에서만 사용할 수 있습니다. MD5와 salt 없는 SHA-512는 설정 검증에서 거부됩니다. 비밀번호는 대소문자와 공백을 그대로 구분합니다.
 
 ```bash
-PASSWORDS=bcrypt:<bcrypt-hash>
+PASSWORDS='bcrypt:<bcrypt-hash>'
 # 로컬 테스트 전용:
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 ```
 
 ## 설정 예제
@@ -341,7 +341,7 @@ PASSWORDS=plaintext:test123
 ```bash
 # 필수 설정
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # 선택적 설정
 DEBUG=false
@@ -353,13 +353,13 @@ LANGUAGE=en
 ```bash
 # 필수 설정
 AUTH_HOST=auth.example.com
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # 선택적 설정
 DEBUG=false
 LANGUAGE=ko
-LOGIN_PAGE_TITLE=내 인증 서비스
-LOGIN_PAGE_FOOTER_TEXT=© 2024 내 회사
+LOGIN_PAGE_TITLE='내 인증 서비스'
+LOGIN_PAGE_FOOTER_TEXT='© 2024 내 회사'
 USER_HEADER_NAME=X-Forwarded-User
 COOKIE_DOMAIN=.example.com
 ```
@@ -373,7 +373,7 @@ services:
     environment:
       # 필수 설정
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+      - PASSWORDS=bcrypt:$$2a$$10$$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
       
       # 선택적 설정
       - DEBUG=false
@@ -388,7 +388,7 @@ services:
 ```bash
 # 필수 설정
 AUTH_HOST=localhost
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # 선택적 설정
 DEBUG=true

--- a/docs/koKR/DEPLOYMENT.md
+++ b/docs/koKR/DEPLOYMENT.md
@@ -106,7 +106,7 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=plaintext:yourpassword \
+  -e 'PASSWORDS=plaintext:yourpassword' \
   stargate:latest
 ```
 
@@ -117,11 +117,11 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
+  -e 'PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy' \
   -e DEBUG=false \
   -e LANGUAGE=ko \
-  -e LOGIN_PAGE_TITLE=내 인증 서비스 \
-  -e LOGIN_PAGE_FOOTER_TEXT=© 2024 내 회사 \
+  -e 'LOGIN_PAGE_TITLE=내 인증 서비스' \
+  -e 'LOGIN_PAGE_FOOTER_TEXT=© 2024 내 회사' \
   -e COOKIE_DOMAIN=.example.com \
   --restart unless-stopped \
   stargate:latest
@@ -228,7 +228,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
       - DEBUG=false
       - LANGUAGE=ko
       - COOKIE_DOMAIN=.example.com
@@ -250,7 +250,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
     networks:
       - traefik
     labels:
@@ -335,13 +335,13 @@ services:
 **권장하지 않음:**
 
 ```bash
-PASSWORDS=plaintext:yourpassword
+PASSWORDS='plaintext:yourpassword'
 ```
 
 **권장:**
 
 ```bash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 ```
 
 #### 2. HTTPS 활성화

--- a/docs/zhCN/ARCHITECTURE.md
+++ b/docs/zhCN/ARCHITECTURE.md
@@ -5,7 +5,7 @@
 ## 技术栈
 
 - **语言**: Go 1.27
-- **Web 框架**: [Fiber v2.52.x](https://github.com/gofiber/fiber)
+- **Web 框架**: [Fiber v3.5.0](https://github.com/gofiber/fiber)
 - **模板引擎**: [Fiber Template v1.7.5](https://github.com/gofiber/template)
 - **会话管理**: session-kit（兼容 Fiber 的存储；支持内存与 Redis）
 - **日志**: [Zerolog](https://github.com/rs/zerolog)（通过 logger-kit）
@@ -374,7 +374,7 @@ Stargate 支持可选的服务集成，以扩展认证功能。这些集成都�
 ### Docker 部署
 
 - 多阶段构建，减小镜像体积
-- 构建阶段：`golang:1.27.0-alpine3.24`；运行阶段：`alpine:3.24`（含 curl 用于健康检查）
+- 构建阶段：`golang:1.27.0-alpine3.24`；运行阶段：`alpine:3.24`（健康检查使用 BusyBox wget）
 - 模板文件从 `src/internal/web/templates` 复制到镜像中的 `/app/web/templates`
 - 编译时使用 `-ldflags "-s -w"` 减小二进制体积
 - 应用会自动查找模板路径（支持本地开发的 `./internal/web/templates` 和生产环境的 `./web/templates`）

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -21,7 +21,7 @@ Stargate 通过环境变量进行配置。所有配置项都通过环境变量�
 
 ```bash
 export AUTH_HOST=auth.example.com
-export PASSWORDS=plaintext:yourpassword
+export PASSWORDS='plaintext:yourpassword'
 ```
 
 **Docker：**
@@ -50,6 +50,7 @@ services:
 | `PASSWORDS` | 见密码配置 | — | 未启用 Warden 时为是 |
 | `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | 否 |
 | `DEBUG` | true/false | false | 否 |
+| `LOG_LEVEL` | debug/info/warn/error | info | 否 |
 | `LOGIN_PAGE_TITLE` | String | Stargate - Login | 否 |
 | `LOGIN_PAGE_FOOTER_TEXT` | String | Copyright © 2024 - Stargate | 否 |
 | `USER_HEADER_NAME` | String | X-Forwarded-User | 否 |
@@ -74,8 +75,6 @@ services:
 | `HEADER_AUTH_SHARED_SECRET` | 密钥字符串 | 空 | 启用请求头认证时为是 |
 | `HEADER_AUTH_SECRET_HEADER` | HTTP 头名称 | X-Stargate-Header-Auth | 否 |
 | `WARDEN_CACHE_TTL` | String | 300 | 否 |
-| `WARDEN_OTP_ENABLED` | true/false | false | 否 |
-| `WARDEN_OTP_SECRET_KEY` | String | 空 | 否 |
 | `HERALD_ENABLED` | true/false | false | 否 |
 | `HERALD_URL` | String | 空 | 否 |
 | `HERALD_API_KEY` | String | 空 | 否 |
@@ -151,13 +150,13 @@ AUTH_HOST=auth.example.com
 
 ```bash
 # 单个明文密码
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # 多个明文密码
-PASSWORDS=plaintext:test123|admin456|user789
+PASSWORDS='plaintext:test123|admin456|user789'
 
 # BCrypt 哈希
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 ```
 
@@ -228,7 +227,7 @@ LANGUAGE=zh
 **示例：**
 
 ```bash
-LOGIN_PAGE_TITLE=我的认证服务
+LOGIN_PAGE_TITLE='我的认证服务'
 ```
 
 ### `LOGIN_PAGE_FOOTER_TEXT`
@@ -249,7 +248,7 @@ LOGIN_PAGE_TITLE=我的认证服务
 **示例：**
 
 ```bash
-LOGIN_PAGE_FOOTER_TEXT=© 2024 我的公司
+LOGIN_PAGE_FOOTER_TEXT='© 2024 我的公司'
 ```
 
 ### `USER_HEADER_NAME`
@@ -473,43 +472,7 @@ Warden 用户信息缓存的 TTL（生存时间）。
 WARDEN_CACHE_TTL=300
 ```
 
-#### `WARDEN_OTP_ENABLED`
-
-启用 Warden 内置 OTP 校验（与 Herald OTP 不同，为旧版/内置能力）。
-
-| 属性 | 值 |
-|------|-----|
-| **类型** | Boolean |
-| **必需** | 否 |
-| **默认值** | `false` |
-| **可选值** | `true`, `false` |
-
-**说明：**
-
-- 为 `true` 时使用 Warden 侧 OTP 校验（需配合 `WARDEN_OTP_SECRET_KEY`）
-- 与 Herald 验证码服务（`HERALD_ENABLED`）为两套独立能力，按需选用其一或组合
-
-**示例：**
-
-```bash
-WARDEN_OTP_ENABLED=true
-```
-
-#### `WARDEN_OTP_SECRET_KEY`
-
-Warden OTP 校验所用密钥（仅在 `WARDEN_OTP_ENABLED=true` 时使用）。
-
-| 属性 | 值 |
-|------|-----|
-| **类型** | String |
-| **必需** | 否 |
-| **默认值** | 空 |
-
-**示例：**
-
-```bash
-WARDEN_OTP_SECRET_KEY=your-warden-otp-secret
-```
+旧版 Warden 全局 OTP 配置已移除。请通过 `HERALD_TOTP_ENABLED` 使用 Herald 提供的 TOTP 能力。
 
 ### Herald 集成（可选）
 
@@ -891,7 +854,7 @@ OTLP 采集端地址（如 Jaeger/OTLP Collector）。
 |------|-----|
 | **类型** | Boolean |
 | **必需** | 否 |
-| **默认值** | `false` |
+| **默认值** | `true` |
 | **可选值** | `true`, `false` |
 
 #### `AUTH_REFRESH_INTERVAL`
@@ -923,7 +886,7 @@ Stargate 支持明文（仅开发环境）和 bcrypt 密码验证。配置格式
 **示例：**
 
 ```bash
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 ```
 
 #### `bcrypt` - BCrypt 哈希
@@ -937,16 +900,14 @@ PASSWORDS=plaintext:test123|admin456
 **生成 BCrypt 哈希：**
 
 ```bash
-# 使用 Go 生成
-go run -c 'golang.org/x/crypto/bcrypt' <<< 'password'
-
-# 使用在线工具或其他工具生成
+# Debian/Ubuntu 和 Alpine 可通过 apache2-utils 安装 `htpasswd`。
+htpasswd -bnBC 10 "" 'password' | tr -d ':\n'
 ```
 
 **示例：**
 
 ```bash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 ```
 
 MD5 和未加盐 SHA-512 都是快速、无盐的通用哈希，并非密码哈希函数，因此配置时会被拒绝。
@@ -964,7 +925,7 @@ MD5 和未加盐 SHA-512 都是快速、无盐的通用哈希，并非密码哈�
 ```bash
 # 必需配置
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # 会话存储到 Redis（多实例或持久化会话）
 SESSION_STORAGE_ENABLED=true
@@ -985,7 +946,7 @@ LANGUAGE=zh
 ```bash
 # 必需配置
 AUTH_HOST=auth.example.com
-PASSWORDS=plaintext:test123
+PASSWORDS='plaintext:test123'
 
 # 可选配置
 DEBUG=false
@@ -997,13 +958,13 @@ LANGUAGE=en
 ```bash
 # 必需配置
 AUTH_HOST=auth.example.com
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # 可选配置
 DEBUG=false
 LANGUAGE=zh
-LOGIN_PAGE_TITLE=我的认证服务
-LOGIN_PAGE_FOOTER_TEXT=© 2024 我的公司
+LOGIN_PAGE_TITLE='我的认证服务'
+LOGIN_PAGE_FOOTER_TEXT='© 2024 我的公司'
 USER_HEADER_NAME=X-Forwarded-User
 COOKIE_DOMAIN=.example.com
 ```
@@ -1028,8 +989,8 @@ HERALD_HMAC_SECRET=your-herald-hmac-secret
 # 可选配置
 DEBUG=false
 LANGUAGE=zh
-LOGIN_PAGE_TITLE=我的认证服务
-LOGIN_PAGE_FOOTER_TEXT=© 2024 我的公司
+LOGIN_PAGE_TITLE='我的认证服务'
+LOGIN_PAGE_FOOTER_TEXT='© 2024 我的公司'
 USER_HEADER_NAME=X-Forwarded-User
 COOKIE_DOMAIN=.example.com
 ```
@@ -1053,7 +1014,7 @@ services:
     environment:
       # 必需配置
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+      - PASSWORDS=bcrypt:$$2a$$10$$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
       
       # 可选配置
       - DEBUG=false
@@ -1112,7 +1073,7 @@ services:
 ```bash
 # 必需配置
 AUTH_HOST=localhost
-PASSWORDS=plaintext:test123|admin456
+PASSWORDS='plaintext:test123|admin456'
 
 # 可选配置
 DEBUG=true
@@ -1149,7 +1110,6 @@ Error: Configuration error: invalid value for environment variable 'PASSWORDS': 
 - **Warden 集成**：
   - `WARDEN_ENABLED=true` 时，必须设置 `WARDEN_URL`
   - `WARDEN_API_KEY` 建议设置（用于服务认证）
-  - 若启用 `WARDEN_OTP_ENABLED=true`，需设置 `WARDEN_OTP_SECRET_KEY`
 
 - **Herald 集成（OTP 短信/邮件）**：
   - `HERALD_ENABLED=true` 时，必须设置 `HERALD_URL`
@@ -1225,7 +1185,7 @@ Error: Configuration error: invalid value for environment variable 'PASSWORDS': 
 
 ```bash
 PASSWORD_HEADER_AUTH_ENABLED=true
-PASSWORDS=bcrypt:<哈希>
+PASSWORDS='bcrypt:<哈希>'
 ```
 
 该请求头属于凭据：必须使用 HTTPS、配置限流，并让反向代理在转发到后端前删除 `Stargate-Password`。浏览器认证仍推荐使用 Cookie 会话。

--- a/docs/zhCN/CONTRIBUTING.md
+++ b/docs/zhCN/CONTRIBUTING.md
@@ -58,7 +58,7 @@ chmod +x start-local.sh
 
 # 或手动启动
 export AUTH_HOST=localhost
-export PASSWORDS=plaintext:test123
+export PASSWORDS='plaintext:test123'
 go run src/cmd/stargate/main.go
 ```
 
@@ -69,7 +69,7 @@ go run src/cmd/stargate/main.go
 1. **启动 Stargate**:
    ```bash
    export AUTH_HOST=auth.example.com
-   export PASSWORDS=plaintext:test123
+   export PASSWORDS='plaintext:test123'
    go run src/cmd/stargate/main.go
    ```
 

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -106,7 +106,7 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=plaintext:yourpassword \
+  -e 'PASSWORDS=plaintext:yourpassword' \
   stargate:latest
 ```
 
@@ -117,11 +117,11 @@ docker run -d \
   --name stargate \
   -p 8080:8080 \
   -e AUTH_HOST=auth.example.com \
-  -e PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy \
+  -e 'PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy' \
   -e DEBUG=false \
   -e LANGUAGE=zh \
-  -e LOGIN_PAGE_TITLE=我的认证服务 \
-  -e LOGIN_PAGE_FOOTER_TEXT=© 2024 我的公司 \
+  -e 'LOGIN_PAGE_TITLE=我的认证服务' \
+  -e 'LOGIN_PAGE_FOOTER_TEXT=© 2024 我的公司' \
   -e COOKIE_DOMAIN=.example.com \
   --restart unless-stopped \
   stargate:latest
@@ -339,7 +339,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
       - DEBUG=false
       - LANGUAGE=zh
       - COOKIE_DOMAIN=.example.com
@@ -361,7 +361,7 @@ services:
     image: ghcr.io/soulteary/stargate:v1.0.0
     environment:
       - AUTH_HOST=auth.example.com
-      - PASSWORDS=bcrypt:$2a$10$...
+      - PASSWORDS=bcrypt:$$2a$$10$$...
     networks:
       - traefik
     labels:
@@ -446,13 +446,13 @@ services:
 **不推荐：**
 
 ```bash
-PASSWORDS=plaintext:yourpassword
+PASSWORDS='plaintext:yourpassword'
 ```
 
 **推荐：**
 
 ```bash
-PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 ```
 
 #### 2. 启用 HTTPS

--- a/docs/zhCN/MIGRATION_V1.md
+++ b/docs/zhCN/MIGRATION_V1.md
@@ -81,7 +81,7 @@ v1.0.0 使用加密、短时、单次有效且绑定目标域名的 `?ticket=` �
 - `COOKIE_SECURE` 默认值为 `true`；本地 HTTP 测试需要显式关闭。
 - 启动校验会拒绝格式错误的 URL、端口、时间间隔、Redis DB、过短的交换密钥，以及不完整的 TLS 证书/私钥和 HMAC Key ID/Secret 组合。
 - 只有在 `CALLBACK_ALLOWED_HOSTS` 中显式允许，才能使用跨域回调目标。
-- 启用 Warden 或 Herald 的 HMAC/TLS 后必须提供完整配置；Herald HMAC 认证还需要 `HERALD_HMAC_KEY_ID`。
+- 启用 Warden 或 Herald 的 HMAC/TLS 后必须提供完整配置。仅当 Herald 已配置有效的默认 Key ID 时，才可省略 `HERALD_HMAC_KEY_ID`；没有合适默认项的多密钥部署应显式设置。
 
 切流前，使用生产环境变量启动 v1.0.0 镜像，并逐项修复所有启动校验错误。
 

--- a/docs/zhCN/SECURITY.md
+++ b/docs/zhCN/SECURITY.md
@@ -31,7 +31,7 @@
 **配置示例**:
 ```bash
 export AUTH_HOST=auth.example.com
-export PASSWORDS=bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
+export PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 export COOKIE_DOMAIN=.example.com
 export TRUSTED_PROXIES=10.20.0.10
 ```
@@ -160,9 +160,9 @@ Stargate 支持多种会话存储后端：
 
 **Redis 配置**:
 ```bash
-export REDIS_ENABLED=true
-export REDIS_ADDR=redis:6379
-export REDIS_PASSWORD=your-redis-password
+export SESSION_STORAGE_ENABLED=true
+export SESSION_STORAGE_REDIS_ADDR=redis:6379
+export SESSION_STORAGE_REDIS_PASSWORD=your-redis-password
 ```
 
 ### 敏感信息管理


### PR DESCRIPTION
## Summary

- remove the retired Warden global OTP settings from all configuration references
- document `LOG_LEVEL` and add `PASSWORD_HEADER_AUTH_ENABLED` to every localized configuration table
- align the auth-refresh default, Redis session variables, Herald HMAC Key ID condition, Fiber version, and runtime health-check command with the code
- replace the invalid bcrypt generation command with a working `htpasswd` example
- quote shell environment values containing pipes, dollar signs, apostrophes, or spaces
- escape bcrypt dollar signs in Docker Compose examples
- replace promotional security/readiness claims in the English README with concrete capabilities

## Validation

- `git diff --check`
- verified every localized CONFIG contains `LOG_LEVEL` and `PASSWORD_HEADER_AUTH_ENABLED`
- verified every localized ARCHITECTURE references Fiber v3.5.0 and BusyBox wget
- checked Markdown relative links and code-fence balance
- searched for the retired OTP settings, legacy Redis names, invalid bcrypt command, and stale Fiber/curl descriptions