### PR TITLE
fix: make the Compose proxy network self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ services:
 docker-compose up -d
 ```
 
-**That's it!** Your authentication service is now running. 🎉
+The bundled stack starts Traefik, Stargate, and the protected `whoami` demo on
+a Compose-managed network whose CIDR matches `TRUSTED_PROXIES`. Open
+`http://whoami.test.localhost` to exercise the complete login flow.
 
 ### Local Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,17 @@
 services:
+  traefik:
+    image: traefik:v3.7.12
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.http.address=:80
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - traefik
+
   stargate: # Your Stargate forward auth service
     image: ghcr.io/soulteary/stargate:v1.0.0
     # Local development port mapping: host port 8080 -> container port 8080
@@ -12,7 +25,7 @@ services:
       - PASSWORDS=plaintext:test1234|test1337 # Replace with your passwords. See the docs for more info.
       - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
-      - TRUSTED_PROXIES=${TRUSTED_PROXIES:-172.30.0.0/24} # Set this to the actual Traefik network CIDR.
+      - TRUSTED_PROXIES=172.30.0.0/24 # Matches the Compose-managed Traefik network below.
       - COOKIE_SECURE=false # Local HTTP only. Keep the default true in HTTPS deployments.
       - PORT=8080
     read_only: true
@@ -52,4 +65,7 @@ services:
 
 networks:
   traefik:
-    external: true
+    name: stargate-traefik
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24


### PR DESCRIPTION
## Summary

- include a pinned Traefik service in the bundled Quick Start stack
- let Compose create a deterministic `172.30.0.0/24` proxy network
- align `TRUSTED_PROXIES` with that managed CIDR
- document the complete protected `whoami` login flow

## Verification

- `git diff --check`
- the current execution environment does not include Docker; GitHub Actions will validate the repository changes