### PR TITLE
fix(config): validate security-sensitive contracts

### DIFF
--- a/docs/deDE/CONFIG.md
+++ b/docs/deDE/CONFIG.md
@@ -284,7 +284,7 @@ Die folgende Tabelle ist mit den tatsächlich in `internal/config` registrierten
 | `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | Aktiviert den vertrauenswürdigen Legacy-Passwort-Header |
 | `LOG_LEVEL` | debug/info/warn/error | info | Start-Protokollstufe |
 | `HEADER_AUTH_ENABLED` | true/false | false | Vertrauenswürdige Header-Authentifizierung |
-| `HEADER_AUTH_SHARED_SECRET` | Geheimnis | leer | Gemeinsames Geheimnis für Header-Authentifizierung |
+| `HEADER_AUTH_SHARED_SECRET` | Geheimnis, mindestens 32 Zeichen | leer | Gemeinsames Geheimnis für Header-Authentifizierung |
 | `HEADER_AUTH_SECRET_HEADER` | Headername | `X-Stargate-Header-Auth` | Transportiert das gemeinsame Geheimnis |
 | `WARDEN_ENABLED` | true/false | false | Warden-Integration |
 | `WARDEN_URL` | URL | leer | Warden-Endpunkt |

--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -72,7 +72,7 @@ Below are all environment variables used in code. "Required" means the service w
 | `WARDEN_TLS_CLIENT_KEY_FILE` | path | empty | No |
 | `WARDEN_TLS_SERVER_NAME` | String | empty | No |
 | `HEADER_AUTH_ENABLED` | true/false | false | No |
-| `HEADER_AUTH_SHARED_SECRET` | Secret string | empty | Yes when header auth enabled |
+| `HEADER_AUTH_SHARED_SECRET` | Secret string (at least 32 characters) | empty | Yes when header auth enabled |
 | `HEADER_AUTH_SECRET_HEADER` | HTTP header name | X-Stargate-Header-Auth | No |
 | `WARDEN_CACHE_TTL` | String | 300 | No |
 | `HERALD_ENABLED` | true/false | false | No |
@@ -1186,11 +1186,13 @@ Trusted identity headers are disabled by default. This mode requires Warden and 
 WARDEN_ENABLED=true
 WARDEN_URL=http://warden:8080
 HEADER_AUTH_ENABLED=true
-HEADER_AUTH_SHARED_SECRET=<random-shared-secret>
+HEADER_AUTH_SHARED_SECRET=<at-least-32-random-characters>
 # Optional; this is the default header name:
 HEADER_AUTH_SECRET_HEADER=X-Stargate-Header-Auth
 ```
 
 The proxy sends `X-User-Phone` or `X-User-Mail` together with the configured secret header. Stargate removes the secret header before forwarding and discards the identity headers when the secret does not match.
+
+Configured header names must be valid HTTP field names and must not reuse routing, authentication, identity, or hop-by-hop headers. In particular, do not configure the shared-secret header as `X-Forwarded-Uri`, `Stargate-Password`, `X-User-Phone`, or `X-User-Mail`; Stargate rejects these combinations at startup.
 
 Treat all three headers as trust-boundary inputs: use HTTPS, generate a strong shared secret, and configure the edge proxy to remove any client-supplied `X-User-Phone`, `X-User-Mail`, and header named by `HEADER_AUTH_SECRET_HEADER` before adding its own. Never expose this mode directly to untrusted clients.

--- a/docs/enUS/MIGRATION_V1.md
+++ b/docs/enUS/MIGRATION_V1.md
@@ -59,7 +59,7 @@ Do not place arbitrary client networks in `TRUSTED_PROXIES`.
 
 - The login form remains available through `POST /_login`.
 - Authentication through the `Stargate-Password` request header is disabled by default. Set `PASSWORD_HEADER_AUTH_ENABLED=true` only for a trusted proxy integration, and make the proxy remove any client-supplied copy of that header.
