### PR TITLE
ci: serialize all release tag workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
       - 'v*.*.*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Every release tag updates shared semver aliases. Serialize all tags so an
+  # older run cannot finish last and overwrite latest, major, or minor tags.
+  group: ${{ github.repository }}-release
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## Summary

- use one repository-wide concurrency group for every release tag
- keep release runs queued instead of cancelling an in-progress publication
- prevent an older tag from finishing last and overwriting shared Docker aliases

## Verification

- `git diff --check`
- GitHub Actions will parse and validate the workflow