### PR TITLE
release: freeze CHANGELOG 1.0.0 entry with release date

### DIFF
--- a/.github/scripts/test-release-notes.sh
+++ b/.github/scripts/test-release-notes.sh
@@ -15,15 +15,19 @@ if grep -Fq '[1.0.0]:' "$rc_notes"; then
   exit 1
 fi
 
-if bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0 "$temp_dir/formal.md" "$repo_root/CHANGELOG.md" >/dev/null 2>&1; then
-  echo "Formal release unexpectedly accepted an Unreleased changelog entry" >&2
+if bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0 "$temp_dir/formal.md" "$repo_root/CHANGELOG.md"; then
+  grep -Fq '## [1.0.0] - 2026-08-27' "$temp_dir/formal.md"
+else
+  echo "Formal release unexpectedly rejected a dated changelog entry" >&2
   exit 1
 fi
 
-dated_changelog="$temp_dir/CHANGELOG.md"
-sed 's/## \[1.0.0\] - Unreleased/## [1.0.0] - 2026-08-27/' "$repo_root/CHANGELOG.md" > "$dated_changelog"
-bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0 "$temp_dir/formal.md" "$dated_changelog"
-grep -Fq '## [1.0.0] - 2026-08-27' "$temp_dir/formal.md"
+unreleased_changelog="$temp_dir/unreleased-CHANGELOG.md"
+sed 's/## \[1.0.0\] - 2026-08-27/## [1.0.0] - Unreleased/' "$repo_root/CHANGELOG.md" > "$unreleased_changelog"
+if bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0 "$temp_dir/unreleased.md" "$unreleased_changelog" >/dev/null 2>&1; then
+  echo "Formal release unexpectedly accepted an Unreleased changelog entry" >&2
+  exit 1
+fi
 
 if bash "$repo_root/.github/scripts/extract-release-notes.sh" v9.9.9 "$temp_dir/missing.md" "$repo_root/CHANGELOG.md" >/dev/null 2>&1; then
   echo "Missing changelog version unexpectedly succeeded" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file records user-visible changes. For upgrade steps and configuration examples, see the [v1.0.0 migration guide](docs/enUS/MIGRATION_V1.md).
 
-## [1.0.0] - Unreleased
+## [1.0.0] - 2026-08-27
 
 ### Breaking changes
 


### PR DESCRIPTION
## Summary

- Freeze the `## [1.0.0]` CHANGELOG heading from `Unreleased` to the dated `2026-08-27` entry so the release pipeline accepts a formal `v1.0.0` tag.
- Update `.github/scripts/test-release-notes.sh` so its guards stay consistent with the frozen changelog: the acceptance check now runs against the live dated `CHANGELOG.md`, and the Unreleased-rejection check runs against a synthetic Unreleased fixture.

## Test plan

- [x] `extract-release-notes.sh v1.0.0` succeeds against the dated CHANGELOG (header `## [1.0.0] - 2026-08-27`).
- [x] `extract-release-notes.sh v1.0.0` is rejected against a synthetic Unreleased CHANGELOG.
- [ ] CI `test-release-notes.sh` green on ubuntu (local rc.1 branch fails only due to macOS BSD `sed -i`, unrelated to this change).

Made with [Cursor](https://cursor.com)