### PR TITLE
docs: align verification and TOTP API contracts

### DIFF
--- a/docs/deDE/API.md
+++ b/docs/deDE/API.md
@@ -68,6 +68,7 @@ Der Name des Benutzer-Headers kann über die Umgebungsvariable `USER_HEADER_NAME
 **Verwendung der Header-Authentifizierung (API-Anfrage)**
 
 ```bash
+# Server-Voraussetzung: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" \
      http://auth.example.com/_auth
 ```

--- a/docs/deDE/API.md
+++ b/docs/deDE/API.md
@@ -198,7 +198,7 @@ Anfrage zum Senden eines Verifizierungscodes. Dieser Endpunkt wird im Warden + H
 
 #### Anfragekörper
 
-Formulardaten (`application/x-www-form-urlencoded`) oder JSON (`application/json`) :
+Nur Formulardaten (`application/x-www-form-urlencoded`):
 
 | Feld | Typ | Erforderlich | Beschreibung |
 |------|-----|--------------|--------------|
@@ -226,11 +226,10 @@ Formulardaten (`application/x-www-form-urlencoded`) oder JSON (`application/json
 ```json
 {
   "success": true,
+  "message": "Verification code sent",
   "challenge_id": "ch_xxxxxxxxxxxx",
   "expires_in": 300,
-  "next_resend_in": 60,
-  "channel": "email",
-  "destination": "u***@example.com"
+  "next_resend_in": 60
 }
 ```
 
@@ -258,11 +257,6 @@ curl -X POST \
      -H "Content-Type: application/x-www-form-urlencoded" \
      http://auth.example.com/_send_verify_code
 
-# JSON-Format verwenden
-curl -X POST \
-     -H "Content-Type: application/json" \
-     -d '{"mail":"user@example.com"}' \
-     http://auth.example.com/_send_verify_code
 ```
 
 #### Hinweise
@@ -360,15 +354,19 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## TOTP-Endpunkte
 
-Diese Endpunkte sind verfügbar, wenn Herald und Herald-TOTP aktiviert sind. Sie erfordern eine authentifizierte Sitzung.
+Diese Endpunkte sind verfügbar, wenn Herald und Herald-TOTP aktiviert sind. Die Registrierung muss innerhalb von 10 Minuten nach der Anmeldung gestartet und abgeschlossen werden.
+
+### `GET /totp/enroll`
+
+Zeigt eine Bestätigungsseite an, ohne Registrierungsstatus zu erzeugen. Erfordert eine innerhalb der letzten 10 Minuten erstellte authentifizierte Sitzung.
 
 ### `POST /totp/enroll`
 
-Startet die Registrierung und zeigt die TOTP-Bindungsseite an.
+Startet die Registrierung und zeigt die TOTP-Bindungsseite an. Erfordert eine innerhalb der letzten 10 Minuten erstellte Sitzung.
 
 ### `POST /totp/enroll/confirm`
 
-Bestätigt die Registrierung mit dem sechsstelligen TOTP-Code im Feld `code`.
+Bestätigt die Registrierung mit Formulardaten (`application/x-www-form-urlencoded`). Sowohl `enroll_id` als auch der sechsstellige TOTP-`code` sind erforderlich. Die Antwort ist JSON und enthält bei Erfolg auch die einmalig ausgegebenen Backup-Codes.
 
 ### `GET /totp/revoke`
 

--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -72,6 +72,7 @@ The user header name can be configured via the `USER_HEADER_NAME` environment va
 **Using Header Authentication (API Request)**
 
 ```bash
