### PR TITLE
docs: correct verification and TOTP API contracts

### DIFF
--- a/docs/deDE/API.md
+++ b/docs/deDE/API.md
@@ -183,6 +183,12 @@ curl -X POST \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
+
+# Warden + Herald: mit dem von /_send_verify_code zurückgegebenen Challenge-Wert anmelden
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
 ```
 
 ## Endpunkt zum Senden von Verifizierungscode
@@ -205,6 +211,7 @@ Nur Formulardaten (`application/x-www-form-urlencoded`):
 |------|-----|--------------|--------------|
 | `phone` | String | Nein | Benutzertelefonnummer (eines von `phone` oder `mail`) |
 | `mail` | String | Nein | Benutzer-E-Mail (eines von `phone` oder `mail`) |
+| `deliver_via` | String | Nein | Bevorzugter Kanal: `sms`, `email` oder `dingtalk`; ohne Angabe wird ein aktivierter Kanal aus dem Warden-Datensatz gewählt. |
 
 #### Verarbeitungsablauf
 
@@ -239,9 +246,10 @@ Nur Formulardaten (`application/x-www-form-urlencoded`):
 | Statuscode | Beschreibung | Antwortkörper |
 |------------|--------------|----------------|
 | `400 Bad Request` | Ungültige Anfrageparameter (phone oder mail fehlt) | Fehlermeldung |
-| `404 Not Found` | Benutzer nicht in Warden-Whitelist | Fehlermeldung |
+| `401 Unauthorized` | Benutzer fehlt in Warden oder ist nicht aktiv | JSON-Fehler mit `success=false` |
 | `429 Too Many Requests` | Rate-Limit ausgelöst | Fehlermeldung |
-| `500 Internal Server Error` | Serverfehler oder Herald-Service nicht verfügbar | Fehlermeldung |
+| `503 Service Unavailable` | Herald-Client oder -Service ist nicht verfügbar | JSON-Fehler mit `success=false` |
+| `500 Internal Server Error` | Anderer Providerfehler beim Senden | JSON-Fehler mit `success=false` |
 
 #### Beispiele
 

--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -150,7 +150,7 @@ Form data (`application/x-www-form-urlencoded`):
 | `phone` | String | No | User phone number (one of `phone` or `mail`) |
 | `mail` | String | No | User email (one of `phone` or `mail`) |
 | `challenge_id` | String | Yes | challenge_id returned by Herald |
-| `code` | String | Yes | Verification code entered by user |
+| `verify_code` | String | Yes | Verification code entered by user |
 | `callback` | String | No | Callback URL after successful login |
 
 #### Callback Retrieval Priority
@@ -206,7 +206,7 @@ curl -X POST \
 ```bash
 # Submit login form (with verification code)
 curl -X POST \
-     -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&code=123456&callback=app.example.com" \
+     -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 ```
@@ -240,12 +240,7 @@ Form data (`application/x-www-form-urlencoded`) only:
 |-------|------|----------|-------------|
 | `phone` | String | No | User phone number (one of `phone` or `mail`) |
 | `mail` | String | No | User email (one of `phone` or `mail`) |
-
-#### Request Headers (optional)
-
-| Header | Description |
-|--------|-------------|
-| `Idempotency-Key` | Passed through to Herald; same key within TTL returns cached challenge (no duplicate send). Omit for each new send. |
+| `deliver_via` | String | No | Preferred channel: `sms`, `email`, or `dingtalk`. If omitted, Stargate selects an enabled channel backed by the Warden record. |
 
 #### Processing Flow
 
@@ -280,9 +275,10 @@ Form data (`application/x-www-form-urlencoded`) only:
 | Status Code | Description | Response Body |
 |-------------|-------------|---------------|
 | `400 Bad Request` | Invalid request parameters (missing phone or mail) | Error message |
-| `404 Not Found` | User not in Warden whitelist | Error message |
+| `401 Unauthorized` | User is absent from Warden or is not active | JSON error with `success=false` |
 | `429 Too Many Requests` | Rate limit triggered | Error message |
-| `500 Internal Server Error` | Server error or Herald service unavailable | Error message |
+| `503 Service Unavailable` | Herald client or service is unavailable | JSON error with `success=false` |
+| `500 Internal Server Error` | Herald rejected the send for another provider error | JSON error with `success=false` |
 
 #### Examples
 

