### PR TITLE
ci: publish curated v1 release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,12 +303,18 @@ jobs:
       - name: Sign checksum manifest
         run: cosign sign-blob --yes --bundle dist/checksums.txt.sigstore.json dist/checksums.txt
 
+      - name: Prepare curated release notes
+        run: |
+          sed "s#](docs/enUS/MIGRATION_V1.md)#](https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF_NAME}/docs/enUS/MIGRATION_V1.md)#" \
+            CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
+
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             dist/*
           name: Release ${{ steps.version.outputs.tag }}
+          body_path: ${{ runner.temp }}/release-notes.md
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
## Summary

- prepend the maintained `CHANGELOG.md` content to GitHub Releases
- rewrite the migration-guide link to the immutable release tag
- retain GitHub's auto-generated commit notes after the curated v1 contract
- leave release artifacts, checksums, signing, attestations, and image publishing unchanged

## Verification

- `git diff --check`
- `bash .github/scripts/check-doc-contracts.sh`
- rendered the `v1.0.0-rc.1` migration link and verified it targets the tag

This keeps `v1.0.0-rc.1` useful as a full release-pipeline rehearsal without making the formal v1 release the first test of its notes.