+# Server prerequisite: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" \
      http://auth.example.com/_auth
 ```

--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -233,7 +233,7 @@ Send verification code request. This endpoint is used in the Warden + Herald OTP
 
 #### Request Body
 
-Form data (`application/x-www-form-urlencoded`) or JSON (`application/json`):
+Form data (`application/x-www-form-urlencoded`) only:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -267,11 +267,10 @@ Form data (`application/x-www-form-urlencoded`) or JSON (`application/json`):
 ```json
 {
   "success": true,
+  "message": "Verification code sent",
   "challenge_id": "ch_xxxxxxxxxxxx",
   "expires_in": 300,
-  "next_resend_in": 60,
-  "channel": "email",
-  "destination": "u***@example.com"
+  "next_resend_in": 60
 }
 ```
 
@@ -299,11 +298,6 @@ curl -X POST \
      -H "Content-Type: application/x-www-form-urlencoded" \
      http://auth.example.com/_send_verify_code
 
-# Using JSON format
-curl -X POST \
-     -H "Content-Type: application/json" \
-     -d '{"mail":"user@example.com"}' \
-     http://auth.example.com/_send_verify_code
 ```
 
 #### Notes
@@ -401,22 +395,26 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## TOTP Endpoints
 
-When Herald TOTP is enabled (`HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`), Stargate provides TOTP (authenticator app) bind/unbind and verification as part of login. These endpoints require an authenticated session.
+When Herald TOTP is enabled (`HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`), Stargate provides TOTP (authenticator app) bind/unbind and verification as part of login. These endpoints require an authenticated session. Enrollment must start and finish within 10 minutes of the login that created the session.
+
+### `GET /totp/enroll`
+
+Displays a confirmation page without creating enrollment state. It requires a recently authenticated session; unauthenticated users are redirected to `/_login`, while an older session receives `401 Unauthorized`.
 
 ### `POST /totp/enroll`
 
 Starts enrollment and displays the TOTP bind page. POST prevents cross-site navigation from creating enrollment state.
 
-- **Authentication**: Required (session cookie). Unauthenticated users are redirected to `/_login`.
+- **Authentication**: A session created by a successful login within the last 10 minutes. Unauthenticated users are redirected to `/_login`; older sessions receive `401 Unauthorized`.
 - **Response**: 200 OK with enrollment page HTML; or 302 to `/_login` if not authenticated; or 400/503 on configuration or Herald errors.
 
 ### `POST /totp/enroll/confirm`
 
 Confirms TOTP binding with the code from the authenticator app.
 
-- **Authentication**: Required (session cookie).
-- **Request Body**: Form or JSON with `code` (6-digit TOTP code).
-- **Response**: Success redirects to a success page or root; failure returns error (e.g. 400 for invalid code).
+- **Authentication**: A session created by a successful login within the last 10 minutes.
+- **Request Body**: Form data (`application/x-www-form-urlencoded`) containing the `enroll_id` returned by the enrollment page and the 6-digit TOTP `code`.
+- **Response**: JSON. Success returns `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`; invalid or expired enrollment state returns `400`, and missing recent authentication returns `401`.
 
 ### `GET /totp/revoke`
 
@@ -431,7 +429,7 @@ Confirms TOTP unbind (removes TOTP from the account).
 
 - **Authentication**: Required (session cookie).
 - **Request Body**: `password` or a valid current TOTP `code` is required to prove recent authentication.
-- **Response**: Success redirects or returns OK; failure returns error.
+- **Response**: JSON. Success returns `{"ok":true,"subject":"..."}`; failed reauthentication returns `401`, and an upstream revoke failure returns `502`.
 
 **Notes:** TOTP creation and verification are performed by Herald (which may proxy to herald-totp). Stargate only orchestrates the UI and session; it does not implement OTP algorithms.
 

--- a/docs/frFR/API.md
+++ b/docs/frFR/API.md
@@ -69,6 +69,7 @@ Le nom de l'en-tête utilisateur peut être configuré via la variable d'environ
 **Utilisation de l'Authentification par En-tête (Requête API)**
 
 ```bash
+# Prérequis côté serveur : PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" \
      http://auth.example.com/_auth
 ```

