### PR TITLE
fix: enforce step-up for stateless authentication

### DIFF
--- a/src/internal/handlers/check.go
+++ b/src/internal/handlers/check.go
@@ -139,6 +139,26 @@ func CheckRoute(store SessionStoreForCheck) func(c fiber.Ctx) error {
 			}
 		}
 
+		// Header and password authentication are stateless. They are evaluated by
+		// forwardauth-kit after the session-only check above, so enforce the path
+		// policy again after a successful authentication result. A protected path
+		// requires a session because that is where the recent verification marker
+		// is stored.
+		if stepUpApplies(ctx) {
+			if !stepUpVerified(sess) {
+				if auth.IsAuthenticated(sess) {
+					return redirectToStepUp(ctx)
+				}
+				return SendErrorResponse(ctx, fiber.StatusForbidden, "step-up requires an authenticated session")
+			}
+			// A verification marker belongs to the session identity that created it.
+			// Password and trusted-header checkers run before the session checker, so
+			// never let a stateless result borrow a verified session's marker.
+			if result.AuthMethod != forwardauth.AuthMethodSession {
+				return SendErrorResponse(ctx, fiber.StatusForbidden, "step-up verification does not match the authentication identity")
+			}
+		}
+
 		// Set authentication headers
 		handler.SetAuthHeaders(faCtx, result)
 

--- a/src/internal/handlers/check_test.go
+++ b/src/internal/handlers/check_test.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/MarvinJWendt/testza"
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/session"
+	"github.com/soulteary/stargate/src/internal/auth"
 	"github.com/soulteary/stargate/src/internal/config"
 )
 
@@ -103,6 +105,89 @@ func TestCheckRouteUsesForwardedRedirectHeadersFromTrustedPeer(t *testing.T) {
 	testza.AssertNoError(t, err)
 	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
 	testza.AssertEqual(t, "https://auth.example.com/_login?callback=app.example.com", string(ctx.Response().Header.Peek("Location")))
+}
+
+func TestCheckRouteRejectsStatelessPasswordOnStepUpPath(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("PASSWORD_HEADER_AUTH_ENABLED", "true")
+	t.Setenv("STEP_UP_ENABLED", "true")
+	t.Setenv("STEP_UP_PATHS", "/admin")
+	t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+	logger := testLoggerCheckHeaders()
+	testza.AssertNoError(t, config.Initialize(logger))
+	InitForwardAuthHandler(logger)
+
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{
+		"Accept":            "application/json",
+		"Stargate-Password": "test123",
+		"X-Forwarded-Uri":   "/admin/settings",
+	}, "")
+	defer app.ReleaseCtx(ctx)
+
+	testza.AssertNoError(t, CheckRoute(setupTestStore())(ctx))
+	testza.AssertEqual(t, fiber.StatusForbidden, ctx.Response().StatusCode())
+	testza.AssertContains(t, string(ctx.Response().Body()), "step-up requires an authenticated session")
+}
+
+func TestCheckRouteRejectsStatelessIdentityUsingVerifiedSession(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("PASSWORD_HEADER_AUTH_ENABLED", "true")
+	t.Setenv("STEP_UP_ENABLED", "true")
+	t.Setenv("STEP_UP_PATHS", "/admin")
+	t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+	logger := testLoggerCheckHeaders()
+	testza.AssertNoError(t, config.Initialize(logger))
+	InitForwardAuthHandler(logger)
+
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{
+		"Accept":            "application/json",
+		"Stargate-Password": "test123",
+		"X-Forwarded-Uri":   "/admin/settings",
+	}, "")
+	defer app.ReleaseCtx(ctx)
+
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	sess.Set("user_id", "session-user")
+	sess.Set("step_up_verified_at", time.Now().Unix())
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	ctx.Request().Header.SetCookie(auth.SessionCookieName, sess.ID())
+
+	testza.AssertNoError(t, CheckRoute(store)(ctx))
+	testza.AssertEqual(t, fiber.StatusForbidden, ctx.Response().StatusCode())
+	testza.AssertContains(t, string(ctx.Response().Body()), "does not match the authentication identity")
+}
+
+func TestCheckRouteAllowsVerifiedSessionOnStepUpPath(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("STEP_UP_ENABLED", "true")
+	t.Setenv("STEP_UP_PATHS", "/admin")
+	t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+	logger := testLoggerCheckHeaders()
+	testza.AssertNoError(t, config.Initialize(logger))
+	InitForwardAuthHandler(logger)
+
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{
+		"Accept":          "application/json",
+		"X-Forwarded-Uri": "/admin/settings",
+	}, "")
+	defer app.ReleaseCtx(ctx)
+
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	sess.Set("user_id", "session-user")
+	sess.Set("step_up_verified_at", time.Now().Unix())
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	ctx.Request().Header.SetCookie(auth.SessionCookieName, sess.ID())
+
+	testza.AssertNoError(t, CheckRoute(store)(ctx))
+	testza.AssertEqual(t, fiber.StatusOK, ctx.Response().StatusCode())
+	testza.AssertEqual(t, "session-user", string(ctx.Response().Header.Peek("X-Forwarded-User")))
 }
 
 // Ensure *session.Store satisfies SessionStoreForCheck at compile time.

--- a/src/internal/handlers/step_up.go
+++ b/src/internal/handlers/step_up.go
@@ -21,7 +21,18 @@ func stepUpVerified(sess *session.Session) bool {
 }
 
 func requiresStepUp(ctx fiber.Ctx, sess *session.Session) bool {
-	if !config.StepUpEnabled.ToBool() || !auth.IsAuthenticated(sess) || stepUpVerified(sess) {
+	if !auth.IsAuthenticated(sess) || stepUpVerified(sess) {
+		return false
+	}
+	return stepUpApplies(ctx)
+}
+
+// stepUpApplies reports whether the original protected request is covered by
+// the configured step-up policy. It deliberately does not inspect the session:
+// stateless authentication methods must not bypass a protected path merely
+// because they cannot persist step-up state.
+func stepUpApplies(ctx fiber.Ctx) bool {
+	if !config.StepUpEnabled.ToBool() {
 		return false
 	}
 	raw, ok := stepUpForwardedURI(ctx)

--- a/src/internal/handlers/step_up_test.go
+++ b/src/internal/handlers/step_up_test.go
@@ -121,6 +121,14 @@ func TestRequiresStepUpUsesForwardedBusinessPath(t *testing.T) {
 	testza.AssertFalse(t, requiresStepUp(ctx, sess))
 }
 
+func TestStepUpAppliesWithoutSessionAuthentication(t *testing.T) {
+	setupStepUpTest(t)
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{"X-Forwarded-Uri": "/admin/users"}, "")
+	defer app.ReleaseCtx(ctx)
+
+	testza.AssertTrue(t, stepUpApplies(ctx))
+}
+
 func TestRequiresStepUpIgnoresForwardedQuery(t *testing.T) {
 	setupStepUpTestWithPaths(t, "/admin")
 


### PR DESCRIPTION
## Summary

- evaluate the configured step-up path policy independently of session state
- reject stateless password-header and trusted-header results on protected paths
- bind a successful step-up marker to the session authentication result, so another identity cannot borrow it
- keep authenticated browser sessions on the existing step-up redirect flow
- add regression coverage for stateless bypass, mixed session/stateless identity, and valid verified sessions

## Verification

- `git diff --check`
- rebased onto current `main`
- GitHub Actions runs the Go test suite (the current execution environment does not include Go)