### PR TITLE
fix(step-up): enforce trusted route provenance

### DIFF
--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -778,7 +778,7 @@ Audit log output format.
 
 ### Step-up Authentication (Optional)
 
-Require a second factor (e.g. password or OTP) for selected paths.
+Require password re-authentication for selected paths.
 
 #### `STEP_UP_ENABLED`
 
@@ -804,6 +804,8 @@ Paths that require step-up; comma-separated; prefix matching supported.
 **Example:** `/admin,/api/sensitive`
 
 At least one path is required when `STEP_UP_ENABLED=true`. Matching uses the request path only; query parameters do not affect protection.
+
+`TRUSTED_PROXIES` must also be configured. The trusted ForwardAuth proxy must send the original request URI in `X-Forwarded-Uri`; Stargate rejects the Step-up check when this trusted path provenance is missing or invalid. A plain path matches itself and child path segments, so `/admin` protects both `/admin` and `/admin/users` but not `/administrator`. Explicit `*` and `?` glob patterns remain supported.
 
 ### OpenTelemetry (Optional)
 

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -792,7 +792,7 @@ Redis 数据库编号。
 
 ### Step-up 认证（可选）
 
-对部分路径要求二次认证（如再次输入密码或 OTP）时启用。
+对部分路径要求再次验证密码时启用。
 
 #### `STEP_UP_ENABLED`
 
@@ -818,6 +818,8 @@ Redis 数据库编号。
 **示例：** `/admin,/api/sensitive`
 
 启用 `STEP_UP_ENABLED=true` 时必须配置至少一个路径。匹配仅使用请求路径，查询参数不会影响保护规则。