-- Trusted identity headers require `HEADER_AUTH_ENABLED=true`, a matching `HEADER_AUTH_SHARED_SECRET`, and Warden. The proxy must remove client-supplied identity and secret headers before adding its own values.
+- Trusted identity headers require `HEADER_AUTH_ENABLED=true`, a matching `HEADER_AUTH_SHARED_SECRET` of at least 32 characters, and Warden. The proxy must remove client-supplied identity and secret headers before adding its own values.
 - Invalid Warden or Herald client configuration now fails at startup instead of producing a partially working service.
 - The legacy Warden global OTP fallback has been removed. Use Herald-backed TOTP enrollment and verification.
 

--- a/docs/frFR/CONFIG.md
+++ b/docs/frFR/CONFIG.md
@@ -284,7 +284,7 @@ Ce tableau est synchronisé avec les variables de sécurité réellement enregis
 | `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | Active l'en-tête de mot de passe historique de confiance |
 | `LOG_LEVEL` | debug/info/warn/error | info | Niveau de journalisation initial |
 | `HEADER_AUTH_ENABLED` | true/false | false | Authentification par en-têtes de confiance |
-| `HEADER_AUTH_SHARED_SECRET` | secret | vide | Secret partagé de l'authentification par en-tête |
+| `HEADER_AUTH_SHARED_SECRET` | secret, 32 caractères min. | vide | Secret partagé de l'authentification par en-tête |
 | `HEADER_AUTH_SECRET_HEADER` | nom d'en-tête | `X-Stargate-Header-Auth` | Transporte le secret partagé |
 | `WARDEN_ENABLED` | true/false | false | Intégration Warden |
 | `WARDEN_URL` | URL | vide | Point de terminaison Warden |

--- a/docs/itIT/CONFIG.md
+++ b/docs/itIT/CONFIG.md
@@ -284,7 +284,7 @@ La tabella è sincronizzata con le variabili di sicurezza realmente registrate i
 | `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | Abilita l'header password legacy attendibile |
 | `LOG_LEVEL` | debug/info/warn/error | info | Livello di log iniziale |
 | `HEADER_AUTH_ENABLED` | true/false | false | Autenticazione tramite header attendibili |
-| `HEADER_AUTH_SHARED_SECRET` | segreto | vuoto | Segreto condiviso per header auth |
+| `HEADER_AUTH_SHARED_SECRET` | segreto, almeno 32 caratteri | vuoto | Segreto condiviso per header auth |
 | `HEADER_AUTH_SECRET_HEADER` | nome header | `X-Stargate-Header-Auth` | Trasporta il segreto condiviso |
 | `WARDEN_ENABLED` | true/false | false | Integrazione Warden |
 | `WARDEN_URL` | URL | vuoto | Endpoint Warden |

