### PR TITLE
fix: make dependency readiness checks TLS-aware

### DIFF
--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -26,6 +27,7 @@ import (
 	"github.com/soulteary/stargate/src/internal/handlers"
 	"github.com/soulteary/stargate/src/internal/i18n"
 	"github.com/soulteary/stargate/src/internal/metrics"
+	internal_tls "github.com/soulteary/stargate/src/internal/tlsconfig"
 	internal_tracing "github.com/soulteary/stargate/src/internal/tracing"
 )
 
@@ -160,8 +162,16 @@ func setupHealthChecker(redisClient *redis.Client) *health.Aggregator {
 	if config.HeraldEnabled.ToBool() {
 		heraldURL := config.HeraldURL.String()
 		if heraldURL != "" {
-			aggregator.AddChecker(health.NewHTTPChecker("herald", heraldURL+"/healthz").
-				WithTimeout(2 * time.Second))
+			client, err := internal_tls.HTTPClient(
+				"Herald", config.HeraldTLSCACertFile.String(), config.HeraldTLSClientCert.String(),
+				config.HeraldTLSClientKey.String(), config.HeraldTLSServerName.String(), 2*time.Second,
+			)
+			if err != nil {
+				aggregator.AddChecker(health.NewCustomChecker("herald", func(_ context.Context) error { return err }))
+			} else {
+				aggregator.AddChecker(health.NewHTTPChecker("herald", heraldURL+"/healthz").
+					WithTimeout(2 * time.Second).WithClient(client))
+			}
 		} else {
 			aggregator.AddChecker(health.NewDisabledChecker("herald").
 				WithMessage("Herald URL not configured"))
@@ -175,8 +185,16 @@ func setupHealthChecker(redisClient *redis.Client) *health.Aggregator {
 	if config.WardenEnabled.ToBool() {
 		wardenURL := config.WardenURL.String()
 		if wardenURL != "" {
-			aggregator.AddChecker(health.NewHTTPChecker("warden", wardenURL+"/health").
-				WithTimeout(2 * time.Second))
+			client, err := internal_tls.HTTPClient(
+				"Warden", config.WardenTLSCACertFile.String(), config.WardenTLSClientCert.String(),
+				config.WardenTLSClientKey.String(), config.WardenTLSServerName.String(), 2*time.Second,
+			)
+			if err != nil {
+				aggregator.AddChecker(health.NewCustomChecker("warden", func(_ context.Context) error { return err }))
+			} else {
+				aggregator.AddChecker(health.NewHTTPChecker("warden", wardenURL+"/health").
+					WithTimeout(2 * time.Second).WithClient(client))
+			}
 		} else {
 			aggregator.AddChecker(health.NewDisabledChecker("warden").
 				WithMessage("Warden URL not configured"))

--- a/src/cmd/stargate/server_test.go
+++ b/src/cmd/stargate/server_test.go
@@ -210,6 +210,27 @@ func TestSetupHealthChecker_Combinations(t *testing.T) {
 	}
 }
 
+func TestSetupHealthCheckerReportsTLSConfigurationFailure(t *testing.T) {
+	setupTestConfig(t)
+	previousEnabled := config.HeraldEnabled.Value
+	previousURL := config.HeraldURL.Value
+	previousCA := config.HeraldTLSCACertFile.Value
+	t.Cleanup(func() {
+		config.HeraldEnabled.Value = previousEnabled
+		config.HeraldURL.Value = previousURL
+		config.HeraldTLSCACertFile.Value = previousCA
+	})
+	config.HeraldEnabled.Value = "true"
+	config.HeraldURL.Value = "https://herald.example.com"
+	config.HeraldTLSCACertFile.Value = filepath.Join(t.TempDir(), "missing-ca.pem")
+
+	result := setupHealthChecker(nil).Check(context.Background())
+	heraldResult, ok := result.Checks["herald"]
+	testza.AssertTrue(t, ok)
+	testza.AssertEqual(t, health.StatusUnhealthy, heraldResult.Status)
+	testza.AssertContains(t, heraldResult.Error, "read Herald CA certificate")
+}
+
 func TestSetupRoutes(t *testing.T) {
 	setupTestConfig(t)
 

--- a/src/internal/auth/auth.go
+++ b/src/internal/auth/auth.go
@@ -4,9 +4,7 @@ package auth
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +16,7 @@ import (
 	secure "github.com/soulteary/secure-kit"
 	session "github.com/soulteary/session-kit/v2"
 	"github.com/soulteary/stargate/src/internal/config"
+	internal_tls "github.com/soulteary/stargate/src/internal/tlsconfig"
 	"github.com/soulteary/warden/pkg/warden"
 )
 
@@ -204,36 +203,7 @@ func InitWardenClient(l *logger.Logger) error {
 }
 
 func buildWardenTLSConfig(caFile, certFile, keyFile, serverName string) (*tls.Config, error) {
-	if caFile == "" && certFile == "" && keyFile == "" && serverName == "" {
-		return nil, nil
-	}
-	if (certFile == "") != (keyFile == "") {
-		return nil, fmt.Errorf("WARDEN_TLS_CLIENT_CERT_FILE and WARDEN_TLS_CLIENT_KEY_FILE must be configured together")
-	}
-
-	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, ServerName: serverName}
-	if caFile != "" {
-		pem, err := os.ReadFile(caFile)
-		if err != nil {
-			return nil, fmt.Errorf("read Warden CA certificate: %w", err)
-		}
-		roots, err := x509.SystemCertPool()
-		if err != nil || roots == nil {
-			roots = x509.NewCertPool()
-		}
-		if !roots.AppendCertsFromPEM(pem) {
-			return nil, fmt.Errorf("WARDEN_TLS_CA_CERT_FILE contains no valid certificates")
-		}
-		tlsConfig.RootCAs = roots
-	}
-	if certFile != "" {
-		certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
-		if err != nil {
-			return nil, fmt.Errorf("load Warden client certificate: %w", err)
-		}
-		tlsConfig.Certificates = []tls.Certificate{certificate}
-	}
-	return tlsConfig, nil
+	return internal_tls.Build("Warden", caFile, certFile, keyFile, serverName)
 }
 
 // getWardenClient returns the warden client.

--- a/src/internal/tlsconfig/tlsconfig.go
+++ b/src/internal/tlsconfig/tlsconfig.go
@@ -1,0 +1,56 @@
+package tlsconfig
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Build creates a client-side TLS configuration from the certificate settings
+// shared by service SDKs and readiness checks.
+func Build(service, caFile, certFile, keyFile, serverName string) (*tls.Config, error) {
+	if caFile == "" && certFile == "" && keyFile == "" && serverName == "" {
+		return nil, nil
+	}
+	if (certFile == "") != (keyFile == "") {
+		return nil, fmt.Errorf("%s TLS client certificate and key must be configured together", service)
+	}
+
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, ServerName: serverName}
+	if caFile != "" {
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("read %s CA certificate: %w", service, err)
+		}
+		roots, err := x509.SystemCertPool()
+		if err != nil || roots == nil {
+			roots = x509.NewCertPool()
+		}
+		if !roots.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("%s TLS CA certificate file contains no valid certificates", service)
+		}
+		tlsConfig.RootCAs = roots
+	}
+	if certFile != "" {
+		certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load %s client certificate: %w", service, err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{certificate}
+	}
+	return tlsConfig, nil
+}
+
+// HTTPClient builds an HTTP client that uses the supplied TLS configuration.
+func HTTPClient(service, caFile, certFile, keyFile, serverName string, timeout time.Duration) (*http.Client, error) {
+	tlsConfig, err := Build(service, caFile, certFile, keyFile, serverName)
+	if err != nil {
+		return nil, err
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	return &http.Client{Transport: transport, Timeout: timeout}, nil
+}

--- a/src/internal/tlsconfig/tlsconfig_test.go
+++ b/src/internal/tlsconfig/tlsconfig_test.go
@@ -1,0 +1,37 @@
+package tlsconfig
+
+import (
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MarvinJWendt/testza"
+)
+
+func TestHTTPClientUsesConfiguredCA(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.TLS.Certificates[0].Certificate[0]})
+	testza.AssertNoError(t, os.WriteFile(caFile, certificate, 0o600))
+
+	client, err := HTTPClient("test service", caFile, "", "", "", time.Second)
+	testza.AssertNoError(t, err)
+	resp, err := client.Get(server.URL)
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, http.StatusOK, resp.StatusCode)
+	testza.AssertNoError(t, resp.Body.Close())
+}
+
+func TestBuildRejectsIncompleteClientCertificatePair(t *testing.T) {
+	_, err := Build("test service", "", "client.pem", "", "")
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "configured together")
+}


### PR DESCRIPTION
## Summary

- share client-side CA, mTLS, minimum TLS version, and server-name construction
- apply Herald and Warden TLS settings to their readiness HTTP clients
- report TLS client construction failures as unhealthy dependency checks
- retain the Warden SDK's existing TLS behavior through the shared builder

## Validation

- `go test ./src/internal/tlsconfig ./src/internal/auth ./src/cmd/stargate`
- `git diff --check`