### PR TITLE
docs: correct v1 deployment and migration guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This file records user-visible changes. For upgrade steps and configuration exam
 - Added strict callback-host, cookie-domain, HTTP-header, service-URL, secret-length, and TLS-pair validation.
 - Added Redis-backed shared session and session-ticket replay state for multi-instance deployments.
 - Split liveness (`/healthz`) from dependency readiness (`/readyz`) and added TLS-aware Warden and Herald checks.
-- Added Prometheus metrics, structured audit events, configurable log levels, container hardening, SBOMs, artifact attestations, checksums, Cosign signatures, and multi-architecture image scanning.
+- Added structured audit events, configurable log levels, container hardening, SBOMs, artifact attestations, checksums, Cosign signatures, and multi-architecture image scanning.
 - User-visible verification errors no longer expose upstream provider details.
 
 ### Compatibility and documentation

--- a/docs/deDE/DEPLOYMENT.md
+++ b/docs/deDE/DEPLOYMENT.md
@@ -438,7 +438,7 @@ Verwenden Sie `/healthz` für die Prozess-Liveness und `/readyz` für die Bereit
 ```bash
 # Gesundheitsprüfungs-Skript
 #!/bin/bash
-if curl -f http://localhost/healthz > /dev/null 2>&1; then
+if curl -f http://localhost:8080/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -609,6 +609,7 @@ docker logs traefik
 curl http://auth.example.com/healthz
 
 # Authentifizierung testen (mit Header)
+# Server-Voraussetzung: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" http://auth.example.com/_auth
 
 # Authentifizierung testen (mit Cookie)

--- a/docs/enUS/CONTRIBUTING.md
+++ b/docs/enUS/CONTRIBUTING.md
@@ -224,7 +224,7 @@ Clearly and concisely describe what actually happened.
 
 **Environment Information**
 - OS: [e.g. macOS 12.0]
-- Go Version: [e.g. 1.26]
+- Go Version: [e.g. 1.27]
 - Traefik Version: [e.g. v2.10] (if applicable)
 - Stargate Version: [e.g. v1.0.0]
 ```

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -438,7 +438,7 @@ Use `/healthz` for process liveness. Use `/readyz` separately when traffic shoul
 ```bash
 # Health check script
 #!/bin/bash
-if curl -f http://localhost/healthz > /dev/null 2>&1; then
+if curl -f http://localhost:8080/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -609,6 +609,7 @@ docker logs traefik
 curl http://auth.example.com/healthz
 
 # Test authentication (using Header)
+# Server prerequisite: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" http://auth.example.com/_auth
 
 # Test authentication (using Cookie)

--- a/docs/enUS/MIGRATION_V1.md
+++ b/docs/enUS/MIGRATION_V1.md
@@ -70,7 +70,7 @@ Do not place arbitrary client networks in `TRUSTED_PROXIES`.
 | `GET /_logout` | `POST /_logout` | Update links and clients to submit a POST request. |
 | `GET /totp/enroll` | `POST /totp/enroll` | Start enrollment with POST. |
 | `GET /health` for all probes | `GET /healthz` and `GET /readyz` | Separate liveness from dependency readiness. |
-| No metrics endpoint | `GET /metrics` | Point Prometheus-compatible scraping here. |
+| `GET /metrics` | `GET /metrics` (unchanged) | Keep the existing Prometheus-compatible scrape target. |
 | Session exchange `?id=` | Session exchange `?ticket=` | Follow Stargate redirects; do not expose session IDs. |
 
 `GET /health` remains as a deprecated compatibility alias for readiness. New deployments should not use it. Browser requests that change authentication state are subject to same-origin checks and endpoint-specific rate limits.

--- a/docs/frFR/DEPLOYMENT.md
+++ b/docs/frFR/DEPLOYMENT.md
@@ -438,7 +438,7 @@ Utilisez `/healthz` pour la liveness du processus et `/readyz` pour la disponibi
 ```bash
 # Script de vérification de santé
 #!/bin/bash
-if curl -f http://localhost/healthz > /dev/null 2>&1; then
+if curl -f http://localhost:8080/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -609,6 +609,7 @@ docker logs traefik
 curl http://auth.example.com/healthz
 
 # Tester l'authentification (utilisant l'En-tête)
+# Prérequis côté serveur : PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" http://auth.example.com/_auth
 
 # Tester l'authentification (utilisant le Cookie)

