### PR TITLE
docs: require Redis for multi-instance deployments

### DIFF
--- a/docs/deDE/DEPLOYMENT.md
+++ b/docs/deDE/DEPLOYMENT.md
@@ -404,10 +404,7 @@ services:
       replicas: 3
 ```
 
-**Hinweis:** Wenn Redis-Sitzungsspeicher nicht aktiviert ist (`SESSION_STORAGE_ENABLED=false`), werden Sitzungen nur im Speicher gehalten und nicht zwischen Instanzen geteilt. Für Multi-Instance-Bereitstellung:
-
-- Redis-Sitzungsspeicher aktivieren (`SESSION_STORAGE_ENABLED=true` und `SESSION_STORAGE_REDIS_*` konfigurieren), oder
-- Sitzungspersistenz des Load Balancers (Sticky Session) verwenden
+**Erforderlich:** Für mehrere Instanzen, Rolling Upgrades und domänenübergreifende Bereitstellungen muss Redis-Sitzungsspeicher aktiviert werden (`SESSION_STORAGE_ENABLED=true` und `SESSION_STORAGE_REDIS_*`). Redis teilt Sitzungen und den Replay-Status einmaliger Tickets zwischen allen Replikaten. Sticky Sessions allein werden nicht unterstützt und dürfen nur zusätzlich zur Routing-Optimierung eingesetzt werden.
 
 #### 2. Lastverteilung
 

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -404,10 +404,7 @@ services:
       replicas: 3
 ```
 
-**Note:** When Redis session storage is not enabled (`SESSION_STORAGE_ENABLED=false`), sessions are stored in memory and are not shared between instances. For multi-instance deployment, either:
-
-- Enable Redis session storage (`SESSION_STORAGE_ENABLED=true` and configure `SESSION_STORAGE_REDIS_*`), or
-- Use load balancer session persistence (sticky session)
+**Required:** Multi-instance, rolling-upgrade, and cross-domain deployments must enable Redis session storage (`SESSION_STORAGE_ENABLED=true` and configure `SESSION_STORAGE_REDIS_*`). Redis shares both sessions and single-use ticket replay state across replicas. Load-balancer sticky sessions alone are not supported; they may be used only as an additional routing optimization.
 
 #### 2. Load Balancing
 

--- a/docs/frFR/DEPLOYMENT.md
+++ b/docs/frFR/DEPLOYMENT.md
@@ -404,10 +404,7 @@ services:
       replicas: 3
 ```
 
-**Note :** Sans stockage Redis (`SESSION_STORAGE_ENABLED=false`), les sessions sont en mémoire et ne sont pas partagées entre instances. Pour un déploiement multi-instance :
-
-- Activer le stockage Redis (`SESSION_STORAGE_ENABLED=true` et configurer `SESSION_STORAGE_REDIS_*`), ou
-- Utiliser la persistance de session du répartiteur de charge (Sticky Session)
+**Obligatoire :** Les déploiements multi-instances, les mises à niveau progressives et les scénarios inter-domaines doivent activer le stockage Redis (`SESSION_STORAGE_ENABLED=true` et `SESSION_STORAGE_REDIS_*`). Redis partage les sessions et l'état anti-rejeu des tickets à usage unique entre les réplicas. Les Sticky Sessions seules ne sont pas prises en charge et ne peuvent servir que d'optimisation de routage supplémentaire.
 
 #### 2. Répartition de Charge
 

--- a/docs/itIT/DEPLOYMENT.md
+++ b/docs/itIT/DEPLOYMENT.md
@@ -404,10 +404,7 @@ services:
       replicas: 3
 ```
 
-**Nota:** Senza storage Redis (`SESSION_STORAGE_ENABLED=false`), le sessioni sono solo in memoria e non condivise tra istanze. Per deployment multi-istanza:
-
-- Abilitare storage sessione Redis (`SESSION_STORAGE_ENABLED=true` e configurare `SESSION_STORAGE_REDIS_*`), oppure
-- Utilizzare persistenza sessione del bilanciatore di carico (Sticky Session)
+**Obbligatorio:** I deployment multi-istanza, gli aggiornamenti progressivi e gli scenari cross-domain devono abilitare Redis (`SESSION_STORAGE_ENABLED=true` e `SESSION_STORAGE_REDIS_*`). Redis condivide tra le repliche sia le sessioni sia lo stato anti-replay dei ticket monouso. Le Sticky Session da sole non sono supportate e possono essere usate solo come ottimizzazione aggiuntiva del routing.
 
 #### 2. Bilanciamento Carico
 

