### PR TITLE
ci: publish versioned changelog release notes

### DIFF
--- a/.github/scripts/extract-release-notes.sh
+++ b/.github/scripts/extract-release-notes.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag=${1:?usage: extract-release-notes.sh TAG OUTPUT [CHANGELOG]}
+output=${2:?usage: extract-release-notes.sh TAG OUTPUT [CHANGELOG]}
+changelog=${3:-CHANGELOG.md}
+repository=${GITHUB_REPOSITORY:-soulteary/stargate}
+
+version=${tag#v}
+base_version=${version%%-*}
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Unsupported release tag: $tag" >&2
+  exit 1
+fi
+
+temp_file=$(mktemp)
+trap 'rm -f "$temp_file"' EXIT
+
+awk -v version="$base_version" '
+  index($0, "## [" version "] - ") == 1 {
+    found = 1
+    printing = 1
+  }
+  printing && found && $0 ~ /^## \[/ && index($0, "## [" version "] - ") != 1 {
+    exit
+  }
+  printing && $0 == "### Release verification" {
+    exit
+  }
+  printing && $0 ~ /^\[[0-9]+\.[0-9]+\.[0-9]+\]:/ {
+    exit
+  }
+  printing { print }
+  END {
+    if (!found) {
+      exit 2
+    }
+  }
+' "$changelog" > "$temp_file" || {
+  echo "CHANGELOG.md has no section for $base_version" >&2
+  exit 1
+}
+
+header=$(head -n 1 "$temp_file")
+if [[ "$version" != *-* && "$header" == *Unreleased* ]]; then
+  echo "Formal release $tag requires a dated CHANGELOG entry" >&2
+  exit 1
+fi
+
+if [[ "$version" == *-* ]]; then
+  sed -i "1s/.*/## [$version] - Prerelease/" "$temp_file"
+fi
+
+sed "s#](docs/enUS/MIGRATION_V1.md)#](https://github.com/${repository}/blob/${tag}/docs/enUS/MIGRATION_V1.md)#" \
+  "$temp_file" > "$output"
+
+printf '\nUpgrade instructions: [v1.0.0 migration guide](https://github.com/%s/blob/%s/docs/enUS/MIGRATION_V1.md).\n' \
+  "$repository" "$tag" >> "$output"

--- a/.github/scripts/test-release-notes.sh
+++ b/.github/scripts/test-release-notes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+rc_notes="$temp_dir/rc.md"
+GITHUB_REPOSITORY=soulteary/stargate \
+  bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0-rc.1 "$rc_notes" "$repo_root/CHANGELOG.md"
+grep -Fq '## [1.0.0-rc.1] - Prerelease' "$rc_notes"
+grep -Fq '### Breaking changes' "$rc_notes"
+if grep -Fq '[1.0.0]:' "$rc_notes"; then
+  echo "Release notes unexpectedly contain changelog reference definitions" >&2
+  exit 1
+fi
+
+if bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0 "$temp_dir/formal.md" "$repo_root/CHANGELOG.md" >/dev/null 2>&1; then
+  echo "Formal release unexpectedly accepted an Unreleased changelog entry" >&2
+  exit 1
+fi
+
+dated_changelog="$temp_dir/CHANGELOG.md"
+sed 's/## \[1.0.0\] - Unreleased/## [1.0.0] - 2026-08-27/' "$repo_root/CHANGELOG.md" > "$dated_changelog"
+bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0 "$temp_dir/formal.md" "$dated_changelog"
+grep -Fq '## [1.0.0] - 2026-08-27' "$temp_dir/formal.md"
+
+if bash "$repo_root/.github/scripts/extract-release-notes.sh" v9.9.9 "$temp_dir/missing.md" "$repo_root/CHANGELOG.md" >/dev/null 2>&1; then
+  echo "Missing changelog version unexpectedly succeeded" >&2
+  exit 1
+fi
+
+echo "Release-note extraction tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           bash .github/scripts/check-doc-contracts.sh "$BASE_SHA"
           bash .github/scripts/test-doc-contracts.sh
 
+      - name: Check release-note extraction
+        run: bash .github/scripts/test-release-notes.sh
+
       - name: Set up Go
         if: steps.changes.outputs.code == 'true'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,9 +304,7 @@ jobs:
         run: cosign sign-blob --yes --bundle dist/checksums.txt.sigstore.json dist/checksums.txt
 
       - name: Prepare curated release notes
-        run: |
-          sed "s#](docs/enUS/MIGRATION_V1.md)#](https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF_NAME}/docs/enUS/MIGRATION_V1.md)#" \
-            CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
+        run: bash .github/scripts/extract-release-notes.sh "$GITHUB_REF_NAME" "$RUNNER_TEMP/release-notes.md"
 
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -315,6 +313,5 @@ jobs:
             dist/*
           name: Release ${{ steps.version.outputs.tag }}
           body_path: ${{ runner.temp }}/release-notes.md
-          generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
## Summary

- extract only the CHANGELOG section matching the release tag instead of publishing the whole file
- make prerelease tags reuse the intended base-version notes with a clear prerelease heading
- fail a formal release while its matching changelog entry is still marked `Unreleased`
- remove GitHub-generated notes so the curated CHANGELOG is the single release-note source
- add extraction regression tests to main CI

## Validation

- `bash -n .github/scripts/extract-release-notes.sh .github/scripts/test-release-notes.sh`
- `bash .github/scripts/test-release-notes.sh`
- `git diff --check`