--- a/docs/itIT/DEPLOYMENT.md
+++ b/docs/itIT/DEPLOYMENT.md
@@ -438,7 +438,7 @@ Usare `/healthz` per la liveness del processo e `/readyz` per la readiness delle
 ```bash
 # Script verifica salute
 #!/bin/bash
-if curl -f http://localhost/healthz > /dev/null 2>&1; then
+if curl -f http://localhost:8080/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -609,6 +609,7 @@ docker logs traefik
 curl http://auth.example.com/healthz
 
 # Testare autenticazione (utilizzando Header)
+# Prerequisito del server: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" http://auth.example.com/_auth
 
 # Testare autenticazione (utilizzando Cookie)

--- a/docs/jaJP/DEPLOYMENT.md
+++ b/docs/jaJP/DEPLOYMENT.md
@@ -438,7 +438,7 @@ services:
 ```bash
 # ヘルスチェックスクリプト
 #!/bin/bash
-if curl -f http://localhost/healthz > /dev/null 2>&1; then
+if curl -f http://localhost:8080/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -609,6 +609,7 @@ docker logs traefik
 curl http://auth.example.com/healthz
 
 # 認証をテスト（ヘッダーを使用）
+# サーバー側の前提条件: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" http://auth.example.com/_auth
 
 # 認証をテスト（Cookie を使用）

--- a/docs/koKR/DEPLOYMENT.md
+++ b/docs/koKR/DEPLOYMENT.md
@@ -438,7 +438,7 @@ services:
 ```bash
 # 헬스 체크 스크립트
 #!/bin/bash
-if curl -f http://localhost/healthz > /dev/null 2>&1; then
+if curl -f http://localhost:8080/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -609,6 +609,7 @@ docker logs traefik
 curl http://auth.example.com/healthz
 
 # 인증 테스트 (헤더 사용)
+# 서버 전제 조건: PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" http://auth.example.com/_auth
 
 # 인증 테스트 (Cookie 사용)

--- a/docs/zhCN/CONTRIBUTING.md
+++ b/docs/zhCN/CONTRIBUTING.md
@@ -224,7 +224,7 @@ git push origin feature/your-feature-name
 
 **环境信息**
 - OS: [e.g. macOS 12.0]
-- Go 版本: [e.g. 1.26]
+- Go 版本: [e.g. 1.27]
 - Traefik 版本: [e.g. v2.10]（如适用）
 - Stargate 版本: [e.g. v1.0.0]
 ```

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -548,7 +548,7 @@ services:
 ```bash
 # 健康检查脚本
 #!/bin/bash
-if curl -f http://localhost/healthz > /dev/null 2>&1; then
+if curl -f http://localhost:8080/healthz > /dev/null 2>&1; then
   exit 0
 else
   exit 1
@@ -794,6 +794,7 @@ docker logs traefik
 curl http://auth.example.com/healthz
 
 # 测试认证（使用 Header）
+# 服务端启动前必须设置：PASSWORD_HEADER_AUTH_ENABLED=true
 curl -H "Stargate-Password: yourpassword" http://auth.example.com/_auth
 
 # 测试认证（使用 Cookie）

--- a/docs/zhCN/MIGRATION_V1.md
+++ b/docs/zhCN/MIGRATION_V1.md
@@ -70,7 +70,7 @@ v1.0.0 使用加密、短时、单次有效且绑定目标域名的 `?ticket=` �
 | `GET /_logout` | `POST /_logout` | 将链接或客户端改为提交 POST 请求。 |
 | `GET /totp/enroll` | `POST /totp/enroll` | 使用 POST 发起注册。 |
 | 所有探针使用 `GET /health` | `GET /healthz` 与 `GET /readyz` | 区分进程存活和依赖就绪。 |
-| 无指标端点 | `GET /metrics` | 将 Prometheus 兼容采集目标指向此端点。 |
+| `GET /metrics` | `GET /metrics`（保持不变） | 继续使用现有的 Prometheus 兼容采集目标。 |
 | 会话交换 `?id=` | 会话交换 `?ticket=` | 跟随 Stargate 重定向，不再暴露会话 ID。 |
 
 `GET /health` 仅作为已弃用的就绪检查兼容别名保留，新部署不应继续使用。浏览器中改变认证状态的请求会受到同源检查和端点级限流保护。


### PR DESCRIPTION
## Summary

- use port `8080` in direct-container health checks across all seven deployment guides
- state the server-side `PASSWORD_HEADER_AUTH_ENABLED=true` prerequisite for header-auth checks
- stop describing `/metrics` as new in v1; it already existed in v0.12.0
- remove the same historical error from the changelog
- update the contributing issue templates to Go 1.27

## Verification

- `bash .github/scripts/check-doc-contracts.sh`
- `git diff --check`
- checked that stale health, metrics, and Go 1.26 patterns are absent