### PR TITLE
fix: share password parsing across validation and auth

### DIFF
--- a/src/internal/auth/auth.go
+++ b/src/internal/auth/auth.go
@@ -76,25 +76,11 @@ var (
 // Note: This function assumes the password format has been validated during configuration initialization.
 // If the format is invalid, it will return empty values, which will cause authentication to fail safely.
 func GetValidPasswords() (string, []string) {
-	// Schema: "algorithm:pass1|pass2|pass3"
-	passwordsRaw := config.Passwords.String()
-	if passwordsRaw == "" {
+	algorithm, passwords, ok := config.ParsePasswords(config.Passwords.String())
+	if !ok {
 		return "", []string{}
 	}
-
-	parts := strings.SplitN(passwordsRaw, ":", 2)
-	if len(parts) < 2 {
-		// Invalid format, return empty to fail safely
-		return "", []string{}
-	}
-
-	algorithm := strings.ToLower(strings.TrimSpace(parts[0]))
-	passwordsStr := parts[1]
-	if passwordsStr == "" {
-		return algorithm, []string{}
-	}
-
-	return algorithm, strings.Split(passwordsStr, "|")
+	return algorithm, passwords
 }
 
 // CheckPassword validates a password against the configured valid passwords.
@@ -106,6 +92,9 @@ func GetValidPasswords() (string, []string) {
 //
 // Returns true if the password matches any of the configured passwords, false otherwise.
 func CheckPassword(password string) bool {
+	if password == "" {
+		return false
+	}
 	algo, validPasswords := GetValidPasswords()
 
 	// If no valid passwords configured, authentication fails

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -293,6 +293,7 @@ func TestValidatePasswords_Invalid(t *testing.T) {
 		{"missing algorithm", "pass1", false},
 		{"empty password", "plaintext:", false},
 		{"empty password in list", "plaintext:pass1||pass3", false},
+		{"empty password after additional colon", "plaintext:pass1:|", false},
 		{"missing colon", "plaintextpass1", false},
 	}
 

--- a/src/internal/config/validation.go
+++ b/src/internal/config/validation.go
@@ -125,36 +125,8 @@ var (
 	}
 
 	ValidatePasswords = func(v EnvVariable) bool {
-		// Schema: "algorithm:pass1|pass2|pass3"
-		passwordsRaw := v.Value
-		if passwordsRaw == "" {
-			return false
-		}
-		parts := strings.Split(passwordsRaw, ":")
-		if len(parts) < 2 {
-			return false
-		}
-		algorithm := parts[0]
-		passwords := strings.Split(parts[1], "|")
-
-		algoSupported := false
-		for possibleValue := range SupportedAlgorithms {
-			if algorithm == possibleValue {
-				algoSupported = true
-				break
-			}
-		}
-		if !algoSupported {
-			return false
-		}
-
-		for _, password := range passwords {
-			if password == "" {
-				return false
-			}
-		}
-
-		return true
+		_, _, ok := ParsePasswords(v.Value)
+		return ok
 	}
 
 	// ValidatePasswordsOrEmpty allows empty value (for pure Warden deployment); otherwise same as ValidatePasswords.
@@ -165,6 +137,33 @@ var (
 		return ValidatePasswords(v)
 	}
 )
+
+// ParsePasswords is the single parser for the PASSWORDS contract used by both
+// startup validation and authentication. Password values are opaque and may
+// contain additional colons, so only the first colon separates the algorithm.
+func ParsePasswords(raw string) (string, []string, bool) {
+	if raw == "" {
+		return "", nil, false
+	}
+	parts := strings.SplitN(raw, ":", 2)
+	if len(parts) != 2 {
+		return "", nil, false
+	}
+	algorithm := strings.ToLower(strings.TrimSpace(parts[0]))
+	if _, supported := SupportedAlgorithms[algorithm]; !supported {
+		return "", nil, false
+	}
+	passwords := strings.Split(parts[1], "|")
+	if len(passwords) == 0 {
+		return "", nil, false
+	}
+	for _, password := range passwords {
+		if password == "" {
+			return "", nil, false
+		}
+	}
+	return algorithm, passwords, true
+}
 
 type ValidationError struct {
 	KeyName        string


### PR DESCRIPTION
## Summary

- introduce one parser for the `PASSWORDS` startup and runtime contract
- split only on the first colon so opaque credentials retain subsequent colons
- reject every empty password entry, including malformed values that previously passed validation
- fail closed on an empty password input even if configuration state is invalid

## Verification

- `git diff --check`
- added a regression case for `plaintext:pass1:|`
- GitHub Actions will run the Go test suite