### PR TITLE
fix: preserve verification audit context

### DIFF
--- a/src/internal/auditlog/auditlog.go
+++ b/src/internal/auditlog/auditlog.go
@@ -73,8 +73,9 @@ func (s *StreamStorage) Write(_ context.Context, record *audit.Record) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.format == "text" {
-		_, err := fmt.Fprintf(s.writer, "timestamp=%d event=%s result=%s user_id=%q ip=%q reason=%q metadata=%v\n",
-			record.Timestamp, record.EventType, record.Result, record.UserID, record.IP, record.Reason, record.Metadata)
+		_, err := fmt.Fprintf(s.writer, "timestamp=%d event=%s result=%s user_id=%q channel=%q destination=%q ip=%q reason=%q metadata=%v\n",
+			record.Timestamp, record.EventType, record.Result, record.UserID, record.Channel, record.Destination,
+			record.IP, record.Reason, record.Metadata)
 		return err
 	}
 	data, err := json.Marshal(record)
@@ -155,7 +156,7 @@ func LogVerifyCodeSend(ctx context.Context, userID, channel, destination, ip str
 }
 
 // LogVerifyCodeCheck records a verification code check event
-func LogVerifyCodeCheck(ctx context.Context, userID, ip string, success bool, reason string) {
+func LogVerifyCodeCheck(ctx context.Context, userID, channel, destination, ip string, success bool, reason string) {
 	l := GetLogger()
 	if l == nil {
 		return
@@ -169,6 +170,8 @@ func LogVerifyCodeCheck(ctx context.Context, userID, ip string, success bool, re
 	}
 
 	l.LogChallenge(ctx, eventType, "", userID, result,
+		audit.WithRecordChannel(channel),
+		audit.WithRecordDestination(destination),
 		audit.WithRecordIP(ip),
 		audit.WithRecordReason(reason),
 	)

--- a/src/internal/auditlog/auditlog_test.go
+++ b/src/internal/auditlog/auditlog_test.go
@@ -50,11 +50,11 @@ func TestAuditLogFunctions(t *testing.T) {
 	})
 
 	t.Run("LogVerifyCodeCheck Success", func(t *testing.T) {
-		LogVerifyCodeCheck(ctx, "user1", "127.0.0.1", true, "")
+		LogVerifyCodeCheck(ctx, "user1", "sms", "13800000000", "127.0.0.1", true, "")
 	})
 
 	t.Run("LogVerifyCodeCheck Failure", func(t *testing.T) {
-		LogVerifyCodeCheck(ctx, "user1", "127.0.0.1", false, "invalid_code")
+		LogVerifyCodeCheck(ctx, "user1", "email", "user@example.com", "127.0.0.1", false, "invalid_code")
 	})
 
 	t.Run("LogSessionCreate", func(t *testing.T) {
@@ -82,6 +82,8 @@ func TestGetLoggerWithoutInit(t *testing.T) {
 func TestStreamStorageHonorsFormats(t *testing.T) {
 	record := audit.NewRecord(audit.EventLoginSuccess, audit.ResultSuccess)
 	record.UserID = "user1"
+	record.Channel = "email"
+	record.Destination = "u***@example.com"
 
 	var jsonOutput bytes.Buffer
 	assert.NoError(t, NewStreamStorage(&jsonOutput, "json").Write(context.Background(), record))
@@ -91,6 +93,8 @@ func TestStreamStorageHonorsFormats(t *testing.T) {
 	assert.NoError(t, NewStreamStorage(&textOutput, "text").Write(context.Background(), record))
 	assert.Contains(t, textOutput.String(), "event=")
 	assert.Contains(t, textOutput.String(), "user_id=\"user1\"")
+	assert.Contains(t, textOutput.String(), "channel=\"email\"")
+	assert.Contains(t, textOutput.String(), "destination=\"u***@example.com\"")
 }
 
 func TestInitDefaultAcceptsCaseInsensitiveFormat(t *testing.T) {

--- a/src/internal/handlers/login.go
+++ b/src/internal/handlers/login.go
@@ -232,6 +232,7 @@ func loginAPIHandler(ctx fiber.Ctx, sessionGetter SessionGetter, authenticator A
 		challengeID := ctx.FormValue("challenge_id")
 		otpCode := ctx.FormValue("otp_code")
 		useOTP := ctx.FormValue("use_otp") == "true"
+		auditChannel, auditDestination, _ := selectVerificationDestination(userInfo, ctx.FormValue("deliver_via"))
 
 		// Only per-user TOTP managed by Herald is supported.
 		otpEnabled := config.HeraldTOTPEnabled.ToBool()
@@ -292,7 +293,7 @@ func loginAPIHandler(ctx fiber.Ctx, sessionGetter SessionGetter, authenticator A
 					if (heraldErr.StatusCode == http.StatusUnauthorized || heraldErr.StatusCode == http.StatusBadRequest) &&
 						verifyResp != nil && !verifyResp.OK && verifyResp.Reason != "" {
 						reason := verifyResp.Reason
-						auditlog.LogVerifyCodeCheck(ctx.Context(), userID, ctx.IP(), false, reason)
+						auditlog.LogVerifyCodeCheck(ctx.Context(), userID, auditChannel, auditDestination, ctx.IP(), false, reason)
 						var errorMsg string
 						switch reason {
 						case "expired":
@@ -342,7 +343,7 @@ func loginAPIHandler(ctx fiber.Ctx, sessionGetter SessionGetter, authenticator A
 					reason = "invalid"
 				}
 				log.Warn().Str("reason", reason).Msg("Challenge verification failed")
-				auditlog.LogVerifyCodeCheck(ctx.Context(), userID, ctx.IP(), false, reason)
+				auditlog.LogVerifyCodeCheck(ctx.Context(), userID, auditChannel, auditDestination, ctx.IP(), false, reason)
 
 				// Provide detailed error message based on reason
 				var errorMsg string
@@ -382,7 +383,7 @@ func loginAPIHandler(ctx fiber.Ctx, sessionGetter SessionGetter, authenticator A
 			)
 			heraldSpan.End()
 			metrics.RecordHeraldCall("verify_challenge", "success", duration)
-			auditlog.LogVerifyCodeCheck(ctx.Context(), userID, ctx.IP(), true, "")
+			auditlog.LogVerifyCodeCheck(ctx.Context(), userID, auditChannel, auditDestination, ctx.IP(), true, "")
 
 			// Verify user ID matches
 			if verifyResp.UserID != userID {

--- a/src/internal/handlers/send_verify_code.go
+++ b/src/internal/handlers/send_verify_code.go
@@ -18,6 +18,7 @@ import (
 	"github.com/soulteary/stargate/src/internal/i18n"
 	"github.com/soulteary/stargate/src/internal/metrics"
 	"github.com/soulteary/tracing-kit"
+	"github.com/soulteary/warden/pkg/warden"
 )
 
 // sendVerifyCodeErrorJSON returns JSON in the shape expected by the login page Send Code UI:
@@ -54,6 +55,58 @@ func getLocaleFromConfig() string {
 	default:
 		return "en-US"
 	}
+}
+
+// selectVerificationDestination resolves the same canonical Warden-backed
+// channel and destination for challenge creation and verification auditing.
+// Request identifiers are lookup inputs only and are never used as fallback
+// destinations.
+func selectVerificationDestination(userInfo *warden.AllowListUser, deliverVia string) (channel, destination, reason string) {
+	if userInfo == nil {
+		return "", "", "destination_unavailable"
+	}
+	canonicalPhone := strings.TrimSpace(userInfo.Phone)
+	canonicalMail := strings.TrimSpace(userInfo.Mail)
+	canonicalDingTalkID := strings.TrimSpace(userInfo.DingtalkUserID)
+
+	if deliverVia == "sms" && !config.LoginSMSEnabled.ToBool() {
+		return "", "", "channel_disabled"
+	}
+	if deliverVia == "email" && !config.LoginEmailEnabled.ToBool() {
+		return "", "", "channel_disabled"
+	}
+	switch deliverVia {
+	case "dingtalk":
+		if canonicalDingTalkID != "" {
+			return "dingtalk", canonicalDingTalkID, ""
+		}
+		if canonicalPhone != "" {
+			return "dingtalk", canonicalPhone, ""
+		}
+		return "", "", "dingtalk_not_bound"
+	case "email":
+		if config.LoginEmailEnabled.ToBool() && canonicalMail != "" {
+			return "email", canonicalMail, ""
+		}
+		if config.LoginSMSEnabled.ToBool() && canonicalPhone != "" {
+			return "sms", canonicalPhone, ""
+		}
+	case "sms", "":
+		if config.LoginSMSEnabled.ToBool() && canonicalPhone != "" {
+			return "sms", canonicalPhone, ""
+		}
+		if config.LoginEmailEnabled.ToBool() && canonicalMail != "" {
+			return "email", canonicalMail, ""
+		}
+	default:
+		if config.LoginSMSEnabled.ToBool() && canonicalPhone != "" {
+			return "sms", canonicalPhone, ""
+		}
+		if config.LoginEmailEnabled.ToBool() && canonicalMail != "" {
+			return "email", canonicalMail, ""
+		}
+	}
+	return "", "", "destination_unavailable"
 }
 
 // SendVerifyCodeAPI handles POST requests to /_send_verify_code for sending verification codes via Herald
@@ -123,51 +176,19 @@ func SendVerifyCodeAPI() func(c fiber.Ctx) error {
 		// Warden. Request identifiers are lookup inputs, not trusted destinations:
 		// binding a victim user_id to an attacker-supplied fallback address would
 		// turn the verification challenge into an account-takeover primitive.
-		canonicalPhone := strings.TrimSpace(userInfo.Phone)
-		canonicalMail := strings.TrimSpace(userInfo.Mail)
-		canonicalDingTalkID := strings.TrimSpace(userInfo.DingtalkUserID)
-
-		var channel, destination string
 		deliverVia := ctx.FormValue("deliver_via")
-		if deliverVia == "sms" && !config.LoginSMSEnabled.ToBool() {
-			return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.login_sms_disabled"), "channel_disabled")
-		}
-		if deliverVia == "email" && !config.LoginEmailEnabled.ToBool() {
-			return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.login_email_disabled"), "channel_disabled")
-		}
-		switch deliverVia {
-		case "dingtalk":
-			if canonicalDingTalkID != "" {
-				channel, destination = "dingtalk", canonicalDingTalkID
-			} else if canonicalPhone != "" {
-				// Herald may resolve the DingTalk user by the canonical Warden phone.
-				channel, destination = "dingtalk", canonicalPhone
-			} else {
-				return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.dingtalk_not_bound"), "dingtalk_not_bound")
-			}
-		case "email":
-			if config.LoginEmailEnabled.ToBool() && canonicalMail != "" {
-				channel, destination = "email", canonicalMail
-			} else if config.LoginSMSEnabled.ToBool() && canonicalPhone != "" {
-				channel, destination = "sms", canonicalPhone
-			} else {
-				return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.user_not_in_list"), "destination_unavailable")
-			}
-		case "sms":
-			if config.LoginSMSEnabled.ToBool() && canonicalPhone != "" {
-				channel, destination = "sms", canonicalPhone
-			} else if config.LoginEmailEnabled.ToBool() && canonicalMail != "" {
-				channel, destination = "email", canonicalMail
-			} else {
-				return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.user_not_in_list"), "destination_unavailable")
-			}
-		default:
-			if config.LoginSMSEnabled.ToBool() && canonicalPhone != "" {
-				channel, destination = "sms", canonicalPhone
-			} else if config.LoginEmailEnabled.ToBool() && canonicalMail != "" {
-				channel, destination = "email", canonicalMail
-			} else {
-				return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.user_not_in_list"), "destination_unavailable")
+		channel, destination, selectionReason := selectVerificationDestination(userInfo, deliverVia)
+		if selectionReason != "" {
+			switch selectionReason {
+			case "channel_disabled":
+				if deliverVia == "sms" {
+					return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.login_sms_disabled"), selectionReason)
+				}
+				return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.login_email_disabled"), selectionReason)
+			case "dingtalk_not_bound":
+				return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.dingtalk_not_bound"), selectionReason)
+			default:
+				return sendVerifyCodeErrorJSON(ctx, fiber.StatusBadRequest, i18n.T(ctx, "error.user_not_in_list"), selectionReason)
 			}
 		}
 


### PR DESCRIPTION
## Summary

- include verification `channel` and masked `destination` in text audit output
- attach the same fields to verification success and failure events, not only send events
- centralize canonical Warden-backed destination selection so send behavior and audit context cannot diverge
- keep request identifiers from becoming audit destinations
- extend audit-format tests for both fields

`audit-kit` keeps its default `MaskDestination=true`, so email addresses, phone numbers, and unknown destinations are masked before either JSON or text storage writes them.

## Verification

- `git diff --check`
- `bash .github/scripts/check-doc-contracts.sh`
- full Go checks delegated to PR Actions because this execution image does not contain Go