### PR TITLE
fix: validate usable step-up path patterns

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -494,13 +494,18 @@ func Initialize(l *logger.Logger) error {
 		return NewValidationError(StepUpPaths.Name, "must contain at least one protected path when step-up is enabled", StepUpPaths.PossibleValues)
 	}
 	if StepUpEnabled.ToBool() {
+		usablePatterns := 0
 		for _, pattern := range strings.Split(StepUpPaths.Value, ",") {
 			if strings.TrimSpace(pattern) == "" {
 				continue
 			}
+			usablePatterns++
 			if !ValidStepUpPathPattern(pattern) {
 				return NewValidationError(StepUpPaths.Name, "must contain only local absolute path patterns without queries, fragments, backslashes, or dot segments", StepUpPaths.PossibleValues)
 			}
+		}
+		if usablePatterns == 0 {
+			return NewValidationError(StepUpPaths.Name, "must contain at least one usable protected path", StepUpPaths.PossibleValues)
 		}
 	}
 	if StepUpEnabled.ToBool() && strings.TrimSpace(TrustedProxies.Value) == "" {

--- a/src/internal/config/stepup.go
+++ b/src/internal/config/stepup.go
@@ -21,11 +21,13 @@ func ValidStepUpPathPattern(raw string) bool {
 	if raw == "" || !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") || strings.ContainsAny(raw, "\\#") {
 		return false
 	}
-	parsed, err := url.ParseRequestURI(raw)
-	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+	// Do not parse the pattern as a request URI: '?' is a documented
+	// single-character glob here, not a query delimiter.
+	decoded, err := url.PathUnescape(raw)
+	if err != nil {
 		return false
 	}
-	for _, segment := range strings.Split(parsed.Path, "/") {
+	for _, segment := range strings.Split(decoded, "/") {
 		if segment == "." || segment == ".." {
 			return false
 		}

--- a/src/internal/config/stepup_test.go
+++ b/src/internal/config/stepup_test.go
@@ -34,6 +34,31 @@ func TestInitStepUpMatcher_Enabled_EmptyPaths(t *testing.T) {
 	testza.AssertContains(t, err.Error(), "STEP_UP_PATHS")
 }
 
+func TestInitializeStepUpRejectsDelimiterOnlyPaths(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("STEP_UP_ENABLED", "true")
+	t.Setenv("STEP_UP_PATHS", " , , ")
+	t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+
+	err := Initialize(testLogger())
+	testza.AssertNotNil(t, err)
+	testza.AssertContains(t, err.Error(), "STEP_UP_PATHS")
+}
+
+func TestInitializeStepUpAcceptsQuestionMarkGlob(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("STEP_UP_ENABLED", "true")
+	t.Setenv("STEP_UP_PATHS", "/users/?/settings")
+	t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+
+	testza.AssertNoError(t, Initialize(testLogger()))
+	matcher := GetStepUpMatcher()
+	testza.AssertTrue(t, matcher.RequiresStepUp("/users/a/settings"))
+	testza.AssertFalse(t, matcher.RequiresStepUp("/users/ab/settings"))
+}
+
 func TestInitStepUpMatcher_Enabled_SinglePath(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")
@@ -86,7 +111,7 @@ func TestInitializeStepUpRequiresTrustedProxy(t *testing.T) {
 }
 
 func TestInitializeRejectsUnsafeStepUpPathPatterns(t *testing.T) {
-	for _, paths := range []string{"admin", "//evil.example/admin", "/admin?tab=users", "/admin#users", `/admin\\users`, "/admin/../public", "/admin/%2e%2e/public"} {
+	for _, paths := range []string{"admin", "//evil.example/admin", "/admin#users", `/admin\\users`, "/admin/../public", "/admin/%2e%2e/public"} {
 		t.Run(paths, func(t *testing.T) {
 			t.Setenv("AUTH_HOST", "auth.example.com")
 			t.Setenv("PASSWORDS", "plaintext:test123")


### PR DESCRIPTION
## Summary

- reject delimiter-only `STEP_UP_PATHS` values that compile to zero rules
- validate decoded dot segments without parsing `?` as a URI query delimiter
- preserve the documented single-character `?` glob behavior
- add regression tests for empty parsed rules and question-mark patterns

## Verification

- `git diff --check`
- GitHub Actions will run the Go test suite