### PR TITLE
fix: refresh only Warden-authenticated sessions

### DIFF
--- a/src/internal/handlers/auth_refresh.go
+++ b/src/internal/handlers/auth_refresh.go
@@ -23,6 +23,17 @@ func refreshAuthorizationIfNeeded(ctx context.Context, sess *session.Session) (b
 	if !config.AuthRefreshEnabled.ToBool() || !config.WardenEnabled.ToBool() || !auth.IsAuthenticated(sess) {
 		return false, nil
 	}
+	method, _ := sess.Get("auth_method").(string)
+	phone, _ := sess.Get("user_phone").(string)
+	mail, _ := sess.Get("user_mail").(string)
+	if method != "warden" {
+		// Sessions created before auth_method was recorded can still be identified
+		// by their Warden identity. Explicit non-Warden sessions must never be sent
+		// through the global Warden refresh path.
+		if method != "" || (phone == "" && mail == "") {
+			return false, nil
+		}
+	}
 	interval := config.AuthRefreshInterval.ToDuration()
 	if interval <= 0 {
 		interval = 5 * time.Minute
@@ -31,8 +42,6 @@ func refreshAuthorizationIfNeeded(ctx context.Context, sess *session.Session) (b
 		time.Since(time.Unix(refreshedAt, 0)) <= interval {
 		return false, nil
 	}
-	phone, _ := sess.Get("user_phone").(string)
-	mail, _ := sess.Get("user_mail").(string)
 	if phone == "" && mail == "" {
 		return false, errors.New("session has no refresh identity")
 	}

--- a/src/internal/handlers/auth_refresh_test.go
+++ b/src/internal/handlers/auth_refresh_test.go
@@ -36,6 +36,7 @@ func TestAuthRefreshRejectsMissingOrDisabledUser(t *testing.T) {
 	sess, err := store.Get(ctx)
 	testza.AssertNoError(t, err)
 	sess.Set("user_mail", "disabled@example.com")
+	sess.Set("auth_method", "warden")
 	sess.Set("auth_refreshed_at", time.Now().Add(-time.Minute).Unix())
 	sessionID := sess.ID()
 	testza.AssertNoError(t, auth.Authenticate(sess))
@@ -60,6 +61,7 @@ func TestAuthRefreshReplacesRevokedAuthorization(t *testing.T) {
 	sess, err := store.Get(ctx)
 	testza.AssertNoError(t, err)
 	sess.Set("user_mail", "active@example.com")
+	sess.Set("auth_method", "warden")
 	sess.Set("user_scope", []string{"old-admin"})
 	sess.Set("auth_refreshed_at", time.Now().Add(-time.Minute).Unix())
 	sessionID := sess.ID()
@@ -121,4 +123,25 @@ func TestAuthRefreshSkipsStandaloneSession(t *testing.T) {
 	refreshed, err := refreshAuthorizationIfNeeded(context.Background(), sess)
 	testza.AssertNoError(t, err)
 	testza.AssertFalse(t, refreshed)
+}
+
+func TestAuthRefreshSkipsPasswordSessionInMixedDeployment(t *testing.T) {
+	setupRefreshTest(t)
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/_auth", nil, "")
+	defer app.ReleaseCtx(ctx)
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	sess.Set("auth_method", "password")
+	testza.AssertNoError(t, auth.Authenticate(sess))
+
+	lookupCalled := false
+	lookupRefreshUser = func(context.Context, string, string) *warden.AllowListUser {
+		lookupCalled = true
+		return nil
+	}
+	refreshed, err := refreshAuthorizationIfNeeded(context.Background(), sess)
+	testza.AssertNoError(t, err)
+	testza.AssertFalse(t, refreshed)
+	testza.AssertFalse(t, lookupCalled)
 }

--- a/src/internal/handlers/login.go
+++ b/src/internal/handlers/login.go
@@ -475,6 +475,7 @@ func loginAPIHandler(ctx fiber.Ctx, sessionGetter SessionGetter, authenticator A
 	if err := sess.Reset(); err != nil {
 		return SendErrorResponse(ctx, fiber.StatusInternalServerError, "failed to rotate session")
 	}
+	sess.Set("auth_method", authMethod)
 
 	// Set user information to session for warden authentication before authenticating
 	if authMethod == "warden" {


### PR DESCRIPTION
## Summary

- persist the selected login authentication method in the session
- refresh authorization only for explicit Warden sessions
- infer legacy Warden sessions from their stored identity fields for upgrade compatibility
- keep local password sessions usable when Warden is globally enabled

## Verification

- `git diff --check`
- added a mixed-deployment password-session regression test
- GitHub Actions will run the Go test suite