### PR TITLE
fix: preserve one-time TOTP backup codes after confirmation

### DIFF
--- a/src/internal/handlers/totp_enroll.go
+++ b/src/internal/handlers/totp_enroll.go
@@ -138,13 +138,20 @@ func TOTPEnrollConfirmAPI(store *session.Store) func(c fiber.Ctx) error {
 			log.Warn().Err(err).Str("enroll_id", enrollID).Msg("TOTP enroll confirm failed")
 			return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ok": false, "error": "invalid_code"})
 		}
+		if confirmResp == nil {
+			log.Error().Str("enroll_id", enrollID).Msg("TOTP enroll confirm returned an empty response")
+			return ctx.Status(fiber.StatusBadGateway).JSON(fiber.Map{"ok": false, "error": "invalid_provider_response"})
+		}
 		if confirmResp.Subject != boundSubject || !confirmResp.TotpEnabled {
 			log.Error().Str("expected_subject", boundSubject).Str("confirmed_subject", confirmResp.Subject).Msg("TOTP enrollment subject mismatch")
 			return ctx.Status(fiber.StatusBadGateway).JSON(fiber.Map{"ok": false, "error": "enrollment_subject_mismatch"})
 		}
 		clearTOTPEnrollment(sess)
 		if err := sess.Save(); err != nil {
-			return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"ok": false, "error": "session_save_failed"})
+			// Herald has already completed enrollment and backup codes are only
+			// returned once. Preserve that authoritative result for the user;
+			// stale local enrollment metadata expires after a short interval.
+			log.Error().Err(err).Str("enroll_id", enrollID).Msg("Failed to clear completed TOTP enrollment from session")
 		}
 		return ctx.JSON(fiber.Map{
 			"ok":           true,

--- a/src/internal/handlers/totp_enroll_test.go
+++ b/src/internal/handlers/totp_enroll_test.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +18,25 @@ import (
 	"github.com/soulteary/stargate/src/internal/config"
 	"github.com/soulteary/stargate/src/internal/i18n"
 )
+
+type failSetStorage struct {
+	fiber.Storage
+	fail bool
+}
+
+func (s *failSetStorage) Set(key string, value []byte, expiration time.Duration) error {
+	if s.fail {
+		return errors.New("injected session write failure")
+	}
+	return s.Storage.Set(key, value, expiration)
+}
+
+func (s *failSetStorage) SetWithContext(ctx context.Context, key string, value []byte, expiration time.Duration) error {
+	if s.fail {
+		return errors.New("injected session write failure")
+	}
+	return s.Storage.SetWithContext(ctx, key, value, expiration)
+}
 
 func TestTOTPEnrollRoute_NotAuthenticated_Redirects(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
@@ -250,6 +271,56 @@ func TestTOTPEnrollConfirmAPI_RejectsUnboundEnrollment(t *testing.T) {
 	testza.AssertNoError(t, handler(ctx))
 	testza.AssertEqual(t, fiber.StatusBadRequest, ctx.Response().StatusCode())
 	testza.AssertContains(t, string(ctx.Response().Body()), "invalid_enrollment")
+}
+
+func TestTOTPEnrollConfirmAPIReturnsBackupCodesWhenSessionCleanupFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/totp/enroll/confirm" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(herald.TOTPEnrollConfirmResponse{
+			Subject:     "u_test",
+			TotpEnabled: true,
+			BackupCodes: []string{"backup-1", "backup-2"},
+		})
+	}))
+	defer server.Close()
+
+	ResetHeraldClientForTest()
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("HERALD_ENABLED", "true")
+	t.Setenv("HERALD_URL", server.URL)
+	t.Setenv("HERALD_TOTP_ENABLED", "true")
+	testza.AssertNoError(t, config.Initialize(testLogger()))
+	testza.AssertNoError(t, InitHeraldClient(testLogger()))
+
+	store := setupTestStore()
+	failingStorage := &failSetStorage{Storage: store.Storage}
+	store.Storage = failingStorage
+	ctx, app := createTestContext("POST", "/totp/enroll/confirm", map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}, "enroll_id=e1&code=123456")
+	defer app.ReleaseCtx(ctx)
+
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	sess.Set("user_id", "u_test")
+	sess.Set(totpEnrollmentIDKey, "e1")
+	sess.Set(totpEnrollmentSubjectKey, "u_test")
+	sess.Set(totpEnrollmentStartedKey, time.Now().Unix())
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	testza.AssertNoError(t, sess.Save())
+	ctx.Request().Header.SetCookie(auth.SessionCookieName, sess.ID())
+	failingStorage.fail = true
+
+	testza.AssertNoError(t, TOTPEnrollConfirmAPI(store)(ctx))
+	testza.AssertEqual(t, fiber.StatusOK, ctx.Response().StatusCode())
+	testza.AssertContains(t, string(ctx.Response().Body()), "backup-1")
+	testza.AssertContains(t, string(ctx.Response().Body()), "backup-2")
+	testza.AssertNotContains(t, string(ctx.Response().Body()), "session_save_failed")
 }
 
 func TestTOTPEnrollRequiresRecentAuthentication(t *testing.T) {


### PR DESCRIPTION
## Summary

- treat Herald's successful TOTP confirmation as authoritative
- return one-time backup codes even when local session cleanup cannot be persisted
- log the cleanup failure while allowing the short-lived enrollment metadata to expire
- reject an impossible empty provider response and cover the session-write failure path

## Validation

- `go test ./src/internal/handlers -run 'TOTPEnroll' -count=1`
- `git diff --check`