--- a/docs/jaJP/CONFIG.md
+++ b/docs/jaJP/CONFIG.md
@@ -284,7 +284,7 @@ PORT=8080
 | `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | 信頼済みの旧パスワードヘッダーを有効化 |
 | `LOG_LEVEL` | debug/info/warn/error | info | 起動時のログレベル |
 | `HEADER_AUTH_ENABLED` | true/false | false | 信頼済みヘッダー認証 |
-| `HEADER_AUTH_SHARED_SECRET` | 秘密値 | 空 | ヘッダー認証の共有秘密 |
+| `HEADER_AUTH_SHARED_SECRET` | 32文字以上の秘密値 | 空 | ヘッダー認証の共有秘密 |
 | `HEADER_AUTH_SECRET_HEADER` | ヘッダー名 | `X-Stargate-Header-Auth` | 共有秘密を運ぶヘッダー |
 | `WARDEN_ENABLED` | true/false | false | Warden 連携 |
 | `WARDEN_URL` | URL | 空 | Warden エンドポイント |

--- a/docs/koKR/CONFIG.md
+++ b/docs/koKR/CONFIG.md
@@ -284,7 +284,7 @@ PORT=8080
 | `PASSWORD_HEADER_AUTH_ENABLED` | true/false | false | 신뢰된 레거시 비밀번호 헤더 활성화 |
 | `LOG_LEVEL` | debug/info/warn/error | info | 시작 로그 레벨 |
 | `HEADER_AUTH_ENABLED` | true/false | false | 신뢰 헤더 인증 |
-| `HEADER_AUTH_SHARED_SECRET` | 비밀값 | 비어 있음 | 헤더 인증 공유 비밀 |
+| `HEADER_AUTH_SHARED_SECRET` | 최소 32자의 비밀값 | 비어 있음 | 헤더 인증 공유 비밀 |
 | `HEADER_AUTH_SECRET_HEADER` | 헤더 이름 | `X-Stargate-Header-Auth` | 공유 비밀 전달 헤더 |
 | `WARDEN_ENABLED` | true/false | false | Warden 연동 |
 | `WARDEN_URL` | URL | 비어 있음 | Warden 엔드포인트 |

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -72,7 +72,7 @@ services:
 | `WARDEN_TLS_CLIENT_KEY_FILE` | 路径 | 空 | 否 |
 | `WARDEN_TLS_SERVER_NAME` | String | 空 | 否 |
 | `HEADER_AUTH_ENABLED` | true/false | false | 否 |
-| `HEADER_AUTH_SHARED_SECRET` | 密钥字符串 | 空 | 启用请求头认证时为是 |
+| `HEADER_AUTH_SHARED_SECRET` | 至少 32 个字符的密钥字符串 | 空 | 启用请求头认证时为是 |
 | `HEADER_AUTH_SECRET_HEADER` | HTTP 头名称 | X-Stargate-Header-Auth | 否 |
 | `WARDEN_CACHE_TTL` | String | 300 | 否 |
 | `HERALD_ENABLED` | true/false | false | 否 |
@@ -1200,11 +1200,13 @@ PASSWORDS='bcrypt:<哈希>'
 WARDEN_ENABLED=true
 WARDEN_URL=http://warden:8080
 HEADER_AUTH_ENABLED=true
-HEADER_AUTH_SHARED_SECRET=<随机共享密钥>
+HEADER_AUTH_SHARED_SECRET=<至少32个随机字符>
 # 可选；以下为默认请求头名称：
 HEADER_AUTH_SECRET_HEADER=X-Stargate-Header-Auth
 ```
 
 代理需要同时发送 `X-User-Phone` 或 `X-User-Mail` 以及配置的密钥请求头。Stargate 在转发前会删除密钥请求头；密钥不匹配时会丢弃身份请求头。
+
+所有可配置请求头名称必须是合法的 HTTP Field Name，且不能复用路由、认证、身份或 Hop-by-hop 请求头。尤其不能把共享密钥请求头配置成 `X-Forwarded-Uri`、`Stargate-Password`、`X-User-Phone` 或 `X-User-Mail`；Stargate 会在启动时拒绝这些组合。
 
 这三个请求头都属于信任边界输入：必须使用 HTTPS 和高强度共享密钥，并让边缘代理先删除客户端传入的 `X-User-Phone`、`X-User-Mail` 以及由 `HEADER_AUTH_SECRET_HEADER` 指定名称的请求头，再写入代理自己的值。切勿把该模式直接暴露给不受信任的客户端。

--- a/docs/zhCN/MIGRATION_V1.md
+++ b/docs/zhCN/MIGRATION_V1.md
@@ -59,7 +59,7 @@ v1.0.0 使用加密、短时、单次有效且绑定目标域名的 `?ticket=` �
 
 - 登录表单仍通过 `POST /_login` 提交。
 - `Stargate-Password` 请求头认证默认关闭。仅在可信代理集成中设置 `PASSWORD_HEADER_AUTH_ENABLED=true`，并确保代理先删除客户端传入的同名请求头。
