### PR TITLE
fix: preserve complete audit record fields

### DIFF
--- a/src/internal/auditlog/auditlog.go
+++ b/src/internal/auditlog/auditlog.go
@@ -73,9 +73,15 @@ func (s *StreamStorage) Write(_ context.Context, record *audit.Record) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.format == "text" {
-		_, err := fmt.Fprintf(s.writer, "timestamp=%d event=%s result=%s user_id=%q channel=%q destination=%q ip=%q reason=%q metadata=%v\n",
-			record.Timestamp, record.EventType, record.Result, record.UserID, record.Channel, record.Destination,
-			record.IP, record.Reason, record.Metadata)
+		metadata, err := json.Marshal(record.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal audit metadata: %w", err)
+		}
+		_, err = fmt.Fprintf(s.writer, "timestamp=%d event=%q event_id=%q result=%q user_id=%q challenge_id=%q session_id=%q channel=%q destination=%q purpose=%q resource=%q provider=%q provider_message_id=%q ip=%q user_agent=%q request_id=%q trace_id=%q duration_ms=%d reason=%q metadata=%s\n",
+			record.Timestamp, record.EventType, record.EventID, record.Result, record.UserID, record.ChallengeID,
+			record.SessionID, record.Channel, record.Destination, record.Purpose, record.Resource, record.Provider,
+			record.ProviderMessageID, record.IP, record.UserAgent, record.RequestID, record.TraceID, record.DurationMS,
+			record.Reason, metadata)
 		return err
 	}
 	data, err := json.Marshal(record)
@@ -134,7 +140,7 @@ func LogLogout(ctx context.Context, userID, ip string) {
 }
 
 // LogVerifyCodeSend records a verification code send event
