### PR TITLE
docs: make Traefik deployment examples match the v1 contract

### DIFF
--- a/README.deDE.md
+++ b/README.deDE.md
@@ -168,6 +168,7 @@ PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Cross-Domain-Sitzungsteilung
 COOKIE_DOMAIN=.example.com
+SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 
 # Login-Seite anpassen
 LOGIN_PAGE_TITLE='Mein Auth-Service'

--- a/README.frFR.md
+++ b/README.frFR.md
@@ -168,6 +168,7 @@ PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Partage de session cross-domain
 COOKIE_DOMAIN=.example.com
+SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 
 # Personnaliser la page de connexion
 LOGIN_PAGE_TITLE="Mon Service d'Authentification"

--- a/README.itIT.md
+++ b/README.itIT.md
@@ -168,6 +168,7 @@ PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Condivisione sessioni cross-domain
 COOKIE_DOMAIN=.example.com
+SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 
 # Personalizza pagina di login
 LOGIN_PAGE_TITLE='Il Mio Servizio di Autenticazione'

--- a/README.jaJP.md
+++ b/README.jaJP.md
@@ -168,6 +168,7 @@ PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # クロスドメインセッション共有
 COOKIE_DOMAIN=.example.com
+SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 
 # ログインページをカスタマイズ
 LOGIN_PAGE_TITLE='私の認証サービス'

--- a/README.koKR.md
+++ b/README.koKR.md
@@ -168,6 +168,7 @@ PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # 크로스 도메인 세션 공유
 COOKIE_DOMAIN=.example.com
+SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 
 # 로그인 페이지 사용자 정의
 LOGIN_PAGE_TITLE='내 인증 서비스'

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # Cross-domain session sharing
 COOKIE_DOMAIN=.example.com
+SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 
 # Customize login page
 LOGIN_PAGE_TITLE='My Auth Service'

--- a/README.zhCN.md
+++ b/README.zhCN.md
@@ -164,6 +164,7 @@ PASSWORDS='bcrypt:$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy'
 
 # 跨域会话共享
 COOKIE_DOMAIN=.example.com
+SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 
 # 自定义登录页面
 LOGIN_PAGE_TITLE='我的认证服务'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - PASSWORDS=plaintext:test1234|test1337 # Replace with your passwords. See the docs for more info.
       - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - TRUSTED_PROXIES=${TRUSTED_PROXIES:-172.30.0.0/24} # Set this to the actual Traefik network CIDR.
       - COOKIE_SECURE=false # Local HTTP only. Keep the default true in HTTPS deployments.
       - PORT=8080
     read_only: true
