### PR TITLE
fix: harden step-up flow and path validation

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -493,6 +493,16 @@ func Initialize(l *logger.Logger) error {
 	if StepUpEnabled.ToBool() && strings.TrimSpace(StepUpPaths.Value) == "" {
 		return NewValidationError(StepUpPaths.Name, "must contain at least one protected path when step-up is enabled", StepUpPaths.PossibleValues)
 	}
+	if StepUpEnabled.ToBool() {
+		for _, pattern := range strings.Split(StepUpPaths.Value, ",") {
+			if strings.TrimSpace(pattern) == "" {
+				continue
+			}
+			if !ValidStepUpPathPattern(pattern) {
+				return NewValidationError(StepUpPaths.Name, "must contain only local absolute path patterns without queries, fragments, backslashes, or dot segments", StepUpPaths.PossibleValues)
+			}
+		}
+	}
 	if StepUpEnabled.ToBool() && strings.TrimSpace(TrustedProxies.Value) == "" {
 		return NewValidationError(TrustedProxies.Name, "must identify the proxies allowed to provide the original request URI when step-up is enabled", TrustedProxies.PossibleValues)
 	}

--- a/src/internal/config/stepup.go
+++ b/src/internal/config/stepup.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -12,6 +13,25 @@ type StepUpMatcher struct {
 }
 
 var stepUpMatcher *StepUpMatcher
+
+// ValidStepUpPathPattern reports whether a configured step-up pattern is a
+// local absolute path without ambiguous dot segments or backslashes.
+func ValidStepUpPathPattern(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") || strings.ContainsAny(raw, "\\#") {
+		return false
+	}
+	parsed, err := url.ParseRequestURI(raw)
+	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return false
+	}
+	for _, segment := range strings.Split(parsed.Path, "/") {
+		if segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
+}
 
 // InitStepUpMatcher initializes the step-up path matcher
 func InitStepUpMatcher() {

--- a/src/internal/config/stepup_test.go
+++ b/src/internal/config/stepup_test.go
@@ -85,6 +85,22 @@ func TestInitializeStepUpRequiresTrustedProxy(t *testing.T) {
 	testza.AssertContains(t, err.Error(), "TRUSTED_PROXIES")
 }
 
+func TestInitializeRejectsUnsafeStepUpPathPatterns(t *testing.T) {
+	for _, paths := range []string{"admin", "//evil.example/admin", "/admin?tab=users", "/admin#users", `/admin\\users`, "/admin/../public", "/admin/%2e%2e/public"} {
+		t.Run(paths, func(t *testing.T) {
+			t.Setenv("AUTH_HOST", "auth.example.com")
+			t.Setenv("PASSWORDS", "plaintext:test123")
+			t.Setenv("STEP_UP_ENABLED", "true")
+			t.Setenv("STEP_UP_PATHS", paths)
+			t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+
+			err := Initialize(testLogger())
+			testza.AssertNotNil(t, err)
+			testza.AssertContains(t, err.Error(), "STEP_UP_PATHS")
+		})
+	}
+}
+
 func TestGetStepUpMatcher_NilInitializes(t *testing.T) {
 	// Ensure stepUpMatcher is nil by not calling InitStepUpMatcher in a fresh package state.
 	// GetStepUpMatcher() calls InitStepUpMatcher() if nil, so we need to have env set.

--- a/src/internal/handlers/step_up.go
+++ b/src/internal/handlers/step_up.go
@@ -21,7 +21,7 @@ func stepUpVerified(sess *session.Session) bool {
 }
 
 func requiresStepUp(ctx fiber.Ctx, sess *session.Session) bool {
-	if !config.StepUpEnabled.ToBool() || stepUpVerified(sess) {
+	if !config.StepUpEnabled.ToBool() || !auth.IsAuthenticated(sess) || stepUpVerified(sess) {
 		return false
 	}
 	raw, ok := stepUpForwardedURI(ctx)
@@ -51,17 +51,27 @@ func stepUpForwardedURI(ctx fiber.Ctx) (string, bool) {
 // matching the raw value lets `/admin?x=1` bypass an exact `/admin` rule.
 func stepUpRequestPath(raw string) (string, bool) {
 	parsed, err := url.ParseRequestURI(raw)
-	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.Path == "" || !strings.HasPrefix(parsed.Path, "/") {
+	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.Path == "" || !strings.HasPrefix(parsed.Path, "/") || strings.HasPrefix(parsed.Path, "//") || strings.Contains(parsed.Path, "\\") || hasDotPathSegment(parsed.Path) {
 		return "", false
 	}
 	return parsed.Path, true
 }
 
 func safeStepUpCallback(raw string) string {
-	if raw == "" || !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") {
+	parsed, err := url.ParseRequestURI(raw)
+	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.Path == "" || !strings.HasPrefix(parsed.Path, "/") || strings.HasPrefix(parsed.Path, "//") || strings.Contains(parsed.Path, "\\") || hasDotPathSegment(parsed.Path) || parsed.Fragment != "" {
 		return "/"
 	}
 	return raw
+}
+
+func hasDotPathSegment(path string) bool {
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "." || segment == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func redirectToStepUp(ctx fiber.Ctx) error {

--- a/src/internal/handlers/step_up_test.go
+++ b/src/internal/handlers/step_up_test.go
@@ -107,6 +107,8 @@ func TestRequiresStepUpUsesForwardedBusinessPath(t *testing.T) {
 	sess, err := store.Get(ctx)
 	testza.AssertNoError(t, err)
 
+	testza.AssertFalse(t, requiresStepUp(ctx, sess))
+	testza.AssertNoError(t, auth.Authenticate(sess))
 	testza.AssertTrue(t, requiresStepUp(ctx, sess))
 	sess.Set("step_up_verified_at", time.Now().Unix())
 	testza.AssertFalse(t, requiresStepUp(ctx, sess))
@@ -120,6 +122,7 @@ func TestRequiresStepUpIgnoresForwardedQuery(t *testing.T) {
 	defer app.ReleaseCtx(ctx)
 	sess, err := store.Get(ctx)
 	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
 
 	testza.AssertTrue(t, requiresStepUp(ctx, sess))
 }
@@ -129,6 +132,10 @@ func TestStepUpRequestPathRejectsInvalidURI(t *testing.T) {
 	testza.AssertFalse(t, ok)
 	_, ok = stepUpRequestPath("not-a-path")
 	testza.AssertFalse(t, ok)
+	for _, invalid := range []string{"//evil.example/admin", "/admin/../public", "/admin/%2e%2e/public", `/admin\\public`} {
+		_, ok = stepUpRequestPath(invalid)
+		testza.AssertFalse(t, ok)
+	}
 	path, ok := stepUpRequestPath("/admin?x=1")
 	testza.AssertTrue(t, ok)
 	testza.AssertEqual(t, "/admin", path)
@@ -142,6 +149,7 @@ func TestRequiresStepUpFailsClosedWithoutValidForwardedURI(t *testing.T) {
 		ctx, app := createTestContext("GET", "/_auth", map[string]string{"X-Forwarded-Uri": forwardedURI}, "")
 		sess, err := store.Get(ctx)
 		testza.AssertNoError(t, err)
+		testza.AssertNoError(t, auth.Authenticate(sess))
 		testza.AssertTrue(t, requiresStepUp(ctx, sess))
 		sess.Release()
 		app.ReleaseCtx(ctx)
@@ -174,5 +182,9 @@ func TestStepUpAPIRecordsRecentVerification(t *testing.T) {
 func TestSafeStepUpCallbackRejectsExternalURLs(t *testing.T) {
 	testza.AssertEqual(t, "/", safeStepUpCallback("https://evil.example"))
 	testza.AssertEqual(t, "/", safeStepUpCallback("//evil.example"))
+	testza.AssertEqual(t, "/", safeStepUpCallback("/admin/../public"))
+	testza.AssertEqual(t, "/", safeStepUpCallback("/admin/%2e%2e/public"))
+	testza.AssertEqual(t, "/", safeStepUpCallback(`/admin\\public`))
 	testza.AssertEqual(t, "/admin", safeStepUpCallback("/admin"))
+	testza.AssertEqual(t, "/admin?tab=users", safeStepUpCallback("/admin?tab=users"))
 }


### PR DESCRIPTION
## Summary

- skip step-up redirects for unauthenticated sessions so normal login can proceed
- reject unsafe step-up path patterns and callbacks containing external authorities, backslashes, or dot segments
- preserve valid local callback queries while matching configured paths without query strings

## Validation

- `go test ./src/internal/config ./src/internal/handlers`
- `git diff --check`