-func LogVerifyCodeSend(ctx context.Context, userID, channel, destination, ip string, success bool, reason string) {
+func LogVerifyCodeSend(ctx context.Context, userID, challengeID, channel, destination, ip string, success bool, reason string) {
 	l := GetLogger()
 	if l == nil {
 		return
@@ -147,16 +153,17 @@ func LogVerifyCodeSend(ctx context.Context, userID, channel, destination, ip str
 		result = audit.ResultFailure
 	}
 
-	l.LogChallenge(ctx, eventType, "", userID, result,
+	l.LogChallenge(ctx, eventType, challengeID, userID, result,
 		audit.WithRecordChannel(channel),
 		audit.WithRecordDestination(destination),
+		audit.WithRecordPurpose("login"),
 		audit.WithRecordIP(ip),
 		audit.WithRecordReason(reason),
 	)
 }
 
 // LogVerifyCodeCheck records a verification code check event
-func LogVerifyCodeCheck(ctx context.Context, userID, channel, destination, ip string, success bool, reason string) {
+func LogVerifyCodeCheck(ctx context.Context, userID, challengeID, channel, destination, ip string, success bool, reason string) {
 	l := GetLogger()
 	if l == nil {
 		return
@@ -169,9 +176,10 @@ func LogVerifyCodeCheck(ctx context.Context, userID, channel, destination, ip st
 		result = audit.ResultFailure
 	}
 
-	l.LogChallenge(ctx, eventType, "", userID, result,
+	l.LogChallenge(ctx, eventType, challengeID, userID, result,
 		audit.WithRecordChannel(channel),
 		audit.WithRecordDestination(destination),
+		audit.WithRecordPurpose("login"),
 		audit.WithRecordIP(ip),
 		audit.WithRecordReason(reason),
 	)

--- a/src/internal/auditlog/auditlog_test.go
+++ b/src/internal/auditlog/auditlog_test.go
@@ -42,19 +42,19 @@ func TestAuditLogFunctions(t *testing.T) {
 	})
 
 	t.Run("LogVerifyCodeSend Success", func(t *testing.T) {
-		LogVerifyCodeSend(ctx, "user1", "sms", "13800000000", "127.0.0.1", true, "")
+		LogVerifyCodeSend(ctx, "user1", "challenge1", "sms", "13800000000", "127.0.0.1", true, "")
 	})
 
 	t.Run("LogVerifyCodeSend Failure", func(t *testing.T) {
-		LogVerifyCodeSend(ctx, "user1", "sms", "13800000000", "127.0.0.1", false, "limit_exceeded")
+		LogVerifyCodeSend(ctx, "user1", "", "sms", "13800000000", "127.0.0.1", false, "limit_exceeded")
 	})
 
 	t.Run("LogVerifyCodeCheck Success", func(t *testing.T) {
-		LogVerifyCodeCheck(ctx, "user1", "sms", "13800000000", "127.0.0.1", true, "")
+		LogVerifyCodeCheck(ctx, "user1", "challenge1", "sms", "13800000000", "127.0.0.1", true, "")
 	})
 
 	t.Run("LogVerifyCodeCheck Failure", func(t *testing.T) {
-		LogVerifyCodeCheck(ctx, "user1", "email", "user@example.com", "127.0.0.1", false, "invalid_code")
+		LogVerifyCodeCheck(ctx, "user1", "challenge1", "email", "user@example.com", "127.0.0.1", false, "invalid_code")
 	})
 
 	t.Run("LogSessionCreate", func(t *testing.T) {
@@ -84,6 +84,20 @@ func TestStreamStorageHonorsFormats(t *testing.T) {
 	record.UserID = "user1"
 	record.Channel = "email"
 	record.Destination = "u***@example.com"
+	record.EventID = "event1"
+	record.ChallengeID = "challenge1"
+	record.SessionID = "session1"
+	record.Purpose = "login"
+	record.Resource = "/_login"
+	record.Provider = "herald"
+	record.ProviderMessageID = "message1"
+	record.IP = "127.0.0.1"
+	record.UserAgent = "test-agent"
+	record.RequestID = "request1"
+	record.TraceID = "trace1"
+	record.DurationMS = 42
+	record.Reason = "accepted"
+	record.Metadata = map[string]interface{}{"method": "warden"}
 
 	var jsonOutput bytes.Buffer
 	assert.NoError(t, NewStreamStorage(&jsonOutput, "json").Write(context.Background(), record))
@@ -91,10 +105,24 @@ func TestStreamStorageHonorsFormats(t *testing.T) {
 
 	var textOutput bytes.Buffer
 	assert.NoError(t, NewStreamStorage(&textOutput, "text").Write(context.Background(), record))
-	assert.Contains(t, textOutput.String(), "event=")
+	assert.Contains(t, textOutput.String(), "event=\"login_success\"")
+	assert.Contains(t, textOutput.String(), "event_id=\"event1\"")
 	assert.Contains(t, textOutput.String(), "user_id=\"user1\"")
+	assert.Contains(t, textOutput.String(), "challenge_id=\"challenge1\"")
+	assert.Contains(t, textOutput.String(), "session_id=\"session1\"")
 	assert.Contains(t, textOutput.String(), "channel=\"email\"")
 	assert.Contains(t, textOutput.String(), "destination=\"u***@example.com\"")
+	assert.Contains(t, textOutput.String(), "purpose=\"login\"")
+	assert.Contains(t, textOutput.String(), "resource=\"/_login\"")
+	assert.Contains(t, textOutput.String(), "provider=\"herald\"")
+	assert.Contains(t, textOutput.String(), "provider_message_id=\"message1\"")
+	assert.Contains(t, textOutput.String(), "ip=\"127.0.0.1\"")
+	assert.Contains(t, textOutput.String(), "user_agent=\"test-agent\"")
+	assert.Contains(t, textOutput.String(), "request_id=\"request1\"")
+	assert.Contains(t, textOutput.String(), "trace_id=\"trace1\"")
+	assert.Contains(t, textOutput.String(), "duration_ms=42")
+	assert.Contains(t, textOutput.String(), "reason=\"accepted\"")
+	assert.Contains(t, textOutput.String(), `metadata={"method":"warden"}`)
 }
 
 func TestInitDefaultAcceptsCaseInsensitiveFormat(t *testing.T) {

--- a/src/internal/handlers/login.go
+++ b/src/internal/handlers/login.go
@@ -293,7 +293,7 @@ func loginAPIHandler(ctx fiber.Ctx, sessionGetter SessionGetter, authenticator A
 					if (heraldErr.StatusCode == http.StatusUnauthorized || heraldErr.StatusCode == http.StatusBadRequest) &&
 						verifyResp != nil && !verifyResp.OK && verifyResp.Reason != "" {
 						reason := verifyResp.Reason
-						auditlog.LogVerifyCodeCheck(ctx.Context(), userID, auditChannel, auditDestination, ctx.IP(), false, reason)
+						auditlog.LogVerifyCodeCheck(ctx.Context(), userID, challengeID, auditChannel, auditDestination, ctx.IP(), false, reason)
 						var errorMsg string
 						switch reason {
 						case "expired":
@@ -343,7 +343,7 @@ func loginAPIHandler(ctx fiber.Ctx, sessionGetter SessionGetter, authenticator A
 					reason = "invalid"
 				}
 				log.Warn().Str("reason", reason).Msg("Challenge verification failed")
-				auditlog.LogVerifyCodeCheck(ctx.Context(), userID, auditChannel, auditDestination, ctx.IP(), false, reason)
+				auditlog.LogVerifyCodeCheck(ctx.Context(), userID, challengeID, auditChannel, auditDestination, ctx.IP(), false, reason)
 
 				// Provide detailed error message based on reason
 				var errorMsg string
@@ -383,7 +383,7 @@ func loginAPIHandler(ctx fiber.Ctx, sessionGetter SessionGetter, authenticator A
 			)
 			heraldSpan.End()
 			metrics.RecordHeraldCall("verify_challenge", "success", duration)
-			auditlog.LogVerifyCodeCheck(ctx.Context(), userID, auditChannel, auditDestination, ctx.IP(), true, "")
+			auditlog.LogVerifyCodeCheck(ctx.Context(), userID, challengeID, auditChannel, auditDestination, ctx.IP(), true, "")
 
 			// Verify user ID matches
 			if verifyResp.UserID != userID {

--- a/src/internal/handlers/send_verify_code.go
+++ b/src/internal/handlers/send_verify_code.go
@@ -260,29 +260,29 @@ func SendVerifyCodeAPI() func(c fiber.Ctx) error {
 					// Herald service is unavailable, suggest OTP fallback if enabled
 					otpEnabled := config.HeraldTOTPEnabled.ToBool()
 					if otpEnabled {
-						auditlog.LogVerifyCodeSend(ctx.Context(), userID, channel, destination, ctx.IP(), false, reason)
+						auditlog.LogVerifyCodeSend(ctx.Context(), userID, "", channel, destination, ctx.IP(), false, reason)
 						return sendVerifyCodeErrorJSON(ctx, fiber.StatusServiceUnavailable, i18n.T(ctx, "error.herald_unavailable_use_otp"), reason)
 					}
-					auditlog.LogVerifyCodeSend(ctx.Context(), userID, channel, destination, ctx.IP(), false, reason)
+					auditlog.LogVerifyCodeSend(ctx.Context(), userID, "", channel, destination, ctx.IP(), false, reason)
 					return sendVerifyCodeErrorJSON(ctx, fiber.StatusServiceUnavailable, i18n.T(ctx, "error.herald_unavailable_retry"), reason)
 				}
 				// Other errors (rate limit, etc.)
 				if heraldErr.StatusCode == http.StatusTooManyRequests {
 					reason = "rate_limited"
-					auditlog.LogVerifyCodeSend(ctx.Context(), userID, channel, destination, ctx.IP(), false, reason)
+					auditlog.LogVerifyCodeSend(ctx.Context(), userID, "", channel, destination, ctx.IP(), false, reason)
 					return sendVerifyCodeErrorJSON(ctx, fiber.StatusTooManyRequests, i18n.T(ctx, "error.rate_limited_retry"), reason)
 				}
 				reason = "provider_error"
 			}
 
 			// Default error handling
-			auditlog.LogVerifyCodeSend(ctx.Context(), userID, channel, destination, ctx.IP(), false, reason)
+			auditlog.LogVerifyCodeSend(ctx.Context(), userID, "", channel, destination, ctx.IP(), false, reason)
 			return sendVerifyCodeErrorJSON(ctx, fiber.StatusInternalServerError, i18n.T(ctx, "error.send_verify_code_failed"), reason)
 		}
 
 		// Log successful verification code send
 		metrics.RecordHeraldCall("create_challenge", "success", heraldDuration)
-		auditlog.LogVerifyCodeSend(ctx.Context(), userID, channel, destination, ctx.IP(), true, "")
+		auditlog.LogVerifyCodeSend(ctx.Context(), userID, createResp.ChallengeID, channel, destination, ctx.IP(), true, "")
 
 		heraldSpan.SetAttributes(
 			attribute.String("herald.challenge_id", createResp.ChallengeID),


### PR DESCRIPTION
## Summary

- serialize every typed audit record field in text output, including channel, destination, challenge/session IDs, provider data, request/trace IDs, duration, and metadata
- attach verification challenge IDs and the login purpose to send/check events
- update all send and login call sites
- extend text-format tests to prevent silent field loss

## Validation

- audit log unit assertions updated for the complete record
- `git diff --check`

Full Go tests are delegated to the repository CI because this execution environment does not contain the Go toolchain.