--- a/docs/frFR/API.md
+++ b/docs/frFR/API.md
@@ -199,7 +199,7 @@ Requête d'envoi de code de vérification. Ce point de terminaison est utilisé 
 
 #### Corps de Requête
 
-Données de formulaire (`application/x-www-form-urlencoded`) ou JSON (`application/json`) :
+Données de formulaire (`application/x-www-form-urlencoded`) uniquement :
 
 | Champ | Type | Requis | Description |
 |-------|------|--------|-------------|
@@ -227,11 +227,10 @@ Données de formulaire (`application/x-www-form-urlencoded`) ou JSON (`applicati
 ```json
 {
   "success": true,
+  "message": "Verification code sent",
   "challenge_id": "ch_xxxxxxxxxxxx",
   "expires_in": 300,
-  "next_resend_in": 60,
-  "channel": "email",
-  "destination": "u***@example.com"
+  "next_resend_in": 60
 }
 ```
 
@@ -259,11 +258,6 @@ curl -X POST \
      -H "Content-Type: application/x-www-form-urlencoded" \
      http://auth.example.com/_send_verify_code
 
-# Utiliser le format JSON
-curl -X POST \
-     -H "Content-Type: application/json" \
-     -d '{"mail":"user@example.com"}' \
-     http://auth.example.com/_send_verify_code
 ```
 
 #### Notes
@@ -361,15 +355,19 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## Points de Terminaison TOTP
 
-Ces points de terminaison sont disponibles lorsque Herald et Herald TOTP sont activés. Ils nécessitent une session authentifiée.
+Ces points de terminaison sont disponibles lorsque Herald et Herald TOTP sont activés. L'inscription doit commencer et se terminer dans les 10 minutes suivant la connexion qui a créé la session.
+
+### `GET /totp/enroll`
+
+Affiche une page de confirmation sans créer d'état d'inscription. Nécessite une session créée par une connexion réussie au cours des 10 dernières minutes.
 
 ### `POST /totp/enroll`
 
-Démarre l'inscription et affiche la page d'association TOTP.
+Démarre l'inscription et affiche la page d'association TOTP. Nécessite une session créée au cours des 10 dernières minutes.
 
 ### `POST /totp/enroll/confirm`
 
-Confirme l'inscription avec le code TOTP à six chiffres dans le champ `code`.
+Confirme l'inscription avec des données de formulaire (`application/x-www-form-urlencoded`). `enroll_id` et le `code` TOTP à six chiffres sont tous deux obligatoires. La réponse est en JSON et inclut les codes de secours à usage unique en cas de succès.
 
 ### `GET /totp/revoke`
 

--- a/docs/itIT/API.md
+++ b/docs/itIT/API.md
@@ -198,7 +198,7 @@ Richiesta di invio codice di verifica. Questo endpoint è utilizzato nel flusso 
 
 #### Corpo della Richiesta
 
-Dati del form (`application/x-www-form-urlencoded`) o JSON (`application/json`) :
+Solo dati del form (`application/x-www-form-urlencoded`):
 
 | Campo | Tipo | Richiesto | Descrizione |
 |-------|------|-----------|-------------|
@@ -226,11 +226,10 @@ Dati del form (`application/x-www-form-urlencoded`) o JSON (`application/json`) 
 ```json
 {
   "success": true,
+  "message": "Verification code sent",
   "challenge_id": "ch_xxxxxxxxxxxx",
   "expires_in": 300,
-  "next_resend_in": 60,
-  "channel": "email",
-  "destination": "u***@example.com"
+  "next_resend_in": 60
 }
 ```
 
@@ -258,11 +257,6 @@ curl -X POST \
      -H "Content-Type: application/x-www-form-urlencoded" \
      http://auth.example.com/_send_verify_code
 
-# Usando formato JSON
-curl -X POST \
-     -H "Content-Type: application/json" \
-     -d '{"mail":"user@example.com"}' \
-     http://auth.example.com/_send_verify_code
 ```
 
 #### Note
@@ -360,15 +354,19 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## Endpoint TOTP
 
-Questi endpoint sono disponibili quando Herald e Herald TOTP sono abilitati. Richiedono una sessione autenticata.
+Questi endpoint sono disponibili quando Herald e Herald TOTP sono abilitati. La registrazione deve iniziare e terminare entro 10 minuti dal login che ha creato la sessione.
+
+### `GET /totp/enroll`
+
+Mostra una pagina di conferma senza creare lo stato di registrazione. Richiede una sessione creata da un login riuscito negli ultimi 10 minuti.
 
 ### `POST /totp/enroll`
 
-Avvia la registrazione e mostra la pagina di associazione TOTP.
+Avvia la registrazione e mostra la pagina di associazione TOTP. Richiede una sessione creata negli ultimi 10 minuti.
 
 ### `POST /totp/enroll/confirm`
 
-Conferma la registrazione con il codice TOTP a sei cifre nel campo `code`.
+Conferma la registrazione con dati del form (`application/x-www-form-urlencoded`). Sono obbligatori sia `enroll_id` sia il `code` TOTP a sei cifre. La risposta è JSON e, in caso di successo, include i codici di backup mostrati una sola volta.
 
 ### `GET /totp/revoke`
 

--- a/docs/itIT/API.md
+++ b/docs/itIT/API.md
@@ -68,6 +68,7 @@ Il nome dell'header utente può essere configurato tramite la variabile d'ambien
 **Utilizzo Autenticazione Header (Richiesta API)**
 
 ```bash
+# Prerequisito del server: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" \
      http://auth.example.com/_auth
 ```

--- a/docs/jaJP/API.md
+++ b/docs/jaJP/API.md
@@ -68,6 +68,7 @@ X-Forwarded-User: authenticated
 **ヘッダー認証の使用（API リクエスト）**
 
 ```bash
+# サーバー側の前提条件: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" \
      http://auth.example.com/_auth
 ```

--- a/docs/jaJP/API.md
+++ b/docs/jaJP/API.md
@@ -198,7 +198,7 @@ curl -X POST \
 
 #### リクエストボディ
 
-フォームデータ (`application/x-www-form-urlencoded`) または JSON (`application/json`) :
+フォームデータ（`application/x-www-form-urlencoded`）のみ：
 
 | フィールド | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
@@ -226,11 +226,10 @@ curl -X POST \
 ```json
 {
   "success": true,
+  "message": "Verification code sent",
   "challenge_id": "ch_xxxxxxxxxxxx",
   "expires_in": 300,
-  "next_resend_in": 60,
-  "channel": "email",
-  "destination": "u***@example.com"
+  "next_resend_in": 60
 }
 ```
 
@@ -258,11 +257,6 @@ curl -X POST \
      -H "Content-Type: application/x-www-form-urlencoded" \
      http://auth.example.com/_send_verify_code
 
-# JSON形式を使用
-curl -X POST \
-     -H "Content-Type: application/json" \
-     -d '{"mail":"user@example.com"}' \
-     http://auth.example.com/_send_verify_code
 ```
 
 #### 注意事項
@@ -360,15 +354,19 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## TOTP エンドポイント
 
-Herald と Herald TOTP が有効な場合に利用できます。すべて認証済みセッションが必要です。
+Herald と Herald TOTP が有効な場合に利用できます。登録は、セッションを作成したログインから 10 分以内に開始して完了する必要があります。
+
+### `GET /totp/enroll`
+
+登録状態を作成せずに確認ページを表示します。直近 10 分以内のログインで作成されたセッションが必要です。
 
 ### `POST /totp/enroll`
 
-登録を開始し、TOTP の関連付けページを表示します。
+登録を開始し、TOTP の関連付けページを表示します。直近 10 分以内に作成されたセッションが必要です。
 
 ### `POST /totp/enroll/confirm`
 
-`code` フィールドの 6 桁の TOTP コードで登録を確定します。
+フォームデータ（`application/x-www-form-urlencoded`）で登録を確定します。`enroll_id` と 6 桁の TOTP `code` の両方が必要です。レスポンスは JSON で、成功時には一度だけ表示されるバックアップコードを含みます。
 
 ### `GET /totp/revoke`
 

--- a/docs/koKR/API.md
+++ b/docs/koKR/API.md
@@ -198,7 +198,7 @@ curl -X POST \
 
 #### 요청 본문
 
-폼 데이터 (`application/x-www-form-urlencoded`) 또는 JSON (`application/json`) :
+폼 데이터(`application/x-www-form-urlencoded`)만 지원합니다:
 
 | 필드 | 유형 | 필수 | 설명 |
 |------|------|------|------|
@@ -226,11 +226,10 @@ curl -X POST \
 ```json
 {
   "success": true,
+  "message": "Verification code sent",
   "challenge_id": "ch_xxxxxxxxxxxx",
   "expires_in": 300,
-  "next_resend_in": 60,
-  "channel": "email",
-  "destination": "u***@example.com"
+  "next_resend_in": 60
 }
 ```
 
@@ -258,11 +257,6 @@ curl -X POST \
      -H "Content-Type: application/x-www-form-urlencoded" \
      http://auth.example.com/_send_verify_code
 
-# JSON 형식 사용
-curl -X POST \
-     -H "Content-Type: application/json" \
-     -d '{"mail":"user@example.com"}' \
-     http://auth.example.com/_send_verify_code
 ```
 
 #### 참고 사항
@@ -360,15 +354,19 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## TOTP 엔드포인트
 
-Herald와 Herald TOTP가 활성화된 경우 사용할 수 있습니다. 모든 엔드포인트에 인증된 세션이 필요합니다.
+Herald와 Herald TOTP가 활성화된 경우 사용할 수 있습니다. 등록은 세션을 만든 로그인 후 10분 이내에 시작하고 완료해야 합니다.
+
+### `GET /totp/enroll`
+
+등록 상태를 만들지 않고 확인 페이지를 표시합니다. 최근 10분 이내의 로그인으로 생성된 세션이 필요합니다.
 
 ### `POST /totp/enroll`
 
-등록을 시작하고 TOTP 연결 페이지를 표시합니다.
+등록을 시작하고 TOTP 연결 페이지를 표시합니다. 최근 10분 이내에 생성된 세션이 필요합니다.
 
 ### `POST /totp/enroll/confirm`
 
-`code` 필드의 6자리 TOTP 코드로 등록을 확인합니다.
+폼 데이터(`application/x-www-form-urlencoded`)로 등록을 확인합니다. `enroll_id`와 6자리 TOTP `code`가 모두 필요합니다. 응답은 JSON이며 성공 시 한 번만 표시되는 백업 코드를 포함합니다.
 
 ### `GET /totp/revoke`
 

--- a/docs/koKR/API.md
+++ b/docs/koKR/API.md
@@ -68,6 +68,7 @@ X-Forwarded-User: authenticated
 **헤더 인증 사용 (API 요청)**
 
 ```bash
+# 서버 전제 조건: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" \
      http://auth.example.com/_auth
 ```

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -72,6 +72,7 @@ X-Forwarded-User: authenticated
 **使用 Header 认证（API 请求）**
 
 ```bash
+# 服务端启动前必须设置：PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" \
      http://auth.example.com/_auth
 ```

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -233,7 +233,7 @@ curl -X POST \
 
 #### 请求体
 
-表单数据（`application/x-www-form-urlencoded`）或 JSON（`application/json`）：
+仅支持表单数据（`application/x-www-form-urlencoded`）：
 
 | 字段 | 类型 | 必需 | 说明 |
 |------|------|------|------|
@@ -261,11 +261,10 @@ curl -X POST \
 ```json
 {
   "success": true,
+  "message": "验证码已发送",
   "challenge_id": "ch_xxxxxxxxxxxx",
   "expires_in": 300,
-  "next_resend_in": 60,
-  "channel": "email",
-  "destination": "u***@example.com"
+  "next_resend_in": 60
 }
 ```
 
@@ -293,11 +292,6 @@ curl -X POST \
      -H "Content-Type: application/x-www-form-urlencoded" \
      http://auth.example.com/_send_verify_code
 
-# 使用 JSON 格式
-curl -X POST \
-     -H "Content-Type: application/json" \
-     -d '{"mail":"user@example.com"}' \
-     http://auth.example.com/_send_verify_code
 ```
 
 #### 注意事项
@@ -395,22 +389,26 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## TOTP 端点
 
-当启用 Herald TOTP（`HERALD_ENABLED=true`、`HERALD_TOTP_ENABLED=true`）时，Stargate 提供 TOTP（认证器应用）绑定/解绑及登录时的验证。这些端点需要已认证会话。
+当启用 Herald TOTP（`HERALD_ENABLED=true`、`HERALD_TOTP_ENABLED=true`）时，Stargate 提供 TOTP（认证器应用）绑定/解绑及登录时的验证。这些端点需要已认证会话，且绑定流程必须在创建会话的登录成功后 10 分钟内开始并完成。
+
+### `GET /totp/enroll`
+
+显示绑定确认页，但不创建绑定状态。要求最近认证的会话；未认证用户重定向到 `/_login`，超过 10 分钟的会话返回 `401 Unauthorized`。
 
 ### `POST /totp/enroll`
 
 启动绑定并展示 TOTP 页面。使用 POST 可避免跨站导航创建绑定状态。
 
-- **认证**：需要（会话 Cookie）。未认证用户会重定向到 `/_login`。
+- **认证**：要求会话由最近 10 分钟内成功登录创建。未认证用户重定向到 `/_login`，过期会话返回 `401 Unauthorized`。
 - **响应**：200 OK 返回绑定页 HTML；未认证时 302 到 `/_login`；配置或 Herald 错误时 400/503。
 
 ### `POST /totp/enroll/confirm`
 
 使用认证器应用生成的 6 位码确认 TOTP 绑定。
 
-- **认证**：需要（会话 Cookie）。
-- **请求体**：表单或 JSON，包含 `code`（6 位 TOTP 码）。
-- **响应**：成功时重定向到成功页或根路径；失败返回错误（如 400 表示验证码错误）。
+- **认证**：要求会话由最近 10 分钟内成功登录创建。
+- **请求体**：表单数据（`application/x-www-form-urlencoded`），同时包含绑定页返回的 `enroll_id` 和 6 位 TOTP `code`。
+- **响应**：JSON。成功返回 `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`；绑定状态无效或过期返回 `400`，缺少最近认证返回 `401`。
 
 ### `GET /totp/revoke`
 
@@ -425,7 +423,7 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 - **认证**：需要（会话 Cookie）。
 - **请求体**：必须提供密码或当前有效的 TOTP `code`，用于最近认证确认。
-- **响应**：成功时重定向或返回 OK；失败返回错误。
+- **响应**：JSON。成功返回 `{"ok":true,"subject":"..."}`；重新认证失败返回 `401`，上游解绑失败返回 `502`。
 
 **说明**：TOTP 的创建与校验由 Herald（可能代理到 herald-totp）完成。Stargate 仅负责页面与会话编排，不实现 OTP 算法。
 


### PR DESCRIPTION
## Summary

- document `/_send_verify_code` as form-only and remove the unsupported JSON example
- document the exact verification-code response fields
- add the safe `GET /totp/enroll` route and the 10-minute recent-login requirement
- require both `enroll_id` and `code` for TOTP confirmation and document its JSON response
- synchronize all seven API translations

## Verification

- `bash .github/scripts/check-doc-contracts.sh`
- `git diff --check`