--- a/docs/jaJP/DEPLOYMENT.md
+++ b/docs/jaJP/DEPLOYMENT.md
@@ -404,10 +404,7 @@ services:
       replicas: 3
 ```
 
-**注意:** Redis セッションストレージを有効にしていない場合（`SESSION_STORAGE_ENABLED=false`）、セッションはメモリのみでインスタンス間で共有されません。マルチインスタンスデプロイでは：
-
-- Redis セッションストレージを有効化（`SESSION_STORAGE_ENABLED=true` と `SESSION_STORAGE_REDIS_*` を設定）、または
-- ロードバランサーのセッション永続化（Sticky Session）を使用
+**必須:** マルチインスタンス、ローリングアップグレード、クロスドメイン構成では Redis セッションストレージ（`SESSION_STORAGE_ENABLED=true` と `SESSION_STORAGE_REDIS_*`）を有効にしてください。Redis はセッションと使い捨てチケットのリプレイ防止状態を全レプリカで共有します。Sticky Session だけの構成はサポートされず、追加のルーティング最適化としてのみ利用できます。
 
 #### 2. ロードバランシング
 

--- a/docs/koKR/DEPLOYMENT.md
+++ b/docs/koKR/DEPLOYMENT.md
@@ -404,10 +404,7 @@ services:
       replicas: 3
 ```
 
-**주의:** Redis 세션 저장소를 사용하지 않으면(`SESSION_STORAGE_ENABLED=false`) 세션은 메모리에만 저장되며 인스턴스 간 공유되지 않습니다. 다중 인스턴스 배포 시:
-
-- Redis 세션 저장소 활성화(`SESSION_STORAGE_ENABLED=true` 및 `SESSION_STORAGE_REDIS_*` 설정), 또는
-- 로드 밸런서의 세션 영속성(Sticky Session) 사용
+**필수:** 다중 인스턴스, 롤링 업그레이드 및 교차 도메인 배포에서는 Redis 세션 저장소(`SESSION_STORAGE_ENABLED=true` 및 `SESSION_STORAGE_REDIS_*`)를 활성화해야 합니다. Redis는 세션과 일회용 티켓의 재사용 방지 상태를 모든 복제본에서 공유합니다. Sticky Session만 사용하는 구성은 지원되지 않으며 추가 라우팅 최적화로만 사용할 수 있습니다.
 
 #### 2. 로드 밸런싱
 

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -514,10 +514,7 @@ services:
       replicas: 3
 ```
 
-**注意：** 未启用 Redis 会话存储（`SESSION_STORAGE_ENABLED=false`）时，会话仅保存在内存中，多实例间不共享。若需多实例部署，可：
-
-- 启用 Redis 会话存储（`SESSION_STORAGE_ENABLED=true` 并配置 `SESSION_STORAGE_REDIS_*`），或
-- 使用负载均衡器的会话保持（Sticky Session）
+**必须配置：** 多实例、滚动升级和跨域部署必须启用 Redis 会话存储（`SESSION_STORAGE_ENABLED=true` 并配置 `SESSION_STORAGE_REDIS_*`）。Redis 会在副本间同时共享 Session 与单次 Ticket 的重放状态。仅使用负载均衡器会话保持（Sticky Session）不受支持；它只能作为额外的路由优化。
 
 #### 2. 负载均衡
 


### PR DESCRIPTION
## Summary

- require Redis-backed session storage for replicas, rolling upgrades, and cross-domain flows
- explain that Redis also shares single-use ticket replay state
- remove the unsupported claim that sticky sessions can replace shared storage
- synchronize the contract across all seven deployment guides

## Verification

- `bash .github/scripts/check-doc-contracts.sh`
- `git diff --check`