### PR TITLE
fix: make TOTP management flows usable

### DIFF
--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -233,6 +233,7 @@ func setupRoutes(app *fiber.App, store *fibersession.Store, healthAggregator *he
 	sameOrigin := handlers.RequireSameOrigin()
 	app.Post(RouteLogin, sameOrigin, handlers.LoginRateLimit(), handlers.LoginAPI(store))
 	app.Post("/_send_verify_code", sameOrigin, handlers.VerificationRateLimit(), handlers.SendVerifyCodeAPI())
+	app.Get("/totp/enroll", handlers.TOTPEnrollPageRoute(store))
 	app.Post("/totp/enroll", sameOrigin, handlers.VerificationRateLimit(), handlers.TOTPEnrollRoute(store))
 	app.Post("/totp/enroll/confirm", sameOrigin, handlers.VerificationRateLimit(), handlers.TOTPEnrollConfirmAPI(store))
 	app.Get("/totp/revoke", handlers.TOTPRevokeRoute(store))

--- a/src/internal/handlers/totp_enroll.go
+++ b/src/internal/handlers/totp_enroll.go
@@ -33,6 +33,25 @@ func clearTOTPEnrollment(sess *session.Session) {
 	sess.Delete(totpEnrollmentStartedKey)
 }
 
+// TOTPEnrollPageRoute renders a safe confirmation page. Enrollment state is
+// created only by the same-origin POST /totp/enroll action.
+func TOTPEnrollPageRoute(store *session.Store) func(c fiber.Ctx) error {
+	return func(ctx fiber.Ctx) error {
+		sess, err := store.Get(ctx)
+		if err != nil {
+			return SendErrorResponse(ctx, fiber.StatusInternalServerError, i18n.T(ctx, "error.session_store_failed"))
+		}
+		defer sess.Release()
+		if !auth.IsAuthenticated(sess) {
+			return ctx.Redirect().Status(fiber.StatusFound).To("/_login")
+		}
+		if !hasRecentAuthentication(sess) {
+			return SendErrorResponse(ctx, fiber.StatusUnauthorized, "recent authentication required")
+		}
+		return ctx.Type("html").SendString(`<!doctype html><html><body><main><h1>Bind Authenticator (TOTP)</h1><p>Start enrollment to generate a new authenticator secret and recovery codes.</p><form method="post" action="/totp/enroll"><button type="submit">Start enrollment</button></form><p><a href="/totp/revoke">Manage existing TOTP</a></p></main></body></html>`)
+	}
+}
+
 // TOTPEnrollRoute handles POST /totp/enroll - starts enrollment and shows the bind page.
 // Calls herald-totp enroll/start and renders page with QR (otpauth_uri) and enroll_id.
 func TOTPEnrollRoute(store *session.Store) func(c fiber.Ctx) error {

--- a/src/internal/handlers/totp_enroll_test.go
+++ b/src/internal/handlers/totp_enroll_test.go
@@ -24,6 +24,30 @@ type failSetStorage struct {
 	fail bool
 }
 
+func TestTOTPEnrollPageRouteRequiresAuthentication(t *testing.T) {
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/totp/enroll", nil, "")
+	defer app.ReleaseCtx(ctx)
+
+	testza.AssertNoError(t, TOTPEnrollPageRoute(store)(ctx))
+	testza.AssertEqual(t, fiber.StatusFound, ctx.Response().StatusCode())
+	testza.AssertEqual(t, "/_login", string(ctx.Response().Header.Peek("Location")))
+}
+
+func TestTOTPEnrollPageRouteRendersPostForm(t *testing.T) {
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/totp/enroll", nil, "")
+	defer app.ReleaseCtx(ctx)
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	testza.AssertNoError(t, auth.Authenticate(sess))
+	ctx.Request().Header.SetCookie(auth.SessionCookieName, sess.ID())
+
+	testza.AssertNoError(t, TOTPEnrollPageRoute(store)(ctx))
+	testza.AssertEqual(t, fiber.StatusOK, ctx.Response().StatusCode())
+	testza.AssertContains(t, string(ctx.Response().Body()), `method="post" action="/totp/enroll"`)
+}
+
 func (s *failSetStorage) Set(key string, value []byte, expiration time.Duration) error {
 	if s.fail {
 		return errors.New("injected session write failure")

--- a/src/internal/web/templates/totp_revoke.html
+++ b/src/internal/web/templates/totp_revoke.html
@@ -36,6 +36,11 @@
       <div id="error" class="error"></div>
       <div id="success" class="success">TOTP has been unbound. <a href="/">Back to home</a></div>
       <form id="revokeForm" method="post" action="/totp/revoke">
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" autocomplete="current-password" placeholder="Password">
+        <p>or</p>
+        <label for="code">Current authenticator code</label>
+        <input id="code" name="code" type="text" inputmode="numeric" autocomplete="one-time-code" placeholder="TOTP or backup code">
         <div class="actions">
           <button type="button" class="btn btn-secondary" id="btnCancel">Cancel</button>
           <button type="submit" class="btn btn-danger" id="btnRevoke">Unbind TOTP</button>
@@ -64,7 +69,13 @@
         var successEl = document.getElementById('success');
         errEl.classList.remove('show');
         successEl.classList.remove('show');
-        fetch(form.action, { method: 'POST', credentials: 'same-origin' })
+        var body = new URLSearchParams(new FormData(form)).toString();
+        fetch(form.action, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: body
+        })
           .then(function(r) { return r.json().then(function(j){ return { ok: r.ok, json: j }; }); })
           .then(function(res) {
             if (res.ok && res.json.ok) {


### PR DESCRIPTION
## Summary

- add a safe `GET /totp/enroll` confirmation page while keeping enrollment state creation on same-origin POST
- make the existing enrollment links resolve to a usable route
- collect a password or current TOTP/backup code on the revoke page
- submit the reauthentication proof to `POST /totp/revoke`
- add coverage for the enrollment entry page

## Verification

- `git diff --check`
- GitHub Actions will run the Go and template tests