### PR TITLE
ci: make tag releases lossless and monotonic

### DIFF
--- a/.github/scripts/extract-release-notes.sh
+++ b/.github/scripts/extract-release-notes.sh
@@ -6,12 +6,13 @@ output=${2:?usage: extract-release-notes.sh TAG OUTPUT [CHANGELOG]}
 changelog=${3:-CHANGELOG.md}
 repository=${GITHUB_REPOSITORY:-soulteary/stargate}
 
-version=${tag#v}
-base_version=${version%%-*}
-if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
   echo "Unsupported release tag: $tag" >&2
   exit 1
 fi
+
+version=${tag#v}
+base_version=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}
 
 temp_file=$(mktemp)
 trap 'rm -f "$temp_file"' EXIT
@@ -42,8 +43,13 @@ awk -v version="$base_version" '
 }
 
 header=$(head -n 1 "$temp_file")
-if [[ "$version" != *-* && "$header" == *Unreleased* ]]; then
-  echo "Formal release $tag requires a dated CHANGELOG entry" >&2
+if [[ ! "$header" =~ ^##\ \[$base_version\]\ -\ [0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "Release $tag requires an exact dated CHANGELOG heading for $base_version" >&2
+  exit 1
+fi
+
+if ! tail -n +2 "$temp_file" | grep -Eq '^[[:space:]]*[^[:space:]]'; then
+  echo "CHANGELOG.md section for $base_version is empty" >&2
   exit 1
 fi
 

--- a/.github/scripts/plan-release-aliases.sh
+++ b/.github/scripts/plan-release-aliases.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag=${1:?usage: plan-release-aliases.sh TAG RELEASE_TAGS_FILE}
+release_tags=${2:?usage: plan-release-aliases.sh TAG RELEASE_TAGS_FILE}
+
+semver='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+if [[ ! "$tag" =~ ^v${semver}(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+  echo "Unsupported release tag: $tag" >&2
+  exit 1
+fi
+
+# Prereleases always keep their full version image, but never move stable
+# aliases. This also keeps a late RC from changing latest after a GA release.
+if [[ "$tag" == *-* ]]; then
+  exit 0
+fi
+
+major=${BASH_REMATCH[1]}
+minor=${BASH_REMATCH[2]}
+
+temp_file=$(mktemp)
+trap 'rm -f "$temp_file"' EXIT
+
+# Only published, stable vX.Y.Z releases are candidates. Include the release
+# that triggered reconciliation to tolerate short API visibility delays.
+while IFS= read -r candidate; do
+  if [[ "$candidate" =~ ^v${semver}$ ]]; then
+    printf '%s\n' "$candidate"
+  fi
+done < "$release_tags" > "$temp_file"
+printf '%s\n' "$tag" >> "$temp_file"
+sort -Vu -o "$temp_file" "$temp_file"
+
+latest=$(tail -n 1 "$temp_file")
+major_latest=$(awk -v prefix="v${major}." 'index($0, prefix) == 1' "$temp_file" | tail -n 1)
+minor_latest=$(awk -v prefix="v${major}.${minor}." 'index($0, prefix) == 1' "$temp_file" | tail -n 1)
+
+printf 'latest\t%s\n' "$latest"
+printf '%s\t%s\n' "$major" "$major_latest"
+printf '%s.%s\t%s\n' "$major" "$minor" "$minor_latest"

--- a/.github/scripts/prepare-release-notes.sh
+++ b/.github/scripts/prepare-release-notes.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag=${1:?usage: prepare-release-notes.sh TAG OUTPUT [CHANGELOG]}
+output=${2:?usage: prepare-release-notes.sh TAG OUTPUT [CHANGELOG]}
+changelog=${3:-CHANGELOG.md}
+allow_existing=${ALLOW_EXISTING_RELEASE_NOTES:-false}
+script_dir=$(dirname "$0")
+diagnostics=$(mktemp)
+temp_file=""
+trap 'rm -f "$diagnostics" "$temp_file"' EXIT
+
+if bash "$script_dir/extract-release-notes.sh" "$tag" "$output" "$changelog" 2> "$diagnostics"; then
+  exit 0
+fi
+
+if [[ "$allow_existing" != "true" ]]; then
+  cat "$diagnostics" >&2
+  echo "Release-note validation failed for $tag" >&2
+  exit 1
+fi
+
+repo=${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required for release-note fallback}
+temp_file=$(mktemp)
+
+# Historical tags can predate the dated CHANGELOG contract. Manual republish
+# may preserve notes from an already-published Release, but it must never invent
+# notes for a new release or weaken the automatic tag-push gate.
+if ! gh release view "$tag" --repo "$repo" --json body --jq .body > "$temp_file"; then
+  echo "No existing GitHub Release notes are available for $tag" >&2
+  exit 1
+fi
+if ! grep -Eq '[^[:space:]]' "$temp_file" || grep -Fxq 'null' "$temp_file"; then
+  echo "Existing GitHub Release notes are empty for $tag" >&2
+  exit 1
+fi
+
+mv "$temp_file" "$output"
+echo "Reusing existing GitHub Release notes for historical tag $tag."

--- a/.github/scripts/publish-github-release.sh
+++ b/.github/scripts/publish-github-release.sh
@@ -26,9 +26,23 @@ else
 fi
 
 if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+  declare -A wanted_assets=()
+  for asset in "${assets[@]}"; do
+    wanted_assets["$(basename "$asset")"]=1
+  done
+  existing_assets_text=$(
+    gh release view "$tag" --repo "$repo" --json assets --jq '.assets[].name'
+  )
+  mapfile -t existing_assets <<< "$existing_assets_text"
+
   # Keep the existing Release visible while clobbering its assets. In
   # particular, never delete a good Release before its replacement is ready.
   gh release upload "$tag" "${assets[@]}" --repo "$repo" --clobber
+  for asset_name in "${existing_assets[@]}"; do
+    if [[ -n "$asset_name" && ! -v "wanted_assets[$asset_name]" ]]; then
+      gh release delete-asset "$tag" "$asset_name" --repo "$repo" --yes
+    fi
+  done
   gh release edit "$tag" "${metadata[@]}" "${prerelease[@]}" --draft=false
 else
   gh release create "$tag" "${assets[@]}" "${metadata[@]}" "${prerelease[@]}" --verify-tag

--- a/.github/scripts/publish-github-release.sh
+++ b/.github/scripts/publish-github-release.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag=${1:?usage: publish-github-release.sh TAG NOTES_FILE DIST_DIR}
+notes=${2:?usage: publish-github-release.sh TAG NOTES_FILE DIST_DIR}
+dist=${3:?usage: publish-github-release.sh TAG NOTES_FILE DIST_DIR}
+repo=${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}
+
+if [[ ! -s "$notes" ]]; then
+  echo "Release notes are missing or empty: $notes" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+assets=("$dist"/*)
+if (( ${#assets[@]} == 0 )); then
+  echo "Release assets are missing: $dist" >&2
+  exit 1
+fi
+
+metadata=(--repo "$repo" --title "Release $tag" --notes-file "$notes" --latest=false)
+if [[ "$tag" == *-* ]]; then
+  prerelease=(--prerelease=true)
+else
+  prerelease=(--prerelease=false)
+fi
+
+if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+  # Keep the existing Release visible while clobbering its assets. In
+  # particular, never delete a good Release before its replacement is ready.
+  gh release upload "$tag" "${assets[@]}" --repo "$repo" --clobber
+  gh release edit "$tag" "${metadata[@]}" "${prerelease[@]}" --draft=false
+else
+  gh release create "$tag" "${assets[@]}" "${metadata[@]}" "${prerelease[@]}" --verify-tag
+fi

--- a/.github/scripts/reconcile-release-aliases.sh
+++ b/.github/scripts/reconcile-release-aliases.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag=${1:?usage: reconcile-release-aliases.sh TAG IMAGE}
+image=${2:?usage: reconcile-release-aliases.sh TAG IMAGE}
+repo=${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}
+
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+release_tags="$temp_dir/release-tags.txt"
+plan="$temp_dir/alias-plan.tsv"
+
+gh api --paginate "repos/${repo}/releases?per_page=100" \
+  --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+  > "$release_tags"
+
+bash "$(dirname "$0")/plan-release-aliases.sh" "$tag" "$release_tags" > "$plan"
+if [[ ! -s "$plan" ]]; then
+  echo "Prerelease $tag keeps only its immutable full-version image."
+  exit 0
+fi
+
+latest_release=""
+while IFS=$'\t' read -r alias source_tag; do
+  source_ref="${image}:${source_tag#v}"
+  alias_ref="${image}:${alias}"
+  digest=$(docker buildx imagetools inspect "$source_ref" | awk '$1 == "Digest:" { print $2; exit }')
+  if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "Unable to resolve an immutable digest for $source_ref" >&2
+    exit 1
+  fi
+  docker buildx imagetools create --tag "$alias_ref" "${image}@${digest}"
+  if [[ "$alias" == "latest" ]]; then
+    latest_release=$source_tag
+  fi
+done < "$plan"
+
+# Keep GitHub's Latest Release marker consistent with the image alias. Every
+# reconciler computes the high-water SemVer, so completion order cannot cause
+# an older release to win.
+gh release edit "$latest_release" --repo "$repo" --latest

--- a/.github/scripts/test-release-notes.sh
+++ b/.github/scripts/test-release-notes.sh
@@ -28,9 +28,25 @@ if bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0 "$temp_dir/
   echo "Formal release unexpectedly accepted an Unreleased changelog entry" >&2
   exit 1
 fi
+if bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0-rc.2 "$temp_dir/unreleased-rc.md" "$unreleased_changelog" >/dev/null 2>&1; then
+  echo "Prerelease unexpectedly accepted an Unreleased changelog entry" >&2
+  exit 1
+fi
+
+malformed_changelog="$temp_dir/malformed-CHANGELOG.md"
+sed 's/## \[1.0.0\] - 2026-08-27/## [1.0.0] - 27 August 2026/' "$repo_root/CHANGELOG.md" > "$malformed_changelog"
+if bash "$repo_root/.github/scripts/extract-release-notes.sh" v1.0.0 "$temp_dir/malformed.md" "$malformed_changelog" >/dev/null 2>&1; then
+  echo "Malformed changelog heading unexpectedly succeeded" >&2
+  exit 1
+fi
 
 if bash "$repo_root/.github/scripts/extract-release-notes.sh" v9.9.9 "$temp_dir/missing.md" "$repo_root/CHANGELOG.md" >/dev/null 2>&1; then
   echo "Missing changelog version unexpectedly succeeded" >&2
+  exit 1
+fi
+
+if bash "$repo_root/.github/scripts/extract-release-notes.sh" v01.0.0 "$temp_dir/invalid-tag.md" "$repo_root/CHANGELOG.md" >/dev/null 2>&1; then
+  echo "Invalid SemVer tag unexpectedly succeeded" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-release-workflow.sh
+++ b/.github/scripts/test-release-workflow.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+workflow="$repo_root/.github/workflows/release.yml"
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+line_number() {
+  local pattern=$1
+  grep -nF -- "$pattern" "$workflow" | head -n 1 | cut -d: -f1
+}
+
+# Distinct tags never contend for one pending slot. Same-tag retries and the
+# global alias reconciler both opt in to GitHub's supported 100-run queue.
+grep -Fq "group: \${{ github.repository }}-release-\${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}" "$workflow" \
+  || fail "Release concurrency is not scoped by tag"
+[[ $(grep -c 'queue: max' "$workflow") -eq 2 ]] \
+  || fail "Expected queue:max for tag publication and alias reconciliation"
+grep -Fq 'group: ${{ github.repository }}-release-aliases' "$workflow" \
+  || fail "Mutable aliases do not have a dedicated concurrency group"
+
+# Release notes must fail before the state machine reaches its first external
+# write. The workflow must never delete an existing Release as an intermediate
+# overwrite step.
+notes_line=$(line_number 'name: Prepare and validate curated release notes')
+immutability_line=$(line_number 'name: Resolve existing immutable image')
+publish_boundary=$(line_number 'name: Attest release artifacts')
+[[ -n "$notes_line" && -n "$publish_boundary" && "$notes_line" -lt "$publish_boundary" ]] \
+  || fail "Release notes are not validated before external publication"
+[[ -n "$immutability_line" && "$immutability_line" -lt "$publish_boundary" ]] \
+  || fail "Image immutability is not checked before external publication"
+if grep -Fq 'gh release delete' "$workflow"; then
+  fail "Release overwrite still deletes the existing Release"
+fi
+if grep -Fq 'release delete' "$repo_root/.github/scripts/publish-github-release.sh"; then
+  fail "Release publisher still deletes the existing Release"
+fi
+
+metadata=$(sed -n '/name: Extract metadata/,/name: Build amd64 image/p' "$workflow")
+grep -Fq 'pattern={{version}}' <<< "$metadata" \
+  || fail "Immutable full-version image tag is missing"
+if grep -Eq 'pattern=\{\{major|value=latest' <<< "$metadata"; then
+  fail "Mutable aliases are still published by the immutable image step"
+fi
+
+# A late older tag must reconcile from the published SemVer high-water mark,
+# not from its own version or from queue completion order.
+release_tags="$temp_dir/releases.txt"
+printf '%s\n' v1.2.1 v1.3.0 v2.0.0 v2.1.0-rc.1 invalid > "$release_tags"
+actual_plan="$temp_dir/actual-plan.tsv"
+bash "$repo_root/.github/scripts/plan-release-aliases.sh" v1.2.0 "$release_tags" > "$actual_plan"
+expected_plan="$temp_dir/expected-plan.tsv"
+printf 'latest\tv2.0.0\n1\tv1.3.0\n1.2\tv1.2.1\n' > "$expected_plan"
+cmp "$expected_plan" "$actual_plan" \
+  || fail "A late older release can downgrade a mutable alias"
+
+prerelease_plan="$temp_dir/prerelease-plan.tsv"
+bash "$repo_root/.github/scripts/plan-release-aliases.sh" v2.1.0-rc.2 "$release_tags" > "$prerelease_plan"
+[[ ! -s "$prerelease_plan" ]] \
+  || fail "Prerelease unexpectedly updates stable aliases"
+
+# Model both manual overwrite branches with a fake gh client. Existing
+# Releases stay visible and are repaired with upload --clobber + edit.
+fake_bin="$temp_dir/bin"
+mkdir -p "$fake_bin" "$temp_dir/dist"
+printf 'notes\n' > "$temp_dir/notes.md"
+printf 'artifact\n' > "$temp_dir/dist/stargate-linux-amd64"
+fake_gh="$fake_bin/gh"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s " "$@" >> "$GH_TEST_LOG"' \
+  'printf "\n" >> "$GH_TEST_LOG"' \
+  'if [[ "$1 $2" == "release view" ]]; then exit "${GH_VIEW_STATUS:-0}"; fi' \
+  'exit 0' > "$fake_gh"
+chmod +x "$fake_gh"
+
+existing_log="$temp_dir/existing.log"
+PATH="$fake_bin:$PATH" GH_TEST_LOG="$existing_log" GH_VIEW_STATUS=0 \
+  GITHUB_REPOSITORY=soulteary/stargate \
+  bash "$repo_root/.github/scripts/publish-github-release.sh" \
+    v1.2.0 "$temp_dir/notes.md" "$temp_dir/dist"
+grep -Fq 'release upload' "$existing_log" || fail "Existing Release assets were not replaced"
+grep -Fq -- '--clobber' "$existing_log" || fail "Existing Release upload is not idempotent"
+grep -Fq 'release edit' "$existing_log" || fail "Existing Release metadata was not updated"
+if grep -Fq 'release delete' "$existing_log"; then
+  fail "Manual overwrite deleted the existing Release"
+fi
+
+missing_log="$temp_dir/missing.log"
+PATH="$fake_bin:$PATH" GH_TEST_LOG="$missing_log" GH_VIEW_STATUS=1 \
+  GITHUB_REPOSITORY=soulteary/stargate \
+  bash "$repo_root/.github/scripts/publish-github-release.sh" \
+    v1.2.0 "$temp_dir/notes.md" "$temp_dir/dist"
+grep -Fq 'release create' "$missing_log" || fail "Missing Release was not created"
+
+invalid_log="$temp_dir/invalid.log"
+if PATH="$fake_bin:$PATH" GH_TEST_LOG="$invalid_log" GH_VIEW_STATUS=0 \
+  GITHUB_REPOSITORY=soulteary/stargate \
+  bash "$repo_root/.github/scripts/publish-github-release.sh" \
+    v1.2.0 "$temp_dir/missing-notes.md" "$temp_dir/dist" >/dev/null 2>&1; then
+  fail "Missing release notes unexpectedly reached publication"
+fi
+[[ ! -e "$invalid_log" ]] || fail "Validation failure modified an existing Release"
+
+echo "Release workflow state-machine tests passed."

--- a/.github/scripts/test-release-workflow.sh
+++ b/.github/scripts/test-release-workflow.sh
@@ -35,10 +35,10 @@ publish_boundary=$(line_number 'name: Attest release artifacts')
   || fail "Release notes are not validated before external publication"
 [[ -n "$immutability_line" && "$immutability_line" -lt "$publish_boundary" ]] \
   || fail "Image immutability is not checked before external publication"
-if grep -Fq 'gh release delete' "$workflow"; then
+if grep -Eq 'gh release delete[[:space:]]' "$workflow"; then
   fail "Release overwrite still deletes the existing Release"
 fi
-if grep -Fq 'release delete' "$repo_root/.github/scripts/publish-github-release.sh"; then
+if grep -Eq 'gh release delete[[:space:]]' "$repo_root/.github/scripts/publish-github-release.sh"; then
   fail "Release publisher still deletes the existing Release"
 fi
 
@@ -76,7 +76,12 @@ printf '%s\n' \
   '#!/usr/bin/env bash' \
   'printf "%s " "$@" >> "$GH_TEST_LOG"' \
   'printf "\n" >> "$GH_TEST_LOG"' \
-  'if [[ "$1 $2" == "release view" ]]; then exit "${GH_VIEW_STATUS:-0}"; fi' \
+  'if [[ "$1 $2" == "release view" ]]; then' \
+  '  if [[ "${GH_VIEW_STATUS:-0}" != "0" ]]; then exit "$GH_VIEW_STATUS"; fi' \
+  '  if [[ " $* " == *" --json body "* ]]; then printf "Historical release notes.\n"; fi' \
+  '  if [[ " $* " == *" --json assets "* ]]; then printf "stargate-linux-amd64\nobsolete.zip\n"; fi' \
+  '  exit 0' \
+  'fi' \
   'exit 0' > "$fake_gh"
 chmod +x "$fake_gh"
 
@@ -88,7 +93,12 @@ PATH="$fake_bin:$PATH" GH_TEST_LOG="$existing_log" GH_VIEW_STATUS=0 \
 grep -Fq 'release upload' "$existing_log" || fail "Existing Release assets were not replaced"
 grep -Fq -- '--clobber' "$existing_log" || fail "Existing Release upload is not idempotent"
 grep -Fq 'release edit' "$existing_log" || fail "Existing Release metadata was not updated"
-if grep -Fq 'release delete' "$existing_log"; then
+grep -Fq 'release delete-asset v1.2.0 obsolete.zip' "$existing_log" \
+  || fail "Obsolete Release asset was not removed"
+if grep -Fq 'release delete-asset v1.2.0 stargate-linux-amd64' "$existing_log"; then
+  fail "Current Release asset was incorrectly removed"
+fi
+if grep -Eq 'release delete[[:space:]]' "$existing_log"; then
   fail "Manual overwrite deleted the existing Release"
 fi
 
@@ -107,5 +117,27 @@ if PATH="$fake_bin:$PATH" GH_TEST_LOG="$invalid_log" GH_VIEW_STATUS=0 \
   fail "Missing release notes unexpectedly reached publication"
 fi
 [[ ! -e "$invalid_log" ]] || fail "Validation failure modified an existing Release"
+
+# Automatic tag pushes must keep the strict changelog gate. Only an explicit
+# manual republish may reuse the notes of an already-existing historical tag.
+historical_log="$temp_dir/historical.log"
+historical_notes="$temp_dir/historical-notes.md"
+PATH="$fake_bin:$PATH" GH_TEST_LOG="$historical_log" GH_VIEW_STATUS=0 \
+  ALLOW_EXISTING_RELEASE_NOTES=true GITHUB_REPOSITORY=soulteary/stargate \
+  bash "$repo_root/.github/scripts/prepare-release-notes.sh" \
+    v0.12.0 "$historical_notes" "$temp_dir/missing-CHANGELOG.md"
+grep -Fq 'Historical release notes.' "$historical_notes" \
+  || fail "Manual historical republish did not preserve existing notes"
+grep -Fq 'release view v0.12.0' "$historical_log" \
+  || fail "Historical notes fallback did not read the existing Release"
+
+strict_log="$temp_dir/strict.log"
+if PATH="$fake_bin:$PATH" GH_TEST_LOG="$strict_log" GH_VIEW_STATUS=0 \
+  ALLOW_EXISTING_RELEASE_NOTES=false GITHUB_REPOSITORY=soulteary/stargate \
+  bash "$repo_root/.github/scripts/prepare-release-notes.sh" \
+    v0.12.0 "$temp_dir/strict-notes.md" "$temp_dir/missing-CHANGELOG.md" >/dev/null 2>&1; then
+  fail "Automatic publication unexpectedly bypassed the changelog gate"
+fi
+[[ ! -e "$strict_log" ]] || fail "Automatic changelog failure queried an existing Release"
 
 echo "Release workflow state-machine tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
           bash .github/scripts/test-go-version-contract.sh
 
       - name: Check release-note extraction
-        run: bash .github/scripts/test-release-notes.sh
+        run: |
+          bash .github/scripts/test-release-notes.sh
+          bash .github/scripts/test-release-workflow.sh
 
       - name: Set up Go
         if: steps.changes.outputs.code == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,12 @@ on:
         type: string
 
 concurrency:
-  # Every release tag updates shared semver aliases. Serialize all tags so an
-  # older run cannot finish last and overwrite latest, major, or minor tags.
-  group: ${{ github.repository }}-release
+  # A tag owns its immutable publication state. queue:max preserves manual
+  # retries of the same tag without coupling distinct versions to one pending
+  # slot; mutable aliases are reconciled separately below.
+  group: ${{ github.repository }}-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
   cancel-in-progress: false
+  queue: max
 
 env:
   REGISTRY: ghcr.io
@@ -69,6 +71,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: compatibility
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
     permissions:
       contents: write
       packages: write
@@ -83,6 +87,16 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
 
+      # workflow_dispatch may republish a tag created before these scripts
+      # existed. Load automation from the exact commit that supplied this
+      # workflow while keeping the release source pinned to the requested tag.
+      - name: Checkout release automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: _release-automation
+          sparse-checkout: .github/scripts
+
       - name: Resolve release ref
         id: release
         env:
@@ -94,7 +108,7 @@ jobs:
           else
             TAG="${GITHUB_REF#refs/tags/}"
           fi
-          if ! printf '%s' "${TAG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+          if ! printf '%s' "${TAG}" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$'; then
             echo "::error::release_tag 必须是形如 vX.Y.Z 的语义化 tag，实际为 '${TAG}'"
             exit 1
           fi
@@ -104,12 +118,14 @@ jobs:
             test "$(git rev-parse HEAD)" = "$(git rev-parse "refs/tags/${TAG}^{commit}")"
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "manual=${{ github.event_name == 'workflow_dispatch' }}" >> "$GITHUB_OUTPUT"
 
       - name: Verify release commit belongs to main
         run: |
           git fetch origin main
           git merge-base --is-ancestor "$(git rev-parse HEAD)" origin/main
+
+      - name: Prepare and validate curated release notes
+        run: bash _release-automation/.github/scripts/extract-release-notes.sh "${{ steps.release.outputs.tag }}" "$RUNNER_TEMP/release-notes.md"
 
       - name: Check documentation contracts
         run: bash .github/scripts/check-doc-contracts.sh
@@ -185,7 +201,7 @@ jobs:
         run: |
           mkdir -p dist
           VERSION=${{ steps.version.outputs.version }}
-          COMMIT=${{ github.sha }}
+          COMMIT=${{ steps.version.outputs.commit }}
           BUILD_DATE=$(date +%FT%T%z)
           LDFLAGS="-s -w -X 'github.com/soulteary/version-kit/v2.Version=${VERSION}' -X 'github.com/soulteary/version-kit/v2.Commit=${COMMIT}' -X 'github.com/soulteary/version-kit/v2.BuildDate=${BUILD_DATE}'"
           
@@ -215,11 +231,6 @@ jobs:
           # "checksums.txt: FAILED". Hash every artifact EXCEPT the manifest.
           sha256sum $(ls | grep -v '^checksums.txt$') > checksums.txt
 
-      - name: Attest release artifacts
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
-        with:
-          subject-checksums: dist/checksums.txt
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
@@ -240,13 +251,10 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # 手动触发时 github.ref 为分支，semver/ref 无法解析 tag，
-          # 因此统一改用 Resolve release ref 得到的 tag/version 生成别名。
+          # Publish only the full version here. latest/major/minor are mutable
+          # aliases and are moved by the high-water reconciliation job.
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.tag }}
-            type=semver,pattern={{major}},value=${{ steps.release.outputs.tag }}
-            type=raw,value=latest,enable=${{ !contains(steps.release.outputs.tag, '-') }}
 
       - name: Build amd64 image for security scan
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -308,8 +316,42 @@ jobs:
           vuln-type: os,library
           severity: HIGH,CRITICAL
 
+      - name: Resolve existing immutable image
+        id: immutable
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          status=0
+          inspection=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" 2>&1) || status=$?
+          if [ "$status" -eq 0 ]; then
+            digest=$(awk '$1 == "Digest:" { print $2; exit }' <<< "$inspection")
+            if ! printf '%s' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+              echo "::error::Unable to resolve the existing image digest"
+              exit 1
+            fi
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          elif grep -Eqi 'manifest unknown|not found' <<< "$inspection"; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            printf '%s\n' "$inspection" >&2
+            echo "::error::Unable to determine whether the immutable image already exists"
+            exit "$status"
+          fi
+
+      # This is the first external publication step. Every fallible validation,
+      # release-note check, build, image scan, and immutability check above has
+      # already succeeded.
+      - name: Attest release artifacts
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-checksums: dist/checksums.txt
+
       - name: Build and push Docker image
         id: image
+        if: steps.immutable.outputs.exists != 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
@@ -331,11 +373,25 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      - name: Resolve published image digest
+        id: published-image
+        env:
+          EXISTING_DIGEST: ${{ steps.immutable.outputs.digest }}
+          PUSHED_DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          digest=${PUSHED_DIGEST:-$EXISTING_DIGEST}
+          if ! printf '%s' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+            echo "::error::Published image digest is unavailable"
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
       - name: Attest container image
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.image.outputs.digest }}
+          subject-digest: ${{ steps.published-image.outputs.digest }}
           push-to-registry: true
 
       - name: Install Cosign
@@ -344,31 +400,50 @@ jobs:
       - name: Sign container image
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST: ${{ steps.image.outputs.digest }}
+          DIGEST: ${{ steps.published-image.outputs.digest }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
       - name: Sign checksum manifest
         run: cosign sign-blob --yes --bundle dist/checksums.txt.sigstore.json dist/checksums.txt
 
-      - name: Prepare curated release notes
-        run: bash .github/scripts/extract-release-notes.sh "${{ steps.release.outputs.tag }}" "$RUNNER_TEMP/release-notes.md"
-
-      - name: Delete existing release for overwrite
-        if: steps.release.outputs.manual == 'true'
+      - name: Create or repair GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          # 手动重发：删除同名 Release（保留 git tag），随后重新创建以覆盖。
-          gh release delete "$TAG" --yes --repo "$GITHUB_REPOSITORY" || true
+        run: bash _release-automation/.github/scripts/publish-github-release.sh "${{ steps.release.outputs.tag }}" "$RUNNER_TEMP/release-notes.md" dist
 
-      - name: Create Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+  reconcile-aliases:
+    name: Reconcile mutable release aliases
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: write
+      packages: write
+    concurrency:
+      # The queue prevents reconciliation requests from being replaced. The
+      # high-water SemVer calculation, rather than queue order, prevents an
+      # older release that completes late from downgrading an alias.
+      group: ${{ github.repository }}-release-aliases
+      cancel-in-progress: false
+      queue: max
+    steps:
+      - name: Checkout release automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          files: |
-            dist/*
-          tag_name: ${{ steps.release.outputs.tag }}
-          name: Release ${{ steps.version.outputs.tag }}
-          body_path: ${{ runner.temp }}/release-notes.md
-          draft: false
-          prerelease: ${{ contains(steps.release.outputs.tag, '-') }}
+          ref: ${{ github.workflow_sha }}
+          path: _release-automation
+          sparse-checkout: .github/scripts
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reconcile latest, major, and minor aliases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash _release-automation/.github/scripts/reconcile-release-aliases.sh "${{ needs.release.outputs.tag }}" "${REGISTRY}/${IMAGE_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,10 @@ jobs:
           git merge-base --is-ancestor "$(git rev-parse HEAD)" origin/main
 
       - name: Prepare and validate curated release notes
-        run: bash _release-automation/.github/scripts/extract-release-notes.sh "${{ steps.release.outputs.tag }}" "$RUNNER_TEMP/release-notes.md"
+        env:
+          ALLOW_EXISTING_RELEASE_NOTES: ${{ github.event_name == 'workflow_dispatch' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash _release-automation/.github/scripts/prepare-release-notes.sh "${{ steps.release.outputs.tag }}" "$RUNNER_TEMP/release-notes.md"
 
       - name: Check documentation contracts
         run: bash .github/scripts/check-doc-contracts.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Made tag releases independently queueable and immutable, with fail-fast
+  release-note validation and SemVer high-water reconciliation for mutable
+  container aliases.
 - Bound verification audit events to server-side challenge context. The context
   uses process memory for standalone deployments and the configured session
   Redis for multi-instance deployments. Idempotent retries preserve the original


### PR DESCRIPTION
## Summary

Fixes the release races identified in:

- https://github.com/soulteary/stargate/pull/123#discussion_r3869285709
- https://github.com/soulteary/stargate/pull/132#discussion_r3869963214

GitHub Actions now supports `concurrency.queue: max` (up to 100 pending runs), but queue order still is not a correctness guarantee. This change therefore uses the queue for retention and a SemVer high-water reconciliation step for correctness.

## Release state machine

1. **Preflight (no external writes)**
   - resolve and strictly validate the requested SemVer tag
   - verify the tagged commit belongs to `main`
   - extract and validate an exact dated changelog section
   - run documentation contracts, Go validation, tests, builds, SBOM/checksum generation, and both image scans
   - determine whether the full-version image already exists
2. **Immutable publication**
   - attest release artifacts
   - publish only the full version image tag (for example `1.2.3`)
   - if that image already exists, reuse its digest instead of overwriting it
   - attest/sign the digest and checksum manifest
   - create or repair the GitHub Release without deleting the existing Release first
3. **Mutable alias reconciliation**
   - stable releases only
   - query published, non-draft, non-prerelease Releases
   - compute the highest stable SemVer for `latest`, the target major, and the target minor
   - retag aliases from resolved immutable digests
   - align GitHub's Latest Release marker with the same high-water release

## Concurrency strategy

- Publication is keyed by normalized tag name, so distinct tags do not share a replaceable pending slot.
- Same-tag push/manual retries use `queue: max` and cannot run concurrently.
- Alias reconciliation uses its own repository-wide `queue: max` group.
- Reconciliation never trusts FIFO completion order: a late older run recomputes the published SemVer high-water mark and cannot downgrade `latest`, major, or minor aliases.
- Prereleases retain their full version image and never update stable aliases.

## Failure boundaries and manual republish

All changelog and local validation happens before image push, signing, attestation, Release mutation, or alias mutation. A missing, malformed, or `Unreleased` changelog section therefore leaves no partial publication.

Once the first external publication step starts, GitHub Release, GHCR, Sigstore, and attestations cannot form one cross-service transaction. These steps are intentionally idempotent: reruns reuse an existing full-version image digest, repair Release assets/metadata in place, and rerun high-water reconciliation. Manual republish remains supported for existing tags, including tags older than the automation scripts, because the release source is checked out from the tag while automation is loaded from the workflow commit.

The previous delete-then-create Release window is removed. No unrelated Actions were upgraded.

## Verification

- `bash -n .github/scripts/*.sh`
- `bash .github/scripts/check-doc-contracts.sh`
- `bash .github/scripts/test-doc-contracts.sh`
- `bash .github/scripts/test-go-version-contract.sh`
- `bash .github/scripts/test-release-notes.sh`
- `bash .github/scripts/test-release-workflow.sh`
- YAML parsing for every workflow
- `git diff --check`
- `actionlint v1.7.12`, with only the exact `queue` schema warning ignored because this actionlint release (and current main schema) predates GitHub's May 2026 `queue: max` feature

The release workflow contract tests cover:

- multiple tag triggers retaining independent publication state
- an older version finishing after a newer version
- missing, malformed, and `Unreleased` changelog entries
- prereleases not updating `latest`
- manual overwrite of an existing Release without deleting it
- historical manual republish reusing existing notes when the tag predates the changelog contract
- removal of obsolete Release assets after replacement assets are uploaded
- validation failure performing no Release operation
