### PR TITLE
fix: enforce trusted proxy boundary for auth redirects

### DIFF
--- a/src/internal/handlers/check.go
+++ b/src/internal/handlers/check.go
@@ -35,6 +35,13 @@ func sanitizeTrustedIdentityHeaders(ctx fiber.Ctx) {
 	ctx.Request().Header.Del(config.HeaderAuthSecretHeader.String())
 }
 
+func handleNotAuthenticated(ctx fiber.Ctx) error {
+	if IsHTMLRequest(ctx) {
+		return ctx.Redirect().Status(fiber.StatusFound).To(BuildCallbackURL(ctx))
+	}
+	return SendErrorResponse(ctx, fiber.StatusUnauthorized, i18n.T(ctx, "error.auth_required"))
+}
+
 // SessionStoreForCheck is the minimal interface required by CheckRoute to get session.
 // *session.Store implements it; tests can pass a mock to simulate store.Get failure.
 type SessionStoreForCheck interface {
@@ -120,15 +127,15 @@ func CheckRoute(store SessionStoreForCheck) func(c fiber.Ctx) error {
 				if limitErr := rateLimitPasswordHeaderFailure(ctx); limitErr != nil {
 					return limitErr
 				}
-				return handler.HandleNotAuthenticated(faCtx)
+				return handleNotAuthenticated(ctx)
 			case forwardauth.ErrNotAuthenticated, forwardauth.ErrUserNotFound:
-				return handler.HandleNotAuthenticated(faCtx)
+				return handleNotAuthenticated(ctx)
 			case forwardauth.ErrStepUpRequired:
 				return handler.HandleStepUpRequired(faCtx)
 			case forwardauth.ErrSessionRequired:
-				return handler.HandleNotAuthenticated(faCtx)
+				return handleNotAuthenticated(ctx)
 			default:
-				return handler.HandleNotAuthenticated(faCtx)
+				return handleNotAuthenticated(ctx)
 			}
 		}
 

--- a/src/internal/handlers/check_test.go
+++ b/src/internal/handlers/check_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MarvinJWendt/testza"
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/session"
+	"github.com/soulteary/stargate/src/internal/config"
 )
 
 // TestCheckRoute_HandlerNil verifies that when GetForwardAuthHandler returns nil,
@@ -54,6 +55,54 @@ func TestCheckRoute_SessionStoreError(t *testing.T) {
 	testza.AssertTrue(t, len(body) > 0)
 	// Response may be JSON with translated message (e.g. "failed to access session store")
 	testza.AssertTrue(t, strings.Contains(body, "session_store_failed") || strings.Contains(body, "session store"), "body should indicate session store failure: %s", body)
+}
+
+func TestCheckRouteIgnoresForwardedRedirectHeadersFromUntrustedPeer(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com")
+	t.Setenv("TRUSTED_PROXIES", "")
+	testLogger := testLoggerCheckHeaders()
+	testza.AssertNoError(t, config.Initialize(testLogger))
+	InitForwardAuthHandler(testLogger)
+
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{
+		"Accept":            "text/html",
+		"Host":              "auth.example.com",
+		"X-Forwarded-Host":  "evil.example.net",
+		"X-Forwarded-Proto": "https",
+	}, "")
+	defer app.ReleaseCtx(ctx)
+
+	err := CheckRoute(setupTestStore())(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
+	location := string(ctx.Response().Header.Peek("Location"))
+	testza.AssertEqual(t, "http://auth.example.com/_login?callback=auth.example.com", location)
+	testza.AssertNotContains(t, location, "evil.example.net")
+}
+
+func TestCheckRouteUsesForwardedRedirectHeadersFromTrustedPeer(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com")
+	t.Setenv("TRUSTED_PROXIES", "0.0.0.0")
+	testLogger := testLoggerCheckHeaders()
+	testza.AssertNoError(t, config.Initialize(testLogger))
+	InitForwardAuthHandler(testLogger)
+
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{
+		"Accept":            "text/html",
+		"Host":              "auth.example.com",
+		"X-Forwarded-Host":  "app.example.com",
+		"X-Forwarded-Proto": "https",
+	}, "")
+	defer app.ReleaseCtx(ctx)
+
+	err := CheckRoute(setupTestStore())(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
+	testza.AssertEqual(t, "https://auth.example.com/_login?callback=app.example.com", string(ctx.Response().Header.Peek("Location")))
 }
 
 // Ensure *session.Store satisfies SessionStoreForCheck at compile time.


### PR DESCRIPTION
## Summary

- build unauthenticated login redirects through Stargate's trusted-proxy helpers
- validate callback hosts before including them in redirect URLs
- preserve translated 401 responses for non-HTML clients
- cover trusted and untrusted forwarded host/protocol behavior

## Validation

- `go test ./src/internal/handlers`
- `git diff --check`