-- 可信身份请求头需要同时启用 `HEADER_AUTH_ENABLED=true`、配置匹配的 `HEADER_AUTH_SHARED_SECRET` 并接入 Warden。代理必须先删除客户端传入的身份和密钥请求头，再写入可信值。
+- 可信身份请求头需要同时启用 `HEADER_AUTH_ENABLED=true`、配置至少 32 个字符的匹配 `HEADER_AUTH_SHARED_SECRET` 并接入 Warden。代理必须先删除客户端传入的身份和密钥请求头，再写入可信值。
 - Warden 或 Herald 客户端配置无效时，服务现在会在启动阶段直接失败，而不是以不完整状态运行。
 - 已移除旧版 Warden 全局 OTP 回退逻辑，请使用 Herald 支持的 TOTP 注册与校验。
 

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/valyala/fasthttp v1.73.0
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/trace v1.46.0
+	golang.org/x/net v0.58.0
 )
 
 require (
@@ -81,7 +82,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
-	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/src/internal/config/strict_validation.go
+++ b/src/internal/config/strict_validation.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/net/publicsuffix"
 )
 
 func strictValidationError(variable *EnvVariable, reason string) error {
@@ -20,6 +22,118 @@ func validatePositiveInteger(variable *EnvVariable) error {
 	return nil
 }
 
+func validDNSName(host string) bool {
+	if host == "" || len(host) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, char := range label {
+			if (char < 'a' || char > 'z') && (char < 'A' || char > 'Z') &&
+				(char < '0' || char > '9') && char != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func parseHostPort(raw string) (string, error) {
+	if raw == "" || raw != strings.TrimSpace(raw) || strings.ContainsAny(raw, "\\\r\n\t") {
+		return "", strictValidationError(&AuthHost, "must be a host or host:port without scheme, path, query, or fragment")
+	}
+	parsed, err := url.Parse("//" + raw)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.Path != "" ||
+		parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Hostname() == "" {
+		return "", strictValidationError(&AuthHost, "must be a host or host:port without scheme, path, query, or fragment")
+	}
+	if port := parsed.Port(); port != "" {
+		value, err := strconv.Atoi(port)
+		if err != nil || value < 1 || value > 65535 {
+			return "", strictValidationError(&AuthHost, "must contain a TCP port between 1 and 65535")
+		}
+	}
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if net.ParseIP(host) == nil && host != "localhost" && !validDNSName(host) {
+		return "", strictValidationError(&AuthHost, "must contain a valid DNS name or IP address")
+	}
+	return host, nil
+}
+
+func validateAuthHostAndCookieDomain() error {
+	authHost, err := parseHostPort(AuthHost.Value)
+	if err != nil {
+		return err
+	}
+
+	rawDomain := strings.TrimSpace(CookieDomain.Value)
+	if rawDomain == "" {
+		return nil
+	}
+	if rawDomain != CookieDomain.Value {
+		return strictValidationError(&CookieDomain, "must not contain surrounding whitespace")
+	}
+	domain := strings.ToLower(strings.TrimPrefix(rawDomain, "."))
+	if domain == "" || strings.Contains(rawDomain, ":") || net.ParseIP(domain) != nil || !validDNSName(domain) {
+		return strictValidationError(&CookieDomain, "must be a registrable DNS domain without a port")
+	}
+	if _, err := publicsuffix.EffectiveTLDPlusOne(domain); err != nil {
+		return strictValidationError(&CookieDomain, "must not be a public suffix")
+	}
+	if net.ParseIP(authHost) != nil || (authHost != domain && !strings.HasSuffix(authHost, "."+domain)) {
+		return strictValidationError(&CookieDomain, "must equal AUTH_HOST or be its parent domain")
+	}
+	return nil
+}
+
+func isHTTPHeaderName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || strings.ContainsRune("!#$%&'*+-.^_`|~", char) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validateHeaderContracts() error {
+	headers := []*EnvVariable{&UserHeaderName, &ProxyHeader, &HeaderAuthSecretHeader}
+	for _, variable := range headers {
+		if !isHTTPHeaderName(variable.Value) {
+			return strictValidationError(variable, "must be a valid HTTP header field name")
+		}
+	}
+
+	forbidden := map[string]struct{}{
+		"authorization": {}, "connection": {}, "content-length": {}, "cookie": {},
+		"host": {}, "proxy-authorization": {}, "set-cookie": {}, "stargate-password": {},
+		"te": {}, "trailer": {}, "transfer-encoding": {}, "upgrade": {},
+		"x-forwarded-host": {}, "x-forwarded-proto": {}, "x-forwarded-uri": {},
+		"x-user-mail": {}, "x-user-phone": {},
+	}
+	for _, variable := range headers {
+		if _, blocked := forbidden[strings.ToLower(variable.Value)]; blocked {
+			return strictValidationError(variable, "must not collide with a reserved authentication, routing, or hop-by-hop header")
+		}
+	}
+
+	configured := []*EnvVariable{&UserHeaderName, &ProxyHeader, &HeaderAuthSecretHeader}
+	for i, variable := range configured {
+		for _, other := range configured[i+1:] {
+			if strings.EqualFold(variable.Value, other.Value) {
+				return strictValidationError(other, "must not reuse another configured header name")
+			}
+		}
+	}
+	return nil
+}
+
 func validateHTTPServiceURL(variable *EnvVariable) error {
 	if strings.TrimSpace(variable.Value) == "" {
 		return nil
@@ -27,9 +141,14 @@ func validateHTTPServiceURL(variable *EnvVariable) error {
 	parsed, err := url.Parse(variable.Value)
 	if err != nil || parsed.Host == "" || parsed.User != nil ||
 		(parsed.Scheme != "http" && parsed.Scheme != "https") ||
-		parsed.RawQuery != "" || parsed.Fragment != "" {
-		return strictValidationError(variable, "must be an HTTP(S) service URL without credentials, query, or fragment")
+		parsed.RawQuery != "" || parsed.Fragment != "" ||
+		(parsed.Path != "" && parsed.Path != "/") || parsed.RawPath != "" {
+		return strictValidationError(variable, "must be an HTTP(S) service root URL without credentials, path, query, or fragment")
 	}
+	if _, err := parseHostPort(parsed.Host); err != nil {
+		return strictValidationError(variable, "must contain a valid host and optional TCP port")
+	}
+	variable.Value = strings.TrimSuffix(variable.Value, "/")
 	return nil
 }
 
@@ -50,6 +169,15 @@ func validateCallbackHostList(variable *EnvVariable) error {
 }
 
 func validateStrictSettings() error {
+	if err := validateAuthHostAndCookieDomain(); err != nil {
+		return err
+	}
+	if err := validateHeaderContracts(); err != nil {
+		return err
+	}
+	if HeaderAuthEnabled.ToBool() && len(HeaderAuthSharedSecret.Value) < 32 {
+		return strictValidationError(&HeaderAuthSharedSecret, "must contain at least 32 characters when trusted header authentication is enabled")
+	}
 	if strings.TrimSpace(CookieDomain.Value) != "" || strings.TrimSpace(CallbackAllowedHosts.Value) != "" {
 		if len(SessionExchangeSecret.Value) < 32 {
 			return strictValidationError(&SessionExchangeSecret, "must contain at least 32 characters when cross-domain callbacks are enabled")

--- a/src/internal/config/strict_validation_test.go
+++ b/src/internal/config/strict_validation_test.go
@@ -9,9 +9,10 @@ import (
 func setValidStrictTestValues(t *testing.T) {
 	t.Helper()
 	variables := []*EnvVariable{
-		&CookieDomain, &CallbackAllowedHosts, &SessionExchangeSecret, &Port,
+		&AuthHost, &CookieDomain, &CallbackAllowedHosts, &SessionExchangeSecret, &Port,
 		&WardenCacheTTL, &AuthRefreshInterval, &SessionStorageRedisDB,
 		&SessionStorageEnabled, &SessionStorageRedisAddr, &WardenURL, &HeraldURL,
+		&UserHeaderName, &ProxyHeader, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader,
 	}
 	values := make([]string, len(variables))
 	for i, variable := range variables {
@@ -23,6 +24,7 @@ func setValidStrictTestValues(t *testing.T) {
 		}
 	})
 
+	AuthHost.Value = "auth.example.com"
 	CookieDomain.Value = ""
 	CallbackAllowedHosts.Value = ""
 	SessionExchangeSecret.Value = ""
@@ -34,6 +36,11 @@ func setValidStrictTestValues(t *testing.T) {
 	SessionStorageRedisAddr.Value = "localhost:6379"
 	WardenURL.Value = ""
 	HeraldURL.Value = ""
+	UserHeaderName.Value = "X-Forwarded-User"
+	ProxyHeader.Value = "X-Forwarded-For"
+	HeaderAuthEnabled.Value = "false"
+	HeaderAuthSharedSecret.Value = ""
+	HeaderAuthSecretHeader.Value = "X-Stargate-Header-Auth"
 }
 
 func TestValidateStrictSettingsAcceptsOperationalDefaults(t *testing.T) {
@@ -80,6 +87,98 @@ func TestValidateStrictSettingsRejectsUnsafeServiceURL(t *testing.T) {
 	err := validateStrictSettings()
 	testza.AssertNotNil(t, err)
 	testza.AssertEqual(t, WardenURL.Name, err.(*ValidationError).KeyName)
+}
+
+func TestValidateStrictSettingsNormalizesServiceRootURL(t *testing.T) {
+	setValidStrictTestValues(t)
+	WardenURL.Value = "https://warden.example.com/"
+	HeraldURL.Value = "https://herald.example.com/"
+
+	testza.AssertNoError(t, validateStrictSettings())
+	testza.AssertEqual(t, "https://warden.example.com", WardenURL.Value)
+	testza.AssertEqual(t, "https://herald.example.com", HeraldURL.Value)
+}
+
+func TestValidateStrictSettingsRejectsServiceURLPath(t *testing.T) {
+	setValidStrictTestValues(t)
+	WardenURL.Value = "https://warden.example.com/api"
+
+	err := validateStrictSettings()
+	testza.AssertNotNil(t, err)
+	testza.AssertEqual(t, WardenURL.Name, err.(*ValidationError).KeyName)
+}
+
+func TestValidateStrictSettingsRejectsInvalidAuthHost(t *testing.T) {
+	for _, host := range []string{"https://auth.example.com", "auth.example.com/login", "user@auth.example.com", "auth.example.com:70000"} {
+		t.Run(host, func(t *testing.T) {
+			setValidStrictTestValues(t)
+			AuthHost.Value = host
+
+			err := validateStrictSettings()
+			testza.AssertNotNil(t, err)
+			testza.AssertEqual(t, AuthHost.Name, err.(*ValidationError).KeyName)
+		})
+	}
+}
+
+func TestValidateStrictSettingsChecksCookieDomainBoundary(t *testing.T) {
+	tests := []struct {
+		domain string
+		valid  bool
+	}{
+		{domain: ".example.com", valid: true},
+		{domain: "auth.example.com", valid: true},
+		{domain: "example.net", valid: false},
+		{domain: "com", valid: false},
+		{domain: "127.0.0.1", valid: false},
+	}
+	for _, test := range tests {
+		t.Run(test.domain, func(t *testing.T) {
+			setValidStrictTestValues(t)
+			CookieDomain.Value = test.domain
+			SessionExchangeSecret.Value = "0123456789abcdef0123456789abcdef"
+
+			err := validateStrictSettings()
+			if test.valid {
+				testza.AssertNoError(t, err)
+				return
+			}
+			testza.AssertNotNil(t, err)
+			testza.AssertEqual(t, CookieDomain.Name, err.(*ValidationError).KeyName)
+		})
+	}
+}
+
+func TestValidateStrictSettingsRejectsHeaderCollisions(t *testing.T) {
+	tests := []struct {
+		configure func()
+		key       string
+	}{
+		{configure: func() { HeaderAuthSecretHeader.Value = "X-Forwarded-Uri" }, key: HeaderAuthSecretHeader.Name},
+		{configure: func() { HeaderAuthSecretHeader.Value = "invalid header" }, key: HeaderAuthSecretHeader.Name},
+		{configure: func() { UserHeaderName.Value = "Authorization" }, key: UserHeaderName.Name},
+		{configure: func() { ProxyHeader.Value = UserHeaderName.Value }, key: ProxyHeader.Name},
+	}
+	for _, test := range tests {
+		t.Run(test.key, func(t *testing.T) {
+			setValidStrictTestValues(t)
+			test.configure()
+
+			err := validateStrictSettings()
+			testza.AssertNotNil(t, err)
+			testza.AssertEqual(t, test.key, err.(*ValidationError).KeyName)
+		})
+	}
+}
+
+func TestValidateStrictSettingsRequiresStrongHeaderAuthSecret(t *testing.T) {
+	setValidStrictTestValues(t)
+	HeaderAuthEnabled.Value = "true"
+	HeaderAuthSharedSecret.Value = "too-short"
+
+	err := validateStrictSettings()
+	testza.AssertNotNil(t, err)
+	testza.AssertEqual(t, HeaderAuthSharedSecret.Name, err.(*ValidationError).KeyName)
 }
 
 func TestValidateStrictSettingsRejectsPaddedRedisDB(t *testing.T) {

--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -191,10 +191,12 @@ func TestCheckRoute_HeaderAuth_Invalid(t *testing.T) {
 	testza.AssertEqual(t, fiber.StatusUnauthorized, ctx.Response().StatusCode())
 }
 
+const trustedHeaderAuthTestSecret = "trusted-proxy-secret-32-characters"
+
 func enableTrustedHeaderAuth(t *testing.T) {
 	t.Helper()
 	t.Setenv("HEADER_AUTH_ENABLED", "true")
-	t.Setenv("HEADER_AUTH_SHARED_SECRET", "trusted-proxy-secret")
+	t.Setenv("HEADER_AUTH_SHARED_SECRET", trustedHeaderAuthTestSecret)
 }
 
 func TestLoginAPI_ValidPassword(t *testing.T) {
@@ -1809,7 +1811,7 @@ func TestCheckRoute_WardenAuth_ValidPhone(t *testing.T) {
 
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
 		"X-User-Phone":           "13800138000",
-		"X-Stargate-Header-Auth": "trusted-proxy-secret",
+		"X-Stargate-Header-Auth": trustedHeaderAuthTestSecret,
 	}, "")
 	defer app.ReleaseCtx(ctx)
 
@@ -1909,7 +1911,7 @@ func TestCheckRoute_WardenAuth_ValidMail(t *testing.T) {
 
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
 		"X-User-Mail":            "user2@example.com",
-		"X-Stargate-Header-Auth": "trusted-proxy-secret",
+		"X-Stargate-Header-Auth": trustedHeaderAuthTestSecret,
 	}, "")
 	defer app.ReleaseCtx(ctx)
 
@@ -1981,7 +1983,7 @@ func TestCheckRoute_WardenAuth_InvalidUser(t *testing.T) {
 
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
 		"X-User-Phone":           "99999999999", // Not in list
-		"X-Stargate-Header-Auth": "trusted-proxy-secret",
+		"X-Stargate-Header-Auth": trustedHeaderAuthTestSecret,
 	}, "")
 	defer app.ReleaseCtx(ctx)
 
@@ -2109,7 +2111,7 @@ func TestCheckRoute_WardenAuth_WithBothHeaders(t *testing.T) {
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
 		"X-User-Phone":           "13800138000",
 		"X-User-Mail":            "user1@example.com",
-		"X-Stargate-Header-Auth": "trusted-proxy-secret",
+		"X-Stargate-Header-Auth": trustedHeaderAuthTestSecret,
 	}, "")
 	defer app.ReleaseCtx(ctx)
 
@@ -2195,7 +2197,7 @@ func TestCheckRoute_WardenAuth_WithCustomUserHeader(t *testing.T) {
 
 	ctx, app := createTestContext("GET", "/_auth", map[string]string{
 		"X-User-Phone":           "13800138000",
-		"X-Stargate-Header-Auth": "trusted-proxy-secret",
+		"X-Stargate-Header-Auth": trustedHeaderAuthTestSecret,
 	}, "")
 	defer app.ReleaseCtx(ctx)
 


### PR DESCRIPTION
## Summary

- validate configurable HTTP header names and reject collisions with routing, authentication, identity, and hop-by-hop headers
- require at least 32 characters for trusted header authentication secrets
- validate `AUTH_HOST` as a host or host:port without scheme or path
- reject public-suffix, IP, port-bearing, and unrelated `COOKIE_DOMAIN` values
- require Warden and Herald URLs to be service root URLs and normalize a single trailing slash
- document the shared-secret requirement across all seven configuration translations

## Security impact

This closes configuration combinations that could silently remove `X-Forwarded-Uri`, overwrite identity headers, weaken the proxy credential, broaden cookies beyond the authentication host, or build incorrect dependency health-check URLs.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `bash .github/scripts/check-doc-contracts.sh HEAD`
- `git diff --check`