### PR TITLE
ci: avoid heavy main jobs for documentation-only merges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,11 @@ name: Main validation
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,9 @@ jobs:
           git fetch origin main
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
+      - name: Check documentation contracts
+        run: bash .github/scripts/check-doc-contracts.sh
+
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:


### PR DESCRIPTION
## Summary

- skip main-branch race, coverage, Redis integration, artifact, and Codecov work for documentation-only pushes
- keep workflow and contract-script changes on the full validation path
- run the documentation contract checker before release assets are built and published
- preserve manual Main validation dispatch

## Validation

- `bash .github/scripts/check-doc-contracts.sh`
- parsed both edited workflow files as YAML
- `git diff --check`