@@ -35,6 +36,7 @@ services:
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`) # Replace auth.test.localhost with your auth host defined above.
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
   whoami: # A demo whoami service that is protected with Stargate
     image: traefik/whoami:v1.11.0

--- a/docs/deDE/DEPLOYMENT.md
+++ b/docs/deDE/DEPLOYMENT.md
@@ -171,14 +171,19 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
+      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
+      - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
     networks:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
   whoami:
     image: traefik/whoami
@@ -186,7 +191,7 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.whoami.entrypoints=http
       - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
       - "traefik.http.routers.whoami.middlewares=stargate"
@@ -229,9 +234,11 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
       - DEBUG=false
       - LANGUAGE=de
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 ## Traefik-Integration
@@ -251,6 +258,7 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
     networks:
       - traefik
     labels:
@@ -259,7 +267,7 @@ services:
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
       - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
-      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 #### 2. Geschützte Dienste konfigurieren
@@ -316,6 +324,7 @@ services:
   stargate:
     environment:
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 2. Stellen Sie sicher, dass alle zugehörigen Domains über Traefik zu Stargate geroutet werden
@@ -572,6 +581,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 # Sicherstellen, dass die Middleware-Adresse korrekt ist
 - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 ### Debug-Tipps

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -173,15 +173,17 @@ services:
       - PASSWORDS=plaintext:test1234|test1337
       - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
       - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
     networks:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
   whoami:
     image: traefik/whoami
@@ -189,7 +191,7 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.whoami.entrypoints=http
       - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
       - "traefik.http.routers.whoami.middlewares=stargate"
@@ -232,9 +234,11 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
       - DEBUG=false
       - LANGUAGE=zh
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 ## Traefik Integration
@@ -254,6 +258,7 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
     networks:
       - traefik
     labels:
@@ -262,7 +267,7 @@ services:
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
       - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
-      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 #### 2. Configure Protected Services
@@ -319,6 +324,7 @@ services:
   stargate:
     environment:
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 2. Ensure all related domains are routed to Stargate via Traefik
@@ -575,6 +581,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 # Ensure middleware address is correct
 - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 ### Debugging Tips

--- a/docs/frFR/DEPLOYMENT.md
+++ b/docs/frFR/DEPLOYMENT.md
@@ -171,14 +171,19 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
+      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
+      - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
     networks:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
   whoami:
     image: traefik/whoami
@@ -186,7 +191,7 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.whoami.entrypoints=http
       - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
       - "traefik.http.routers.whoami.middlewares=stargate"
@@ -229,9 +234,11 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
       - DEBUG=false
       - LANGUAGE=fr
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 ## Intégration Traefik
@@ -251,6 +258,7 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
     networks:
       - traefik
     labels:
@@ -259,7 +267,7 @@ services:
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
       - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
-      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 #### 2. Configurer les Services Protégés
@@ -316,6 +324,7 @@ services:
   stargate:
     environment:
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 2. S'assurer que tous les domaines associés sont routés vers Stargate via Traefik
@@ -572,6 +581,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 # S'assurer que l'adresse du middleware est correcte
 - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 ### Conseils de Débogage

--- a/docs/itIT/DEPLOYMENT.md
+++ b/docs/itIT/DEPLOYMENT.md
@@ -171,14 +171,19 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
+      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
+      - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
     networks:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
   whoami:
     image: traefik/whoami
@@ -186,7 +191,7 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.whoami.entrypoints=http
       - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
       - "traefik.http.routers.whoami.middlewares=stargate"
@@ -229,9 +234,11 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
       - DEBUG=false
       - LANGUAGE=it
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 ## Integrazione Traefik
@@ -251,6 +258,7 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
     networks:
       - traefik
     labels:
@@ -259,7 +267,7 @@ services:
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
       - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
-      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 #### 2. Configurare i Servizi Protetti
@@ -316,6 +324,7 @@ services:
   stargate:
     environment:
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 2. Assicurarsi che tutti i domini associati siano instradati verso Stargate tramite Traefik
@@ -572,6 +581,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 # Assicurarsi che l'indirizzo middleware sia corretto
 - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 ### Suggerimenti Debug

--- a/docs/jaJP/DEPLOYMENT.md
+++ b/docs/jaJP/DEPLOYMENT.md
@@ -171,14 +171,19 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
+      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
+      - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
     networks:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
   whoami:
     image: traefik/whoami
@@ -186,7 +191,7 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.whoami.entrypoints=http
       - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
       - "traefik.http.routers.whoami.middlewares=stargate"
@@ -229,9 +234,11 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
       - DEBUG=false
       - LANGUAGE=ja
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 ## Traefik 統合
@@ -251,6 +258,7 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
     networks:
       - traefik
     labels:
@@ -259,7 +267,7 @@ services:
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
       - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
-      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 #### 2. 保護されたサービスの設定
@@ -316,6 +324,7 @@ services:
   stargate:
     environment:
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 2. 関連するすべてのドメインが Traefik 経由で Stargate にルーティングされていることを確認
@@ -572,6 +581,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 # ミドルウェアのアドレスが正しいことを確認
 - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 ### デバッグのヒント

--- a/docs/koKR/DEPLOYMENT.md
+++ b/docs/koKR/DEPLOYMENT.md
@@ -171,14 +171,19 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
+      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
+      - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
     networks:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
   whoami:
     image: traefik/whoami
@@ -186,7 +191,7 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.whoami.entrypoints=http
       - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
       - "traefik.http.routers.whoami.middlewares=stargate"
@@ -229,9 +234,11 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
       - DEBUG=false
       - LANGUAGE=ko
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 ## Traefik 통합
@@ -251,6 +258,7 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
     networks:
       - traefik
     labels:
@@ -259,7 +267,7 @@ services:
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
       - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
-      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 #### 2. 보호된 서비스 설정
@@ -316,6 +324,7 @@ services:
   stargate:
     environment:
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 2. 관련된 모든 도메인이 Traefik을 통해 Stargate로 라우팅되는지 확인
@@ -572,6 +581,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 # 미들웨어의 주소가 올바른지 확인
 - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 ### 디버깅 팁

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -173,15 +173,17 @@ services:
       - PASSWORDS=plaintext:test1234|test1337
       - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
       - COOKIE_SECURE=false # 仅本地 HTTP；HTTPS 部署请省略。
     networks:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.auth.entrypoints=http
       - traefik.http.routers.auth.rule=Host(`auth.test.localhost`) || Path(`/_session_exchange`)
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
   whoami:
     image: traefik/whoami
@@ -189,7 +191,7 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.docker.network=proxy
+      - traefik.docker.network=traefik
       - traefik.http.routers.whoami.entrypoints=http
       - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
       - "traefik.http.routers.whoami.middlewares=stargate"
@@ -220,6 +222,7 @@ services:
       - DEBUG=false
       - LANGUAGE=zh
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
     networks:
       - traefik
       - internal
@@ -232,6 +235,7 @@ services:
       - traefik.http.routers.auth.entrypoints=http,https
       - traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
   # Warden 用户白名单服务
   warden:
@@ -340,9 +344,11 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
       - DEBUG=false
       - LANGUAGE=zh
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 ## Traefik 集成
@@ -362,6 +368,7 @@ services:
     environment:
       - AUTH_HOST=auth.example.com
       - PASSWORDS=bcrypt:$$2a$$10$$...
+      - TRUSTED_PROXIES=172.30.0.0/24 # Replace with the actual Traefik network CIDR.
     networks:
       - traefik
     labels:
@@ -370,7 +377,7 @@ services:
       - "traefik.http.routers.auth.entrypoints=http,https"
       - "traefik.http.routers.auth.rule=Host(`auth.example.com`) || Path(`/_session_exchange`)"
       - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
-      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User"
+      - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 #### 2. 配置受保护的服务
@@ -427,6 +434,7 @@ services:
   stargate:
     environment:
       - COOKIE_DOMAIN=.example.com
+      - SESSION_EXCHANGE_SECRET=replace-with-at-least-32-random-characters
 ```
 
 2. 确保所有相关域名都通过 Traefik 路由到 Stargate
@@ -683,6 +691,7 @@ COOKIE_DOMAIN=.example.com
 ```yaml
 # 确保中间件地址正确
 - "traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth"
+- "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 ```
 
 #### 5. Warden 服务问题


### PR DESCRIPTION
## Summary

- use the declared `traefik` Docker network consistently in all seven deployment guides
- forward the complete stable identity-header set from ForwardAuth
- document the Traefik network CIDR as `TRUSTED_PROXIES`
- pair cross-domain cookie examples with a required session-exchange secret
- update the root Compose example with the same proxy and response-header contract

## Validation

- `bash .github/scripts/check-doc-contracts.sh`
- `git diff --check`

Docker CLI is not available in the authoring environment; repository CI remains responsible for Compose validation.