### PR TITLE
fix: preserve application origin through step-up

### DIFF
--- a/src/internal/handlers/step_up.go
+++ b/src/internal/handlers/step_up.go
@@ -77,7 +77,36 @@ func hasDotPathSegment(path string) bool {
 func redirectToStepUp(ctx fiber.Ctx) error {
 	forwardedURI, _ := stepUpForwardedURI(ctx)
 	callback := safeStepUpCallback(forwardedURI)
-	return ctx.Redirect().Status(fiber.StatusFound).To("/_step_up?callback=" + url.QueryEscape(callback))
+	callbackHost, err := ValidateCallbackHost(GetForwardedHost(ctx))
+	if err != nil {
+		return SendErrorResponse(ctx, fiber.StatusForbidden, "step-up callback host is not allowed")
+	}
+	stepUpURL := url.URL{Scheme: GetForwardedProto(ctx), Host: config.AuthHost.String(), Path: "/_step_up"}
+	query := stepUpURL.Query()
+	query.Set("callback", callback)
+	query.Set("callback_host", callbackHost)
+	query.Set("callback_proto", GetForwardedProto(ctx))
+	stepUpURL.RawQuery = query.Encode()
+	return ctx.Redirect().Status(fiber.StatusFound).To(stepUpURL.String())
+}
+
+func stepUpReturnURL(rawProto, rawHost, rawCallback string) string {
+	callback := safeStepUpCallback(rawCallback)
+	host, err := ValidateCallbackHost(rawHost)
+	if err != nil {
+		return callback
+	}
+	proto := strings.ToLower(strings.TrimSpace(rawProto))
+	if proto != "http" && proto != "https" {
+		return callback
+	}
+	parsed, err := url.ParseRequestURI(callback)
+	if err != nil {
+		return "/"
+	}
+	parsed.Scheme = proto
+	parsed.Host = host
+	return parsed.String()
 }
 
 func StepUpRoute(store *session.Store) func(c fiber.Ctx) error {
@@ -91,7 +120,12 @@ func StepUpRoute(store *session.Store) func(c fiber.Ctx) error {
 			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "authentication required")
 		}
 		callback := safeStepUpCallback(ctx.Query("callback"))
-		return ctx.Type("html").SendString(`<!doctype html><html><body><form method="post" action="/_step_up"><input type="password" name="password" autocomplete="current-password" required><input type="hidden" name="callback" value="` + html.EscapeString(callback) + `"><button type="submit">Verify</button></form></body></html>`)
+		callbackHost, _ := ValidateCallbackHost(ctx.Query("callback_host"))
+		callbackProto := strings.ToLower(strings.TrimSpace(ctx.Query("callback_proto")))
+		if callbackProto != "http" && callbackProto != "https" {
+			callbackProto = ""
+		}
+		return ctx.Type("html").SendString(`<!doctype html><html><body><form method="post" action="/_step_up"><input type="password" name="password" autocomplete="current-password" required><input type="hidden" name="callback" value="` + html.EscapeString(callback) + `"><input type="hidden" name="callback_host" value="` + html.EscapeString(callbackHost) + `"><input type="hidden" name="callback_proto" value="` + html.EscapeString(callbackProto) + `"><button type="submit">Verify</button></form></body></html>`)
 	}
 }
 
@@ -112,6 +146,6 @@ func StepUpAPI(store *session.Store) func(c fiber.Ctx) error {
 		if err := sess.Save(); err != nil {
 			return SendErrorResponse(ctx, fiber.StatusInternalServerError, "failed to save additional authentication")
 		}
-		return ctx.Redirect().Status(fiber.StatusFound).To(safeStepUpCallback(ctx.FormValue("callback")))
+		return ctx.Redirect().Status(fiber.StatusFound).To(stepUpReturnURL(ctx.FormValue("callback_proto"), ctx.FormValue("callback_host"), ctx.FormValue("callback")))
 	}
 }

--- a/src/internal/handlers/step_up_test.go
+++ b/src/internal/handlers/step_up_test.go
@@ -15,13 +15,20 @@ import (
 
 func TestRedirectToStepUpPreservesOnlyLocalCallback(t *testing.T) {
 	setupStepUpTest(t)
-	ctx, app := createTestContext("GET", "/_auth", map[string]string{"X-Forwarded-Uri": "/admin/users?tab=roles"}, "")
+	t.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com")
+	testza.AssertNoError(t, config.Initialize(testLogger()))
+	ctx, app := createTestContext("GET", "/_auth", map[string]string{
+		"Host":              "auth.example.com",
+		"X-Forwarded-Host":  "app.example.com",
+		"X-Forwarded-Proto": "https",
+		"X-Forwarded-Uri":   "/admin/users?tab=roles",
+	}, "")
 	defer app.ReleaseCtx(ctx)
 
 	err := redirectToStepUp(ctx)
 	testza.AssertNoError(t, err)
 	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
-	testza.AssertEqual(t, "/_step_up?callback=%2Fadmin%2Fusers%3Ftab%3Droles", string(ctx.Response().Header.Peek("Location")))
+	testza.AssertEqual(t, "https://auth.example.com/_step_up?callback=%2Fadmin%2Fusers%3Ftab%3Droles&callback_host=app.example.com&callback_proto=https", string(ctx.Response().Header.Peek("Location")))
 }
 
 func TestStepUpRouteRequiresAuthentication(t *testing.T) {
@@ -161,7 +168,9 @@ func TestStepUpAPIRecordsRecentVerification(t *testing.T) {
 	store := setupTestStore()
 	ctx, app := createTestContext("POST", "/_step_up", map[string]string{
 		"Content-Type": "application/x-www-form-urlencoded",
-	}, "password=test123&callback=/admin/users")
+	}, "password=test123&callback=/admin/users&callback_host=app.example.com&callback_proto=https")
+	t.Setenv("CALLBACK_ALLOWED_HOSTS", "app.example.com")
+	testza.AssertNoError(t, config.Initialize(testLogger()))
 	defer app.ReleaseCtx(ctx)
 	sess, err := store.Get(ctx)
 	testza.AssertNoError(t, err)
@@ -171,12 +180,17 @@ func TestStepUpAPIRecordsRecentVerification(t *testing.T) {
 	err = StepUpAPI(store)(ctx)
 	testza.AssertNoError(t, err)
 	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
-	testza.AssertEqual(t, "/admin/users", string(ctx.Response().Header.Peek("Location")))
+	testza.AssertEqual(t, "https://app.example.com/admin/users", string(ctx.Response().Header.Peek("Location")))
 	verifiedSession, err := store.Get(ctx)
 	testza.AssertNoError(t, err)
 	verified, ok := verifiedSession.Get("step_up_verified_at").(int64)
 	testza.AssertTrue(t, ok)
 	testza.AssertTrue(t, verified > 0)
+}
+
+func TestStepUpReturnURLRejectsUnapprovedHost(t *testing.T) {
+	setupStepUpTest(t)
+	testza.AssertEqual(t, "/admin", stepUpReturnURL("https", "evil.example.net", "/admin"))
 }
 
 func TestSafeStepUpCallbackRejectsExternalURLs(t *testing.T) {


### PR DESCRIPTION
## Summary

- redirect protected requests to an absolute `AUTH_HOST/_step_up` URL
- carry the allowlisted application host, scheme, path, and query through the verification form
- return successful verification to the original protected application instead of the authentication host
- reject unapproved callback hosts and add cross-host regression coverage

## Verification

- `git diff --check`
- GitHub Actions will run the Go test suite