--- a/docs/frFR/API.md
+++ b/docs/frFR/API.md
@@ -184,6 +184,12 @@ curl -X POST \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
+
+# Warden + Herald : connexion avec le challenge renvoyé par /_send_verify_code
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
 ```
 
 ## Point de Terminaison d'Envoi de Code de Vérification
@@ -206,6 +212,7 @@ Données de formulaire (`application/x-www-form-urlencoded`) uniquement :
 |-------|------|--------|-------------|
 | `phone` | String | Non | Numéro de téléphone utilisateur (un parmi `phone` ou `mail`) |
 | `mail` | String | Non | Email utilisateur (un parmi `phone` ou `mail`) |
+| `deliver_via` | String | Non | Canal préféré : `sms`, `email` ou `dingtalk`. Sans valeur, Stargate choisit un canal activé du compte Warden. |
 
 #### Flux de Traitement
 
@@ -240,9 +247,10 @@ Données de formulaire (`application/x-www-form-urlencoded`) uniquement :
 | Code de Statut | Description | Corps de Réponse |
 |----------------|-------------|-------------------|
 | `400 Bad Request` | Paramètres de requête invalides (phone ou mail manquant) | Message d'erreur |
-| `404 Not Found` | Utilisateur non présent dans la liste blanche Warden | Message d'erreur |
+| `401 Unauthorized` | Utilisateur absent de Warden ou inactif | Erreur JSON avec `success=false` |
 | `429 Too Many Requests` | Limite de débit déclenchée | Message d'erreur |
-| `500 Internal Server Error` | Erreur serveur ou service Herald indisponible | Message d'erreur |
+| `503 Service Unavailable` | Client ou service Herald indisponible | Erreur JSON avec `success=false` |
+| `500 Internal Server Error` | Autre erreur du fournisseur lors de l'envoi | Erreur JSON avec `success=false` |
 
 #### Exemples
 

--- a/docs/itIT/API.md
+++ b/docs/itIT/API.md
@@ -183,6 +183,12 @@ curl -X POST \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
+
+# Warden + Herald: login con il challenge restituito da /_send_verify_code
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
 ```
 
 ## Endpoint Invio Codice di Verifica
@@ -205,6 +211,7 @@ Solo dati del form (`application/x-www-form-urlencoded`):
 |-------|------|-----------|-------------|
 | `phone` | String | No | Numero di telefono utente (uno tra `phone` o `mail`) |
 | `mail` | String | No | Email utente (uno tra `phone` o `mail`) |
+| `deliver_via` | String | No | Canale preferito: `sms`, `email` o `dingtalk`; se omesso, Stargate sceglie un canale abilitato dal record Warden. |
 
 #### Flusso di Elaborazione
 
@@ -239,9 +246,10 @@ Solo dati del form (`application/x-www-form-urlencoded`):
 | Codice di Stato | Descrizione | Corpo della Risposta |
 |-----------------|-------------|----------------------|
 | `400 Bad Request` | Parametri richiesta non validi (manca phone o mail) | Messaggio di errore |
-| `404 Not Found` | Utente non nella whitelist Warden | Messaggio di errore |
+| `401 Unauthorized` | Utente assente da Warden o non attivo | Errore JSON con `success=false` |
 | `429 Too Many Requests` | Limite di velocità attivato | Messaggio di errore |
-| `500 Internal Server Error` | Errore server o servizio Herald non disponibile | Messaggio di errore |
+| `503 Service Unavailable` | Client o servizio Herald non disponibile | Errore JSON con `success=false` |
+| `500 Internal Server Error` | Altro errore del provider durante l'invio | Errore JSON con `success=false` |
 
 #### Esempi
 

--- a/docs/jaJP/API.md
+++ b/docs/jaJP/API.md
@@ -183,6 +183,12 @@ curl -X POST \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
+
+# Warden + Herald：/_send_verify_code が返した challenge でログイン
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
 ```
 
 ## 検証コード送信エンドポイント
@@ -205,6 +211,7 @@ curl -X POST \
 |-----------|-----|------|------|
 | `phone` | String | いいえ | ユーザーの電話番号 (`phone` または `mail` のいずれか) |
 | `mail` | String | いいえ | ユーザーのメール (`phone` または `mail` のいずれか) |
+| `deliver_via` | String | いいえ | 希望するチャネル：`sms`、`email`、`dingtalk`。省略時は Warden レコードから有効なチャネルを選択します。 |
 
 #### 処理フロー
 
@@ -239,9 +246,10 @@ curl -X POST \
 | ステータスコード | 説明 | レスポンスボディ |
 |-----------------|------|------------------|
 | `400 Bad Request` | 無効なリクエストパラメータ（phoneまたはmailが欠落） | エラーメッセージ |
-| `404 Not Found` | ユーザーがWardenホワイトリストに存在しない | エラーメッセージ |
+| `401 Unauthorized` | Warden にユーザーが存在しない、または非アクティブ | `success=false` の JSON エラー |
 | `429 Too Many Requests` | レート制限がトリガーされた | エラーメッセージ |
-| `500 Internal Server Error` | サーバーエラーまたはHeraldサービスが利用不可 | エラーメッセージ |
+| `503 Service Unavailable` | Herald クライアントまたはサービスを利用できない | `success=false` の JSON エラー |
+| `500 Internal Server Error` | その他のプロバイダー送信エラー | `success=false` の JSON エラー |
 
 #### 例
 

--- a/docs/koKR/API.md
+++ b/docs/koKR/API.md
@@ -183,6 +183,12 @@ curl -X POST \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
+
+# Warden + Herald: /_send_verify_code가 반환한 challenge로 로그인
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
 ```
 
 ## 인증 코드 전송 엔드포인트
