### PR TITLE
fix: propagate request cancellation to auth providers

### DIFF
--- a/src/internal/handlers/check.go
+++ b/src/internal/handlers/check.go
@@ -26,13 +26,37 @@ func allowTrustedHeaderAuth(ctx fiber.Ctx) bool {
 	return subtle.ConstantTimeCompare([]byte(expected), []byte(provided)) == 1
 }
 
-func sanitizeTrustedIdentityHeaders(ctx fiber.Ctx) {
-	if !allowTrustedHeaderAuth(ctx) {
+func sanitizeTrustedIdentityHeaders(ctx fiber.Ctx) bool {
+	trusted := allowTrustedHeaderAuth(ctx)
+	if !trusted {
 		ctx.Request().Header.Del("X-User-Phone")
 		ctx.Request().Header.Del("X-User-Mail")
 	}
 	// The proxy credential is only for Stargate and must never be propagated.
 	ctx.Request().Header.Del(config.HeaderAuthSecretHeader.String())
+	return trusted
+}
+
+var lookupTrustedHeaderUser = auth.GetUserInfo
+
+func trustedHeaderAuthResult(ctx context.Context, phone, mail string) (*forwardauth.AuthResult, error) {
+	if phone == "" && mail == "" {
+		return nil, nil
+	}
+	userInfo := lookupTrustedHeaderUser(ctx, phone, mail)
+	if userInfo == nil {
+		return nil, forwardauth.ErrUserNotFound
+	}
+	return &forwardauth.AuthResult{
+		Authenticated: true,
+		AuthMethod:    forwardauth.AuthMethodHeader,
+		UserID:        userInfo.UserID,
+		Email:         userInfo.Mail,
+		Phone:         userInfo.Phone,
+		Name:          userInfo.Name,
+		Scopes:        userInfo.Scope,
+		Role:          userInfo.Role,
+	}, nil
 }
 
 func handleNotAuthenticated(ctx fiber.Ctx) error {
@@ -69,7 +93,7 @@ func CheckRoute(store SessionStoreForCheck) func(c fiber.Ctx) error {
 	}
 
 	return func(ctx fiber.Ctx) error {
-		sanitizeTrustedIdentityHeaders(ctx)
+		trustedIdentity := sanitizeTrustedIdentityHeaders(ctx)
 		// Get trace context from middleware
 		traceCtx := ctx.Locals("trace_context")
 		if traceCtx == nil {
@@ -111,8 +135,19 @@ func CheckRoute(store SessionStoreForCheck) func(c fiber.Ctx) error {
 		faCtx := forwardauth.NewFiberContext(ctx)
 		faSess := forwardauth.NewFiberSession(sess)
 
-		// Perform authentication check using forwardauth-kit
-		result, err := handler.Check(faCtx, faSess)
+		// Password authentication keeps its original priority over trusted
+		// identity headers. Otherwise resolve the trusted identity here with the
+		// active request context, before falling back to the session checker.
+		var result *forwardauth.AuthResult
+		passwordAttempt := config.PasswordHeaderAuthEnabled.ToBool() && ctx.Get("Stargate-Password") != ""
+		if trustedIdentity && !passwordAttempt {
+			result, err = trustedHeaderAuthResult(spanCtx, ctx.Get("X-User-Phone"), ctx.Get("X-User-Mail"))
+			if result == nil && err == nil {
+				result, err = handler.Check(faCtx, faSess)
+			}
+		} else {
+			result, err = handler.Check(faCtx, faSess)
+		}
 		if refreshed {
 			if saveErr := sess.Save(); saveErr != nil {
 				tracing.RecordError(forwardAuthSpan, saveErr)

--- a/src/internal/handlers/check_test.go
+++ b/src/internal/handlers/check_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -11,7 +12,28 @@ import (
 	"github.com/gofiber/fiber/v3/middleware/session"
 	"github.com/soulteary/stargate/src/internal/auth"
 	"github.com/soulteary/stargate/src/internal/config"
+	"github.com/soulteary/warden/pkg/warden"
 )
+
+func TestTrustedHeaderAuthResultPropagatesCancellation(t *testing.T) {
+	originalLookup := lookupTrustedHeaderUser
+	t.Cleanup(func() { lookupTrustedHeaderUser = originalLookup })
+
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	lookupTrustedHeaderUser = func(ctx context.Context, phone, mail string) *warden.AllowListUser {
+		select {
+		case <-ctx.Done():
+		default:
+			t.Fatal("Warden lookup did not receive the canceled request context")
+		}
+		return &warden.AllowListUser{UserID: "user1", Phone: phone, Mail: mail}
+	}
+
+	result, err := trustedHeaderAuthResult(requestCtx, "13800138000", "")
+	testza.AssertNoError(t, err)
+	testza.AssertEqual(t, "user1", result.UserID)
+}
 
 // TestCheckRoute_HandlerNil verifies that when GetForwardAuthHandler returns nil,
 // the check handler returns 500 and "ForwardAuth handler not initialized".

--- a/src/internal/handlers/forwardauth.go
+++ b/src/internal/handlers/forwardauth.go
@@ -2,7 +2,6 @@
 package handlers
 
 import (
-	"context"
 	"strings"
 	"time"
 
@@ -92,27 +91,13 @@ func InitForwardAuthHandler(l *logger.Logger) {
 		},
 
 		// Header-based authentication (Warden)
-		HeaderAuthEnabled:   config.HeaderAuthEnabled.ToBool(),
+		// Trusted identity headers are checked in CheckRoute, where the active
+		// request context can be propagated to Warden. forwardauth-kit v2.1.0
+		// exposes context-free callbacks, so enabling its header checker here
+		// would detach Warden calls from client cancellation.
+		HeaderAuthEnabled:   false,
 		HeaderAuthUserPhone: "X-User-Phone",
 		HeaderAuthUserMail:  "X-User-Mail",
-		HeaderAuthCheckFunc: func(phone, mail string) bool {
-			return auth.CheckUserInList(context.Background(), phone, mail)
-		},
-		HeaderAuthGetInfoFunc: func(phone, mail string) *forwardauth.UserInfo {
-			userInfo := auth.GetUserInfo(context.Background(), phone, mail)
-			if userInfo == nil {
-				return nil
-			}
-			return &forwardauth.UserInfo{
-				UserID: userInfo.UserID,
-				Email:  userInfo.Mail,
-				Phone:  userInfo.Phone,
-				Name:   userInfo.Name,
-				Scopes: userInfo.Scope, // Warden uses 'Scope', forwardauth-kit uses 'Scopes'
-				Role:   userInfo.Role,
-				Status: userInfo.Status,
-			}
-		},
 
 		// Step-up authentication
 		// Enforced by CheckRoute against X-Forwarded-Uri; the library only sees /_auth.

--- a/src/internal/handlers/totp_enroll.go
+++ b/src/internal/handlers/totp_enroll.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"html/template"
 	"time"
 
@@ -84,7 +83,7 @@ func TOTPEnrollRoute(store *session.Store) func(c fiber.Ctx) error {
 			return SendErrorResponse(ctx, fiber.StatusServiceUnavailable, i18n.T(ctx, "error.herald_unavailable"))
 		}
 		// If already bound TOTP, redirect to revoke page
-		statusResp, err := client.TOTPStatus(context.Background(), userID)
+		statusResp, err := client.TOTPStatus(ctx.Context(), userID)
 		if err != nil {
 			log.Warn().Err(err).Str("user_id", userID).Msg("TOTP status check failed")
 			return SendErrorResponse(ctx, fiber.StatusBadGateway, "TOTP status check failed")


### PR DESCRIPTION
## Summary

- move trusted-header Warden resolution into the request handler so it receives the active request context
- preserve password-header authentication priority and session fallback behavior
- pass the Fiber request context to the initial TOTP status call instead of `context.Background()`
- add a cancellation-propagation regression test

## Validation

- remaining handler `context.Background()` uses were audited; production Warden/TOTP calls now use request-derived contexts
- `git diff --check`

Full Go tests are delegated to repository CI because this execution environment does not contain the Go toolchain.