### PR TITLE
fix: issue valid session cookies for cross-root-domain callbacks

### DIFF
--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -683,6 +683,35 @@ func TestSessionShareRoute_WithoutCookieDomain(t *testing.T) {
 	testza.AssertContains(t, cookieStr, sessionID)
 }
 
+func TestSessionShareRouteUsesHostOnlyCookieAcrossRootDomains(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("COOKIE_DOMAIN", ".example.com")
+	t.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.net")
+	t.Setenv("SESSION_EXCHANGE_SECRET", "0123456789abcdef0123456789abcdef")
+	testza.AssertNoError(t, config.Initialize(testLogger()))
+
+	store := setupTestStore()
+	seedCtx, seedApp := createTestContext("GET", "/", nil, "")
+	sess, err := store.Get(seedCtx)
+	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	sessionID := responseCookieValue(seedCtx, auth.SessionCookieName)
+	testza.AssertNotEqual(t, "", sessionID)
+	ticket, err := createSessionExchangeTicket(sessionID, "app.example.net")
+	testza.AssertNoError(t, err)
+	seedApp.ReleaseCtx(seedCtx)
+
+	ctx, app := createTestContext("GET", "/_session_exchange?ticket="+ticket, map[string]string{"Host": "app.example.net"}, "")
+	defer app.ReleaseCtx(ctx)
+	testza.AssertNoError(t, SessionShareRoute(store)(ctx))
+	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
+	cookie := string(ctx.Response().Header.Peek("Set-Cookie"))
+	testza.AssertContains(t, cookie, auth.SessionCookieName)
+	testza.AssertContains(t, cookie, sessionID)
+	testza.AssertNotContains(t, strings.ToLower(cookie), "domain=")
+}
+
 func TestCheckRoute_SetsUserHeader(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")

--- a/src/internal/handlers/session_share.go
+++ b/src/internal/handlers/session_share.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"strings"
+
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/session"
 
@@ -23,21 +25,13 @@ func SessionShareRoute(store *session.Store, replayStores ...SessionExchangeRepl
 	if len(replayStores) > 0 && replayStores[0] != nil {
 		replayStore = replayStores[0]
 	}
-	// Create session config for cookie creation
-	sessionConfig := sessionkit.DefaultConfig().
-		WithCookieName(auth.SessionCookieName).
-		WithExpiration(config.SessionExpiration).
-		WithCookieDomain(config.CookieDomain.Value).
-		WithSecure(config.CookieSecure.ToBool()).
-		WithSameSite("Lax").
-		WithHTTPOnly(true)
-
 	return func(ctx fiber.Ctx) error {
 		ticket := ctx.Query("ticket")
 		if ticket == "" {
 			return SendErrorResponse(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.missing_session_id"))
 		}
-		sessionID, err := consumeSessionExchangeTicketWithStore(ctx.Context(), ticket, GetForwardedHost(ctx), replayStore)
+		targetHost := GetForwardedHost(ctx)
+		sessionID, err := consumeSessionExchangeTicketWithStore(ctx.Context(), ticket, targetHost, replayStore)
 		if err != nil {
 			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "invalid session exchange ticket")
 		}
@@ -52,10 +46,34 @@ func SessionShareRoute(store *session.Store, replayStores ...SessionExchangeRepl
 			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "invalid session exchange ticket")
 		}
 
+		// A Domain cookie is valid only when the exchange target belongs to that
+		// domain. Cross-root-domain callbacks receive a host-only cookie.
+		sessionConfig := sessionkit.DefaultConfig().
+			WithCookieName(auth.SessionCookieName).
+			WithExpiration(config.SessionExpiration).
+			WithSecure(config.CookieSecure.ToBool()).
+			WithSameSite("Lax").
+			WithHTTPOnly(true)
+		if cookieDomain := sessionCookieDomainForHost(targetHost, config.CookieDomain.Value); cookieDomain != "" {
+			sessionConfig = sessionConfig.WithCookieDomain(cookieDomain)
+		}
+
 		// Use session-kit's CreateCookie for consistent cookie creation
 		cookie := sessionkit.CreateCookie(sessionConfig, sessionID)
 		ctx.Cookie(cookie)
 
 		return ctx.Redirect().Status(fiber.StatusFound).To("/")
 	}
+}
+
+func sessionCookieDomainForHost(host, configuredDomain string) string {
+	domain := strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(configuredDomain), "."), "."))
+	hostname := normalizeHost(host)
+	if domain == "" || hostname == "" {
+		return ""
+	}
+	if hostname == domain || strings.HasSuffix(hostname, "."+domain) {
+		return configuredDomain
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary

- apply `COOKIE_DOMAIN` only when the session-exchange target is that domain or one of its subdomains
- issue a host-only session cookie for explicitly allowed callbacks on another root domain
- use one normalized target host for ticket audience validation and cookie scoping
- add a regression test for cross-root-domain exchange

## Validation

- `go test ./src/internal/handlers -run 'SessionShareRoute' -count=1`
- `git diff --check`