@@ -205,6 +211,7 @@ curl -X POST \
 |------|------|------|------|
 | `phone` | String | 아니오 | 사용자 전화번호 (`phone` 또는 `mail` 중 하나) |
 | `mail` | String | 아니오 | 사용자 이메일 (`phone` 또는 `mail` 중 하나) |
+| `deliver_via` | String | 아니오 | 선호 채널: `sms`, `email`, `dingtalk`. 생략하면 Warden 레코드에서 활성화된 채널을 선택합니다. |
 
 #### 처리 흐름
 
@@ -239,9 +246,10 @@ curl -X POST \
 | 상태 코드 | 설명 | 응답 본문 |
 |----------|------|----------|
 | `400 Bad Request` | 잘못된 요청 매개변수 (phone 또는 mail 누락) | 오류 메시지 |
-| `404 Not Found` | 사용자가 Warden 화이트리스트에 없음 | 오류 메시지 |
+| `401 Unauthorized` | Warden에 사용자가 없거나 활성 상태가 아님 | `success=false` JSON 오류 |
 | `429 Too Many Requests` | 속도 제한 트리거됨 | 오류 메시지 |
-| `500 Internal Server Error` | 서버 오류 또는 Herald 서비스 사용 불가 | 오류 메시지 |
+| `503 Service Unavailable` | Herald 클라이언트 또는 서비스를 사용할 수 없음 | `success=false` JSON 오류 |
+| `500 Internal Server Error` | 그 밖의 공급자 전송 오류 | `success=false` JSON 오류 |
 
 #### 예제
 

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -150,7 +150,7 @@ curl http://auth.example.com/_login?callback=app.example.com
 | `phone` | String | 否 | 用户手机号（与 `mail` 二选一） |
 | `mail` | String | 否 | 用户邮箱（与 `phone` 二选一） |
 | `challenge_id` | String | 是 | Herald 返回的 challenge_id |
-| `code` | String | 是 | 用户输入的验证码 |
+| `verify_code` | String | 是 | 用户输入的验证码 |
 | `callback` | String | 否 | 登录成功后的回调 URL |
 
 #### Callback 获取优先级
@@ -206,7 +206,7 @@ curl -X POST \
 ```bash
 # 提交登录表单（使用验证码）
 curl -X POST \
-     -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&code=123456&callback=app.example.com" \
+     -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 ```
@@ -240,6 +240,7 @@ curl -X POST \
 |------|------|------|------|
 | `phone` | String | 否 | 用户手机号（与 `mail` 二选一） |
 | `mail` | String | 否 | 用户邮箱（与 `phone` 二选一） |
+| `deliver_via` | String | 否 | 首选通道：`sms`、`email` 或 `dingtalk`。省略时，从 Warden 用户记录中选择已启用的可用通道。 |
 
 #### 处理流程
 
@@ -274,9 +275,10 @@ curl -X POST \
 | 状态码 | 说明 | 响应体 |
 |--------|------|--------|
 | `400 Bad Request` | 请求参数错误（缺少 phone 或 mail） | 错误消息 |
-| `404 Not Found` | 用户不在 Warden 白名单中 | 错误消息 |
+| `401 Unauthorized` | Warden 中不存在该用户或用户不是活跃状态 | `success=false` 的 JSON 错误 |
 | `429 Too Many Requests` | 触发限流 | 错误消息 |
-| `500 Internal Server Error` | 服务器错误或 Herald 服务不可用 | 错误消息 |
+| `503 Service Unavailable` | Herald 客户端未初始化或服务不可用 | `success=false` 的 JSON 错误 |
+| `500 Internal Server Error` | Herald 因其他提供商错误拒绝发送 | `success=false` 的 JSON 错误 |
 
 #### 示例
 


### PR DESCRIPTION
## Summary

- document Warden login verification with the actual `verify_code` form field
- document optional verification delivery channels and the real 401/500/503 responses
- align the TOTP confirmation contract with the form-only handler and required enrollment state
- apply the contract corrections across all seven supported languages

## Validation

- `bash .github/scripts/check-doc-contracts.sh HEAD`
- seven-language API contract assertions
- `git diff --check`