### PR TITLE
fix: expose local password login in Warden mode

### DIFF
--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -352,6 +352,18 @@ func TestInitializeWardenRequiresReachableAuthenticationPath(t *testing.T) {
 	testza.AssertContains(t, err.Error(), "authentication path")
 }
 
+func TestInitializeAllowsLocalPasswordLoginForWarden(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("PASSWORD_HEADER_AUTH_ENABLED", "false")
+	t.Setenv("WARDEN_ENABLED", "true")
+	t.Setenv("WARDEN_URL", "https://warden.example.com")
+	t.Setenv("HERALD_ENABLED", "false")
+	t.Setenv("HEADER_AUTH_ENABLED", "false")
+
+	testza.AssertNoError(t, Initialize(testLogger()))
+}
+
 func TestInitializeAllowsHeraldAuthenticationPathForWarden(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "")

--- a/src/internal/handlers/handlers_test.go
+++ b/src/internal/handlers/handlers_test.go
@@ -218,6 +218,33 @@ func TestLoginAPI_ValidPassword(t *testing.T) {
 	testza.AssertEqual(t, fiber.StatusOK, ctx.Response().StatusCode())
 }
 
+func TestLoginAPI_LocalPasswordWhileWardenEnabled(t *testing.T) {
+	t.Setenv("AUTH_HOST", "auth.example.com")
+	t.Setenv("PASSWORDS", "plaintext:test123")
+	t.Setenv("PASSWORD_HEADER_AUTH_ENABLED", "false")
+	t.Setenv("WARDEN_ENABLED", "true")
+	t.Setenv("WARDEN_URL", "https://warden.example.com")
+	testza.AssertNoError(t, config.Initialize(testLogger()))
+
+	store := setupTestStore()
+	ctx, app := createTestContext("POST", "/_login", map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}, "auth_method=password&password=test123")
+	defer app.ReleaseCtx(ctx)
+
+	testza.AssertNoError(t, LoginAPI(store)(ctx))
+	testza.AssertEqual(t, fiber.StatusOK, ctx.Response().StatusCode())
+}
+
+func TestWardenLoginTemplateExposesConfiguredLocalPassword(t *testing.T) {
+	template, err := os.ReadFile("../web/templates/login.warden.html")
+	testza.AssertNoError(t, err)
+	body := string(template)
+	testza.AssertContains(t, body, "{{if .PasswordLoginEnabled}}")
+	testza.AssertContains(t, body, `name="auth_method" value="password"`)
+	testza.AssertContains(t, body, `name="password"`)
+}
+
 func TestLoginAPI_InvalidPassword(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")

--- a/src/internal/handlers/login.go
+++ b/src/internal/handlers/login.go
@@ -744,17 +744,18 @@ func loginRouteHandler(ctx fiber.Ctx, sessionGetter SessionGetter) error {
 	otpEnabled := config.HeraldTOTPEnabled.ToBool()
 
 	return ctx.Render(templateName, fiber.Map{
-		"Callback":          callback,
-		"SessionID":         sess.ID(),
-		"Title":             config.LoginPageTitle.Value,
-		"FooterText":        config.LoginPageFooterText.Value,
-		"WardenEnabled":     config.WardenEnabled.ToBool(),
-		"HeraldEnabled":     heraldEnabled,
-		"OTPEnabled":        otpEnabled,
-		"HeraldTOTPEnabled": config.HeraldTOTPEnabled.ToBool(),
-		"LoginSMSEnabled":   config.LoginSMSEnabled.ToBool(),
-		"LoginEmailEnabled": config.LoginEmailEnabled.ToBool(),
-		"Debug":             config.Debug.ToBool(),
+		"Callback":             callback,
+		"SessionID":            sess.ID(),
+		"Title":                config.LoginPageTitle.Value,
+		"FooterText":           config.LoginPageFooterText.Value,
+		"WardenEnabled":        config.WardenEnabled.ToBool(),
+		"PasswordLoginEnabled": config.Passwords.Value != "",
+		"HeraldEnabled":        heraldEnabled,
+		"OTPEnabled":           otpEnabled,
+		"HeraldTOTPEnabled":    config.HeraldTOTPEnabled.ToBool(),
+		"LoginSMSEnabled":      config.LoginSMSEnabled.ToBool(),
+		"LoginEmailEnabled":    config.LoginEmailEnabled.ToBool(),
+		"Debug":                config.Debug.ToBool(),
 	})
 }
 

--- a/src/internal/web/templates/login.warden.html
+++ b/src/internal/web/templates/login.warden.html
@@ -134,6 +134,31 @@
           {{end}}
           <button type="submit" class="btn-verify">Verify Access</button>
         </form>
+        {{if .PasswordLoginEnabled}}
+        <div style="display: flex; align-items: center; gap: 12px; margin: 28px 0; color: #9ca3af; font-size: 0.8125rem;">
+          <span style="height: 1px; background: #e5e7eb; flex: 1;"></span>
+          <span>or use a local password</span>
+          <span style="height: 1px; background: #e5e7eb; flex: 1;"></span>
+        </div>
+        <form action="/_login" method="post" class="form" id="passwordLoginForm">
+          {{if .Callback}}
+          <input type="hidden" name="callback" value="{{.Callback}}">
+          {{end}}
+          <input type="hidden" name="auth_method" value="password">
+          <div class="form-group">
+            <label for="local_password" class="sr-only">Local password</label>
+            <input
+              type="password"
+              id="local_password"
+              name="password"
+              placeholder="Local password"
+              autocomplete="current-password"
+              required
+            >
+          </div>
+          <button type="submit" class="btn-verify">Sign in with password</button>
+        </form>
+        {{end}}
       </div>
     </main>
 


### PR DESCRIPTION
## Summary

- preserve the supported `POST /_login` local-password contract when Warden is enabled
- expose a separate local-password form on the Warden login page whenever `PASSWORDS` is configured
- keep password-header enablement independent from browser/API password login
- add configuration, API-login, and template regression coverage

## Verification

- `git diff --check`
- rebased onto current `main`
- GitHub Actions runs the Go test suite (the current execution environment does not include Go)