### PR TITLE
fix: align response-header and audit-format contracts

### DIFF
--- a/src/internal/auditlog/auditlog.go
+++ b/src/internal/auditlog/auditlog.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 
 	audit "github.com/soulteary/audit-kit"
@@ -45,7 +46,7 @@ func InitDefault() error {
 		Init(audit.NewNoopStorage(), cfg)
 		return nil
 	}
-	format := config.AuditLogFormat.String()
+	format := strings.ToLower(strings.TrimSpace(config.AuditLogFormat.String()))
 	if format != "json" && format != "text" {
 		return fmt.Errorf("unsupported audit log format %q", format)
 	}

--- a/src/internal/auditlog/auditlog_test.go
+++ b/src/internal/auditlog/auditlog_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	audit "github.com/soulteary/audit-kit"
+	"github.com/soulteary/stargate/src/internal/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -90,6 +91,25 @@ func TestStreamStorageHonorsFormats(t *testing.T) {
 	assert.NoError(t, NewStreamStorage(&textOutput, "text").Write(context.Background(), record))
 	assert.Contains(t, textOutput.String(), "event=")
 	assert.Contains(t, textOutput.String(), "user_id=\"user1\"")
+}
+
+func TestInitDefaultAcceptsCaseInsensitiveFormat(t *testing.T) {
+	previousEnabled := config.AuditLogEnabled.Value
+	previousFormat := config.AuditLogFormat.Value
+	t.Cleanup(func() {
+		config.AuditLogEnabled.Value = previousEnabled
+		config.AuditLogFormat.Value = previousFormat
+		logger = nil
+		loggerInit = sync.Once{}
+	})
+	config.AuditLogEnabled.Value = "true"
+	config.AuditLogFormat.Value = " TEXT "
+	logger = nil
+	loggerInit = sync.Once{}
+
+	assert.NoError(t, InitDefault())
+	assert.NotNil(t, GetLogger())
+	assert.NoError(t, Stop())
 }
 
 func TestStop_WhenLoggerNil(t *testing.T) {

--- a/src/internal/config/strict_validation.go
+++ b/src/internal/config/strict_validation.go
@@ -114,6 +114,8 @@ func validateHeaderContracts() error {
 		"authorization": {}, "connection": {}, "content-length": {}, "cookie": {},
 		"host": {}, "proxy-authorization": {}, "set-cookie": {}, "stargate-password": {},
 		"te": {}, "trailer": {}, "transfer-encoding": {}, "upgrade": {},
+		"x-auth-amr": {}, "x-auth-email": {}, "x-auth-name": {},
+		"x-auth-role": {}, "x-auth-scopes": {}, "x-auth-user": {},
 		"x-forwarded-host": {}, "x-forwarded-proto": {}, "x-forwarded-uri": {},
 		"x-user-mail": {}, "x-user-phone": {},
 	}

--- a/src/internal/config/strict_validation_test.go
+++ b/src/internal/config/strict_validation_test.go
@@ -157,6 +157,9 @@ func TestValidateStrictSettingsRejectsHeaderCollisions(t *testing.T) {
 		{configure: func() { HeaderAuthSecretHeader.Value = "X-Forwarded-Uri" }, key: HeaderAuthSecretHeader.Name},
 		{configure: func() { HeaderAuthSecretHeader.Value = "invalid header" }, key: HeaderAuthSecretHeader.Name},
 		{configure: func() { UserHeaderName.Value = "Authorization" }, key: UserHeaderName.Name},
+		{configure: func() { UserHeaderName.Value = "X-Auth-Email" }, key: UserHeaderName.Name},
+		{configure: func() { ProxyHeader.Value = "x-auth-amr" }, key: ProxyHeader.Name},
+		{configure: func() { HeaderAuthSecretHeader.Value = "X-Auth-User" }, key: HeaderAuthSecretHeader.Name},
 		{configure: func() { ProxyHeader.Value = UserHeaderName.Value }, key: ProxyHeader.Name},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- reject configurable headers that collide with Stargate's fixed `X-Auth-*` response headers
- normalize the documented case-insensitive audit format before initializing stream storage
- cover collisions across user, proxy, and trusted-header settings
- cover uppercase audit format initialization

## Validation

- `go test ./src/internal/config ./src/internal/auditlog`
- `git diff --check`