### PR TITLE
ci: reject stale Go 1.26 documentation

### DIFF
--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -191,7 +191,7 @@ contract_violation_count() {
       ["verification endpoint incorrectly claims JSON input", qr/(?:or|oder|ou|o|または|또는|或)\s+JSON\s*\(`application\/json`\)/i],
       ["container health check omits port 8080", qr{http://localhost/healthz}],
       ["metrics incorrectly described as new in v1", qr/(?:No metrics endpoint|无指标端点|Added Prometheus metrics)/],
-      ["stale Go issue-template example", qr/Go (?:Version|版本): \[e\.g\. 1\.26\]/],
+      ["stale Go 1.26 requirement", qr/\bGo(?:\s+(?:Version|版本))?\s*[:：]?\s*1\.26(?:\.\d+)?\+?\b/i],
     );
 
     find({

--- a/.github/scripts/test-go-version-contract.sh
+++ b/.github/scripts/test-go-version-contract.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+git -C "$repo_root" archive HEAD | tar -x -C "$temp_dir"
+cp "$repo_root/.github/scripts/check-doc-contracts.sh" "$temp_dir/.github/scripts/check-doc-contracts.sh"
+git -C "$temp_dir" init -q
+git -C "$temp_dir" config user.name "go-version-contract-test"
+git -C "$temp_dir" config user.email "go-version-contract-test@example.invalid"
+git -C "$temp_dir" add .
+git -C "$temp_dir" commit -qm "test baseline"
+base_sha=$(git -C "$temp_dir" rev-parse HEAD)
+
+printf '\nRequires Go 1.26+.\n' >> "$temp_dir/README.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected stale Go 1.26 documentation to fail" >&2
+  exit 1
+fi
+
+echo "Go documentation version contract test passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           bash .github/scripts/check-doc-contracts.sh "$BASE_SHA"
           bash .github/scripts/test-doc-contracts.sh
+          bash .github/scripts/test-go-version-contract.sh
 
       - name: Set up Go
         if: steps.changes.outputs.code == 'true'


### PR DESCRIPTION
## Summary

- apply the Go-version guard on top of the merged section-aware documentation checker
- broaden the contract from one exact badge string to any Go 1.26 requirement wording in READMEs and documentation
- add a self-test that injects a stale `Requires Go 1.26+` statement and proves CI rejects it

The current tree has no remaining Go 1.26 wording; this PR prevents it from returning.

## Validation

- `bash .github/scripts/check-doc-contracts.sh HEAD^`
- `bash .github/scripts/test-doc-contracts.sh`
- `bash .github/scripts/test-go-version-contract.sh`
- `git diff --check`

This revision also removes the prior `.github/ISSUE_TEMPLATE` archive path, because that directory does not exist and made the baseline archive fail.