+
+同时必须配置 `TRUSTED_PROXIES`。受信任的 ForwardAuth 代理必须通过 `X-Forwarded-Uri` 传递原始请求 URI；缺少该可信路径来源或 URI 无效时，Stargate 会拒绝通过 Step-up 检查。普通路径会匹配自身和下级路径段，例如 `/admin` 同时保护 `/admin` 和 `/admin/users`，但不会误匹配 `/administrator`。仍支持显式的 `*`、`?` Glob 模式。
 
 ### OpenTelemetry（可选）
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -493,6 +493,9 @@ func Initialize(l *logger.Logger) error {
 	if StepUpEnabled.ToBool() && strings.TrimSpace(StepUpPaths.Value) == "" {
 		return NewValidationError(StepUpPaths.Name, "must contain at least one protected path when step-up is enabled", StepUpPaths.PossibleValues)
 	}
+	if StepUpEnabled.ToBool() && strings.TrimSpace(TrustedProxies.Value) == "" {
+		return NewValidationError(TrustedProxies.Name, "must identify the proxies allowed to provide the original request URI when step-up is enabled", TrustedProxies.PossibleValues)
+	}
 	if WardenEnabled.ToBool() {
 		if strings.TrimSpace(WardenURL.Value) == "" {
 			return NewValidationError(WardenURL.Name, i18n.TStatic("error.config_required_not_set"), WardenURL.PossibleValues)

--- a/src/internal/config/stepup.go
+++ b/src/internal/config/stepup.go
@@ -27,12 +27,7 @@ func InitStepUpMatcher() {
 				continue
 			}
 
-			// Convert glob pattern to regex
-			// Simple conversion: * -> .*, ? -> ., ^ and $ for exact match
-			regexPattern := "^" + strings.ReplaceAll(
-				strings.ReplaceAll(regexp.QuoteMeta(pathStr), "\\*", ".*"),
-				"\\?", ".",
-			) + "$"
+			regexPattern := stepUpRegexPattern(pathStr)
 
 			pattern, err := regexp.Compile(regexPattern)
 			if err != nil {
@@ -47,6 +42,24 @@ func InitStepUpMatcher() {
 		patterns: patterns,
 		enabled:  enabled,
 	}
+}
+
+func stepUpRegexPattern(path string) string {
+	// Explicit glob patterns retain their exact glob semantics. Plain paths
+	// match the path itself and descendants separated by '/', not unrelated
+	// paths that happen to share the same string prefix.
+	if strings.ContainsAny(path, "*?") {
+		return "^" + strings.ReplaceAll(
+			strings.ReplaceAll(regexp.QuoteMeta(path), "\\*", ".*"),
+			"\\?", ".",
+		) + "$"
+	}
+
+	if path == "/" {
+		return "^/.*$"
+	}
+	path = strings.TrimSuffix(path, "/")
+	return "^" + regexp.QuoteMeta(path) + "(?:/.*)?$"
 }
 
 // GetStepUpMatcher returns the step-up matcher instance

--- a/src/internal/config/stepup_test.go
+++ b/src/internal/config/stepup_test.go
@@ -27,6 +27,7 @@ func TestInitStepUpMatcher_Enabled_EmptyPaths(t *testing.T) {
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("STEP_UP_ENABLED", "true")
 	t.Setenv("STEP_UP_PATHS", "")
+	t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
 
 	err := Initialize(testLogger())
 	testza.AssertNotNil(t, err)
@@ -37,7 +38,8 @@ func TestInitStepUpMatcher_Enabled_SinglePath(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("STEP_UP_ENABLED", "true")
-	t.Setenv("STEP_UP_PATHS", "/admin*")
+	t.Setenv("STEP_UP_PATHS", "/admin")
+	t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
 
 	err := Initialize(testLogger())
 	testza.AssertNoError(t, err)
@@ -47,6 +49,7 @@ func TestInitStepUpMatcher_Enabled_SinglePath(t *testing.T) {
 	testza.AssertNotNil(t, matcher)
 	testza.AssertTrue(t, matcher.RequiresStepUp("/admin"))
 	testza.AssertTrue(t, matcher.RequiresStepUp("/admin/users"))
+	testza.AssertFalse(t, matcher.RequiresStepUp("/administrator"))
 	testza.AssertFalse(t, matcher.RequiresStepUp("/api"))
 	testza.AssertFalse(t, matcher.RequiresStepUp("/"))
 }
@@ -55,7 +58,8 @@ func TestInitStepUpMatcher_Enabled_MultiplePaths(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("STEP_UP_ENABLED", "true")
-	t.Setenv("STEP_UP_PATHS", "/admin*,/api/secret*")
+	t.Setenv("STEP_UP_PATHS", "/admin,/api/secret")
+	t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
 
 	err := Initialize(testLogger())
 	testza.AssertNoError(t, err)
@@ -67,6 +71,18 @@ func TestInitStepUpMatcher_Enabled_MultiplePaths(t *testing.T) {
 	testza.AssertTrue(t, matcher.RequiresStepUp("/api/secret"))
 	testza.AssertTrue(t, matcher.RequiresStepUp("/api/secret/data"))
 	testza.AssertFalse(t, matcher.RequiresStepUp("/api/public"))
+}
+
+func TestInitializeStepUpRequiresTrustedProxy(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("STEP_UP_ENABLED", "true")
+	t.Setenv("STEP_UP_PATHS", "/admin")
+	t.Setenv("TRUSTED_PROXIES", "")
+
+	err := Initialize(testLogger())
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "TRUSTED_PROXIES")
 }
 
 func TestGetStepUpMatcher_NilInitializes(t *testing.T) {

--- a/src/internal/handlers/forwardauth_test.go
+++ b/src/internal/handlers/forwardauth_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -25,8 +24,10 @@ func TestGetForwardAuthHandler_ReturnsNonNilAfterInit(t *testing.T) {
 // TestInitForwardAuthHandler_WithMinimalConfig verifies InitForwardAuthHandler runs without panic
 // when given minimal env and config. Can be run in isolation via -run InitForwardAuthHandler.
 func TestInitForwardAuthHandler_WithMinimalConfig(t *testing.T) {
-	_ = os.Setenv("AUTH_HOST", "auth.test.com")
-	_ = os.Setenv("PASSWORDS", "plaintext:minimal")
+	t.Setenv("AUTH_HOST", "auth.test.com")
+	t.Setenv("PASSWORDS", "plaintext:minimal")
+	t.Setenv("STEP_UP_ENABLED", "false")
+	t.Setenv("STEP_UP_PATHS", "")
 	testLog := testLogger()
 	if err := config.Initialize(testLog); err != nil {
 		t.Fatalf("config.Initialize: %v", err)
@@ -56,14 +57,8 @@ func TestForwardAuthCheckRoute_ReturnsHandler(t *testing.T) {
 // TestInitForwardAuthHandler_WithStepUpPaths verifies InitForwardAuthHandler runs with step-up paths
 // (covers parseStepUpPaths: comma-separated, trimmed).
 func TestInitForwardAuthHandler_WithStepUpPaths(t *testing.T) {
-	_ = os.Setenv("AUTH_HOST", "auth.test.com")
-	_ = os.Setenv("PASSWORDS", "plaintext:minimal")
-	_ = os.Setenv("STEP_UP_ENABLED", "true")
-	_ = os.Setenv("STEP_UP_PATHS", " /admin*, /api/secret*, ")
+	setupStepUpTestWithPaths(t, " /admin*, /api/secret*, ")
 	testLog := testLogger()
-	if err := config.Initialize(testLog); err != nil {
-		t.Fatalf("config.Initialize: %v", err)
-	}
 	InitForwardAuthHandler(testLog)
 	h := GetForwardAuthHandler()
 	if h == nil {

--- a/src/internal/handlers/step_up.go
+++ b/src/internal/handlers/step_up.go
@@ -24,18 +24,37 @@ func requiresStepUp(ctx fiber.Ctx, sess *session.Session) bool {
 	if !config.StepUpEnabled.ToBool() || stepUpVerified(sess) {
 		return false
 	}
-	return config.GetStepUpMatcher().RequiresStepUp(stepUpRequestPath(GetForwardedURI(ctx)))
+	raw, ok := stepUpForwardedURI(ctx)
+	if !ok {
+		return true
+	}
+	path, ok := stepUpRequestPath(raw)
+	if !ok {
+		return true
+	}
+	return config.GetStepUpMatcher().RequiresStepUp(path)
+}
+
+// stepUpForwardedURI returns the original request URI only when it came from a
+// trusted proxy. Falling back to Stargate's own /_auth path would silently
+// disable every configured business-path rule.
+func stepUpForwardedURI(ctx fiber.Ctx) (string, bool) {
+	if !trustForwardedHeaders(ctx) {
+		return "", false
+	}
+	forwardedURI := strings.TrimSpace(ctx.Get("X-Forwarded-Uri"))
+	return forwardedURI, forwardedURI != ""
 }
 
 // stepUpRequestPath removes the query and fragment before matching protected
 // routes. ForwardAuth proxies commonly send X-Forwarded-Uri as a request URI;
 // matching the raw value lets `/admin?x=1` bypass an exact `/admin` rule.
-func stepUpRequestPath(raw string) string {
+func stepUpRequestPath(raw string) (string, bool) {
 	parsed, err := url.ParseRequestURI(raw)
 	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.Path == "" || !strings.HasPrefix(parsed.Path, "/") {
-		return "/"
+		return "", false
 	}
-	return parsed.Path
+	return parsed.Path, true
 }
 
 func safeStepUpCallback(raw string) string {
@@ -46,7 +65,8 @@ func safeStepUpCallback(raw string) string {
 }
 
 func redirectToStepUp(ctx fiber.Ctx) error {
-	callback := safeStepUpCallback(GetForwardedURI(ctx))
+	forwardedURI, _ := stepUpForwardedURI(ctx)
+	callback := safeStepUpCallback(forwardedURI)
 	return ctx.Redirect().Status(fiber.StatusFound).To("/_step_up?callback=" + url.QueryEscape(callback))
 }
 

--- a/src/internal/handlers/step_up_test.go
+++ b/src/internal/handlers/step_up_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestRedirectToStepUpPreservesOnlyLocalCallback(t *testing.T) {
+	setupStepUpTest(t)
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{"X-Forwarded-Uri": "/admin/users?tab=roles"}, "")
 	defer app.ReleaseCtx(ctx)
 
@@ -76,11 +77,25 @@ func TestStepUpAPIRejectsWrongPassword(t *testing.T) {
 }
 
 func setupStepUpTest(t *testing.T) {
+	setupStepUpTestWithPaths(t, "/admin/*")
+}
+
+func setupStepUpTestWithPaths(t *testing.T, paths string) {
 	t.Helper()
+	previousEnabled := config.StepUpEnabled.Value
+	previousPaths := config.StepUpPaths.Value
+	previousTrustedProxies := config.TrustedProxies.Value
+	t.Cleanup(func() {
+		config.StepUpEnabled.Value = previousEnabled
+		config.StepUpPaths.Value = previousPaths
+		config.TrustedProxies.Value = previousTrustedProxies
+		config.InitStepUpMatcher()
+	})
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
 	t.Setenv("STEP_UP_ENABLED", "true")
-	t.Setenv("STEP_UP_PATHS", "/admin/*")
+	t.Setenv("STEP_UP_PATHS", paths)
+	t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
 	testza.AssertNoError(t, config.Initialize(testLogger()))
 }
 
@@ -98,11 +113,7 @@ func TestRequiresStepUpUsesForwardedBusinessPath(t *testing.T) {
 }
 
 func TestRequiresStepUpIgnoresForwardedQuery(t *testing.T) {
-	t.Setenv("AUTH_HOST", "auth.example.com")
-	t.Setenv("PASSWORDS", "plaintext:test123")
-	t.Setenv("STEP_UP_ENABLED", "true")
-	t.Setenv("STEP_UP_PATHS", "/admin")
-	testza.AssertNoError(t, config.Initialize(testLogger()))
+	setupStepUpTestWithPaths(t, "/admin")
 
 	store := setupTestStore()
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{"X-Forwarded-Uri": "/admin?view=users"}, "")
@@ -114,9 +125,27 @@ func TestRequiresStepUpIgnoresForwardedQuery(t *testing.T) {
 }
 
 func TestStepUpRequestPathRejectsInvalidURI(t *testing.T) {
-	testza.AssertEqual(t, "/", stepUpRequestPath("https://evil.example/admin"))
-	testza.AssertEqual(t, "/", stepUpRequestPath("not-a-path"))
-	testza.AssertEqual(t, "/admin", stepUpRequestPath("/admin?x=1"))
+	_, ok := stepUpRequestPath("https://evil.example/admin")
+	testza.AssertFalse(t, ok)
+	_, ok = stepUpRequestPath("not-a-path")
+	testza.AssertFalse(t, ok)
+	path, ok := stepUpRequestPath("/admin?x=1")
+	testza.AssertTrue(t, ok)
+	testza.AssertEqual(t, "/admin", path)
+}
+
+func TestRequiresStepUpFailsClosedWithoutValidForwardedURI(t *testing.T) {
+	setupStepUpTest(t)
+	store := setupTestStore()
+
+	for _, forwardedURI := range []string{"", "https://evil.example/admin", "not-a-path"} {
+		ctx, app := createTestContext("GET", "/_auth", map[string]string{"X-Forwarded-Uri": forwardedURI}, "")
+		sess, err := store.Get(ctx)
+		testza.AssertNoError(t, err)
+		testza.AssertTrue(t, requiresStepUp(ctx, sess))
+		sess.Release()
+		app.ReleaseCtx(ctx)
+	}
 }
 
 func TestStepUpAPIRecordsRecentVerification(t *testing.T) {


### PR DESCRIPTION
## Summary

- require `TRUSTED_PROXIES` when Step-up authentication is enabled
- fail closed when `X-Forwarded-Uri` is missing, untrusted, or invalid instead of matching Stargate's internal `/_auth` path
- make plain Step-up paths match themselves and child path segments without matching unrelated prefixes
- retain explicit `*` and `?` glob support
- align the English and Chinese configuration contract with password re-authentication and proxy requirements
- isolate Step-up configuration in tests to prevent cross-test state leakage

## Security impact

A Step-up deployment without trusted route provenance could silently skip every protected business path. Plain paths such as `/admin` were also documented as prefixes but previously matched only the exact path.

## Validation

- `go test ./... -count=1`
- `bash .github/scripts/check-doc-contracts.sh HEAD`
- `git diff --check`