### PR TITLE
fix(release): refresh Alpine runtime packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,7 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
             COMMIT=${{ steps.version.outputs.commit }}
             BUILD_DATE=${{ steps.version.outputs.build_date }}
+            ALPINE_PACKAGE_REFRESH=${{ github.run_id }}-${{ github.run_attempt }}
           cache-from: type=gha,scope=release-docker
           platforms: linux/amd64
 
@@ -285,6 +286,7 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
             COMMIT=${{ steps.version.outputs.commit }}
             BUILD_DATE=${{ steps.version.outputs.build_date }}
+            ALPINE_PACKAGE_REFRESH=${{ github.run_id }}-${{ github.run_attempt }}
           cache-from: type=gha,scope=release-docker
           platforms: linux/arm64
 
@@ -311,6 +313,7 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
             COMMIT=${{ steps.version.outputs.commit }}
             BUILD_DATE=${{ steps.version.outputs.build_date }}
+            ALPINE_PACKAGE_REFRESH=${{ github.run_id }}-${{ github.run_attempt }}
           cache-from: type=gha,scope=release-docker
           cache-to: type=gha,mode=max,scope=release-docker
           platforms: linux/amd64,linux/arm64

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,10 +26,13 @@ RUN if command -v upx > /dev/null 2>&1; then \
     fi
 
 FROM alpine:3.24
-RUN apk update && apk upgrade openssl
+# Release builds override this value to invalidate the package layer on every run.
+ARG ALPINE_PACKAGE_REFRESH=local
 COPY --from=builder /app/stargate /bin/stargate
 COPY --from=builder /app/src/internal/web/templates /app/web/templates
-RUN apk add --no-cache ca-certificates && \
+RUN echo "Alpine package refresh: ${ALPINE_PACKAGE_REFRESH}" && \
+    apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates && \
     addgroup -S stargate && \
     adduser -S -D -H -u 10001 -G stargate stargate && \
     chown -R stargate:stargate /app

--- a/docker/Dockerfile.manual
+++ b/docker/Dockerfile.manual
@@ -35,12 +35,15 @@ RUN if command -v upx > /dev/null 2>&1; then \
     fi
 
 FROM alpine:3.24
-RUN apk update && apk upgrade openssl
+# Release builds override this value to invalidate the package layer on every run.
+ARG ALPINE_PACKAGE_REFRESH=local
 COPY --from=Builder /app/stargate /bin/stargate
 COPY --from=Builder /app/src/internal/web/templates /app/web/templates
 ENV TZ=Asia/Shanghai
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories
-RUN apk add --no-cache tzdata ca-certificates && \
+RUN echo "Alpine package refresh: ${ALPINE_PACKAGE_REFRESH}" && \
+    apk upgrade --no-cache && \
+    apk add --no-cache tzdata ca-certificates && \
     addgroup -S stargate && \
     adduser -S -D -H -u 10001 -G stargate stargate && \
     cp /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \


### PR DESCRIPTION
## Summary

- upgrade all installed Alpine runtime packages before installing runtime dependencies
- replace the ineffective `apk upgrade openssl` selector so the base-installed `libcrypto3` and `libssl3` packages are upgraded
- invalidate the Alpine package layer once per Release run/attempt while reusing that same refreshed layer for both security scans and the published image
- keep `docker/Dockerfile` and `docker/Dockerfile.manual` aligned

## Root cause

The Release workflow failed in the amd64 Trivy gate because Alpine 3.24.1 contained:

- `libcrypto3 3.5.7-r0`
- `libssl3 3.5.7-r0`
- `CVE-2026-14456` (HIGH), fixed in `3.5.8-r0`

Failed runs:

- https://github.com/soulteary/stargate/actions/runs/33056714117
- https://github.com/soulteary/stargate/actions/runs/33059406730

The second run still checked out the immutable `v1.0.0` tag at `d7cfdeb`, so the later Dockerfile edit on `main` was not part of that image.

## Validation

- the change is one commit and limited to the Release workflow plus the two runtime Dockerfiles
- all three Release image builds receive the same per-attempt refresh key
- Trivy remains a blocking HIGH/CRITICAL gate

## Release note

After merging, publish a new patch tag (for example `v1.0.1`). Re-running `v1.0.0` cannot include source changes made after that tag without moving the tag.