### PR TITLE
fix: bound provider calls with request context deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added a 10-second, strictly validated request-context deadline before tracing
+  so Warden and Herald calls receive a real `Done` signal and are canceled on
+  timeout or handler completion. Fiber/fasthttp client-disconnect limitations
+  are now documented explicitly.
 - Made tag releases independently queueable and immutable, with fail-fast
   release-note validation and SemVer high-water reconciliation for mutable
   container aliases.

--- a/docs/deDE/CONFIG.md
+++ b/docs/deDE/CONFIG.md
@@ -321,6 +321,7 @@ Die folgende Tabelle ist mit den tatsächlich in `internal/config` registrierten
 | `OTLP_ENDPOINT` | URL | leer | OTLP-Endpunkt |
 | `AUTH_REFRESH_ENABLED` | true/false | true | Regelmäßige Autorisierungsaktualisierung |
 | `AUTH_REFRESH_INTERVAL` | Dauer | `5m` | Aktualisierungsintervall |
+| `REQUEST_CONTEXT_TIMEOUT` | Dauer | `10s` | Request-Deadline für Upstream-Aufrufe; keine Garantie für Abbruch bei Client-Trennung |
 
 HMAC Key ID und Secret müssen gemeinsam gesetzt werden. mTLS-Clientzertifikat und -schlüssel müssen ebenfalls gemeinsam gesetzt werden; unvollständige Paare führen zum Startfehler.
 

--- a/docs/enUS/CONFIG.md
+++ b/docs/enUS/CONFIG.md
@@ -100,6 +100,7 @@ Below are all environment variables used in code. "Required" means the service w
 | `OTLP_ENDPOINT` | String | empty | No |
 | `AUTH_REFRESH_ENABLED` | true/false | true | No |
 | `AUTH_REFRESH_INTERVAL` | duration | 5m | No |
+| `REQUEST_CONTEXT_TIMEOUT` | duration | 10s | No |
 
 ## Required Configuration
 
@@ -856,6 +857,26 @@ Refresh interval (Go duration, e.g. `5m`, `1h`).
 | **Default** | `5m` |
 
 **Example:** `AUTH_REFRESH_INTERVAL=10m`
+
+#### `REQUEST_CONTEXT_TIMEOUT`
+
+Maximum lifetime of the standard Go context propagated through tracing to
+Warden, Herald, and other request-scoped work. The value must be a positive Go
+duration. The default is `10s`, matching the existing Herald client timeout and
+remaining below Stargate's 15-second response write timeout.
+
+Fiber/fasthttp does not provide per-request cancellation when an ordinary HTTP
+client disconnects. This setting therefore supplies the reliable deadline;
+Stargate also cancels the context when the handler returns. It does not add or
+promise immediate client-disconnect cancellation.
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | String (duration) |
+| **Required** | No |
+| **Default** | `10s` |
+
+**Example:** `REQUEST_CONTEXT_TIMEOUT=10s`
 
 ## Password Configuration
 

--- a/docs/frFR/CONFIG.md
+++ b/docs/frFR/CONFIG.md
@@ -321,6 +321,7 @@ Ce tableau est synchronisé avec les variables de sécurité réellement enregis
 | `OTLP_ENDPOINT` | URL | vide | Point de terminaison OTLP |
 | `AUTH_REFRESH_ENABLED` | true/false | true | Actualisation périodique des autorisations |
 | `AUTH_REFRESH_INTERVAL` | durée | `5m` | Intervalle d'actualisation |
+| `REQUEST_CONTEXT_TIMEOUT` | durée | `10s` | Échéance des appels amont ; aucune garantie d'annulation à la déconnexion du client |
 
 L'identifiant et le secret HMAC doivent être définis ensemble. Le certificat et la clé client mTLS doivent également former une paire complète, sinon le démarrage échoue.
 

--- a/docs/itIT/CONFIG.md
+++ b/docs/itIT/CONFIG.md
@@ -321,6 +321,7 @@ La tabella è sincronizzata con le variabili di sicurezza realmente registrate i
 | `OTLP_ENDPOINT` | URL | vuoto | Endpoint OTLP |
 | `AUTH_REFRESH_ENABLED` | true/false | true | Aggiornamento periodico autorizzazioni |
 | `AUTH_REFRESH_INTERVAL` | durata | `5m` | Intervallo aggiornamento |
+| `REQUEST_CONTEXT_TIMEOUT` | durata | `10s` | Scadenza delle chiamate upstream; nessuna garanzia di annullamento alla disconnessione del client |
 
 Key ID e secret HMAC devono essere impostati insieme. Anche certificato e chiave client mTLS devono essere configurati come coppia completa; in caso contrario l'avvio fallisce.
 

--- a/docs/jaJP/CONFIG.md
+++ b/docs/jaJP/CONFIG.md
@@ -321,6 +321,7 @@ PORT=8080
 | `OTLP_ENDPOINT` | URL | 空 | OTLP エンドポイント |
 | `AUTH_REFRESH_ENABLED` | true/false | true | 認可情報の定期更新 |
 | `AUTH_REFRESH_INTERVAL` | 期間 | `5m` | 更新間隔 |
+| `REQUEST_CONTEXT_TIMEOUT` | 期間 | `10s` | 上流呼び出しの期限。クライアント切断時の即時キャンセルは保証しない |
 
 HMAC の Key ID と Secret は必ず同時に設定します。mTLS のクライアント証明書と鍵も完全なペアが必要で、不完全な設定では起動に失敗します。
 

--- a/docs/koKR/CONFIG.md
+++ b/docs/koKR/CONFIG.md
@@ -321,6 +321,7 @@ PORT=8080
 | `OTLP_ENDPOINT` | URL | 비어 있음 | OTLP 엔드포인트 |
 | `AUTH_REFRESH_ENABLED` | true/false | true | 권한 정보 주기적 갱신 |
 | `AUTH_REFRESH_INTERVAL` | 기간 | `5m` | 갱신 간격 |
+| `REQUEST_CONTEXT_TIMEOUT` | 기간 | `10s` | 업스트림 호출 기한. 클라이언트 연결 종료 시 즉시 취소는 보장하지 않음 |
 
 HMAC Key ID와 Secret은 함께 설정해야 합니다. mTLS 클라이언트 인증서와 키도 완전한 쌍이어야 하며, 불완전한 설정은 시작 실패로 처리됩니다.
 

--- a/docs/zhCN/CONFIG.md
+++ b/docs/zhCN/CONFIG.md
@@ -100,6 +100,7 @@ services:
 | `OTLP_ENDPOINT` | String | 空 | 否 |
 | `AUTH_REFRESH_ENABLED` | true/false | true | 否 |
 | `AUTH_REFRESH_INTERVAL` | duration | 5m | 否 |
+| `REQUEST_CONTEXT_TIMEOUT` | duration | 10s | 否 |
 
 ## 必需配置
 
@@ -870,6 +871,24 @@ OTLP 采集端地址（如 Jaeger/OTLP Collector）。
 | **默认值** | `5m` |
 
 **示例：** `AUTH_REFRESH_INTERVAL=10m`
+
+#### `REQUEST_CONTEXT_TIMEOUT`
+
+限制通过 tracing 传递给 Warden、Herald 和其他请求内工作的标准 Go
+context 的最长生命周期。该值必须是正数 Go duration。默认值为 `10s`，
+与现有 Herald 客户端超时时间一致，并低于 Stargate 的 15 秒响应写超时。
+
+Fiber/fasthttp 在普通 HTTP 客户端断开时不会提供逐请求取消信号。因此，
+此配置提供可靠的 deadline；handler 返回时 Stargate 也会主动取消 context。
+该能力不表示、也不承诺客户端断开后会立即取消请求。
+
+| 属性 | 值 |
+|------|-----|
+| **类型** | String（duration） |
+| **必需** | 否 |
+| **默认值** | `10s` |
+
+**示例：** `REQUEST_CONTEXT_TIMEOUT=10s`
 
 ## 密码配置
 

--- a/src/cmd/stargate/server.go
+++ b/src/cmd/stargate/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/soulteary/stargate/src/internal/handlers"
 	"github.com/soulteary/stargate/src/internal/i18n"
 	"github.com/soulteary/stargate/src/internal/metrics"
+	"github.com/soulteary/stargate/src/internal/requestcontext"
 	internal_tls "github.com/soulteary/stargate/src/internal/tlsconfig"
 	internal_tracing "github.com/soulteary/stargate/src/internal/tracing"
 )
@@ -289,19 +290,28 @@ func setupMiddleware(app *fiber.App) {
 	app.Use(middlewarekit.SecurityHeaders(middlewarekit.DefaultSecurityHeadersConfig()))
 	log.Debug().Msg("Security headers middleware enabled")
 
-	// 3. OpenTelemetry tracing middleware (if enabled)
+	// 3. Install a standard Go context with a real Done channel and deadline.
+	// Fiber/fasthttp does not cancel individual request contexts when a client
+	// disconnects, so the configured deadline and handler cleanup are the
+	// cancellation boundaries available to Warden, Herald, and other callers.
+	app.Use(requestcontext.Middleware(config.RequestContextTimeout.ToDuration()))
+	log.Debug().Dur("timeout", config.RequestContextTimeout.ToDuration()).Msg("Request context middleware enabled")
+
+	// 4. OpenTelemetry tracing middleware (if enabled). It derives its span from
+	// the standard request context above so deadline, cancellation, and values
+	// survive tracing.
 	if config.OTLPEnabled.ToBool() {
 		app.Use(internal_tracing.TracingMiddleware("stargate"))
 		log.Info().Msg("OpenTelemetry tracing middleware enabled")
 	}
 
-	// 4. i18n middleware (language detection from Query > Cookie > Header > Accept-Language)
+	// 5. i18n middleware (language detection from Query > Cookie > Header > Accept-Language)
 	app.Use(i18nkit.FiberMiddleware(i18nkit.MiddlewareConfig{
 		Bundle: i18n.GetBundle(),
 	}))
 	log.Debug().Msg("i18n middleware enabled")
 
-	// 5. Request logging with logger-kit
+	// 6. Request logging with logger-kit
 	app.Use(logger.FiberMiddleware(logger.MiddlewareConfig{
 		Logger:           log,
 		SkipPaths:        []string{RouteHealthz, RouteReadyz, RouteHealth, "/metrics"},
@@ -310,7 +320,7 @@ func setupMiddleware(app *fiber.App) {
 	}))
 	log.Debug().Msg("Request logging middleware enabled")
 
-	// 6. Rate limiting (optional - uncomment to enable for production)
+	// 7. Rate limiting (optional - uncomment to enable for production)
 	// To enable rate limiting, uncomment the following code:
 	//
 	// zerologLogger := log.Zerolog()
@@ -331,7 +341,7 @@ func setupMiddleware(app *fiber.App) {
 	// }))
 	// log.Info().Msg("Rate limiting middleware enabled")
 
-	// 7. Favicon middleware
+	// 8. Favicon middleware
 	log.Debug().Msg("Adding favicon middleware")
 	faviconPath := findFaviconPath()
 	// Only add favicon middleware if the file exists

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -408,6 +408,18 @@ var (
 		Validator:      ValidateAny,
 	}
 
+	// RequestContextTimeout bounds request-scoped work, including Warden and
+	// Herald calls. Fiber/fasthttp does not provide per-request cancellation on
+	// ordinary client disconnects, so this deadline is the reliable cancellation
+	// boundary propagated to upstream providers.
+	RequestContextTimeout = EnvVariable{
+		Name:           "REQUEST_CONTEXT_TIMEOUT",
+		Required:       false,
+		DefaultValue:   "10s",
+		PossibleValues: []string{"*"},
+		Validator:      ValidateAny,
+	}
+
 	// Login channel toggles: when false, SMS or email verification code login is disabled
 	LoginSMSEnabled = EnvVariable{
 		Name:           "LOGIN_SMS_ENABLED",
@@ -458,7 +470,7 @@ func Initialize(l *logger.Logger) error {
 	}
 
 	// Then validate all other configuration variables
-	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &PasswordHeaderAuthEnabled, &UserHeaderName, &TrustedProxies, &ProxyHeader, &CookieDomain, &CookieSecure, &CallbackAllowedHosts, &SessionExchangeSecret, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &LoginSMSEnabled, &LoginEmailEnabled}
+	var envVariables = []*EnvVariable{&Debug, &AuthHost, &LoginPageTitle, &LoginPageFooterText, &Passwords, &PasswordHeaderAuthEnabled, &UserHeaderName, &TrustedProxies, &ProxyHeader, &CookieDomain, &CookieSecure, &CallbackAllowedHosts, &SessionExchangeSecret, &Language, &Port, &WardenURL, &WardenAPIKey, &WardenHMACKeyID, &WardenHMACSecret, &WardenTLSCACertFile, &WardenTLSClientCert, &WardenTLSClientKey, &WardenTLSServerName, &WardenEnabled, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader, &WardenCacheTTL, &HeraldURL, &HeraldAPIKey, &HeraldEnabled, &HeraldHMACSecret, &HeraldHMACKeyID, &HeraldTLSCACertFile, &HeraldTLSClientCert, &HeraldTLSClientKey, &HeraldTLSServerName, &HeraldTOTPEnabled, &SessionStorageEnabled, &SessionStorageRedisAddr, &SessionStorageRedisPassword, &SessionStorageRedisDB, &SessionStorageRedisKeyPrefix, &AuditLogEnabled, &AuditLogFormat, &StepUpEnabled, &StepUpPaths, &OTLPEnabled, &OTLPEndpoint, &AuthRefreshEnabled, &AuthRefreshInterval, &RequestContextTimeout, &LoginSMSEnabled, &LoginEmailEnabled}
 
 	for _, variable := range envVariables {
 		err := variable.Validate()

--- a/src/internal/config/strict_validation.go
+++ b/src/internal/config/strict_validation.go
@@ -200,6 +200,9 @@ func validateStrictSettings() error {
 	if _, err := time.ParseDuration(AuthRefreshInterval.Value); err != nil || AuthRefreshInterval.ToDuration() <= 0 {
 		return strictValidationError(&AuthRefreshInterval, "must be a positive Go duration")
 	}
+	if _, err := time.ParseDuration(RequestContextTimeout.Value); err != nil || RequestContextTimeout.ToDuration() <= 0 {
+		return strictValidationError(&RequestContextTimeout, "must be a positive Go duration")
+	}
 	redisDBValue := SessionStorageRedisDB.Value
 	redisDB, err := strconv.Atoi(redisDBValue)
 	if err != nil || redisDB < 0 || strings.TrimSpace(redisDBValue) != redisDBValue {

--- a/src/internal/config/strict_validation_test.go
+++ b/src/internal/config/strict_validation_test.go
@@ -10,7 +10,7 @@ func setValidStrictTestValues(t *testing.T) {
 	t.Helper()
 	variables := []*EnvVariable{
 		&AuthHost, &CookieDomain, &CallbackAllowedHosts, &SessionExchangeSecret, &Port,
-		&WardenCacheTTL, &AuthRefreshInterval, &SessionStorageRedisDB,
+		&WardenCacheTTL, &AuthRefreshInterval, &RequestContextTimeout, &SessionStorageRedisDB,
 		&SessionStorageEnabled, &SessionStorageRedisAddr, &WardenURL, &HeraldURL,
 		&UserHeaderName, &ProxyHeader, &HeaderAuthEnabled, &HeaderAuthSharedSecret, &HeaderAuthSecretHeader,
 	}
@@ -31,6 +31,7 @@ func setValidStrictTestValues(t *testing.T) {
 	Port.Value = ""
 	WardenCacheTTL.Value = "300"
 	AuthRefreshInterval.Value = "5m"
+	RequestContextTimeout.Value = "10s"
 	SessionStorageRedisDB.Value = "0"
 	SessionStorageEnabled.Value = "false"
 	SessionStorageRedisAddr.Value = "localhost:6379"
@@ -68,6 +69,7 @@ func TestValidateStrictSettingsRejectsInvalidNumbers(t *testing.T) {
 		{"cache ttl", func() { WardenCacheTTL.Value = "0" }, WardenCacheTTL.Name},
 		{"redis db", func() { SessionStorageRedisDB.Value = "-1" }, SessionStorageRedisDB.Name},
 		{"refresh duration", func() { AuthRefreshInterval.Value = "soon" }, AuthRefreshInterval.Name},
+		{"request context duration", func() { RequestContextTimeout.Value = "0s" }, RequestContextTimeout.Name},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/src/internal/handlers/check.go
+++ b/src/internal/handlers/check.go
@@ -94,12 +94,9 @@ func CheckRoute(store SessionStoreForCheck) func(c fiber.Ctx) error {
 
 	return func(ctx fiber.Ctx) error {
 		trustedIdentity := sanitizeTrustedIdentityHeaders(ctx)
-		// Get trace context from middleware
-		traceCtx := ctx.Locals("trace_context")
-		if traceCtx == nil {
-			traceCtx = ctx.Context()
-		}
-		spanCtx := traceCtx.(context.Context)
+		// Tracing publishes its span through Fiber's standard Context/SetContext
+		// API; when tracing is disabled this still carries the request deadline.
+		spanCtx := ctx.Context()
 
 		// Start span for forward auth check
 		_, forwardAuthSpan := tracing.StartSpan(spanCtx, "auth.forward_auth")

--- a/src/internal/handlers/check_test.go
+++ b/src/internal/handlers/check_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -10,29 +11,40 @@ import (
 	"github.com/MarvinJWendt/testza"
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/session"
+	forwardauth "github.com/soulteary/forwardauth-kit/v2"
 	"github.com/soulteary/stargate/src/internal/auth"
 	"github.com/soulteary/stargate/src/internal/config"
+	"github.com/soulteary/stargate/src/internal/requestcontext"
 	"github.com/soulteary/warden/pkg/warden"
 )
 
-func TestTrustedHeaderAuthResultPropagatesCancellation(t *testing.T) {
+func TestTrustedHeaderAuthResultUsesRequestDeadline(t *testing.T) {
 	originalLookup := lookupTrustedHeaderUser
 	t.Cleanup(func() { lookupTrustedHeaderUser = originalLookup })
 
-	requestCtx, cancel := context.WithCancel(context.Background())
-	cancel()
+	var providerContext context.Context
 	lookupTrustedHeaderUser = func(ctx context.Context, phone, mail string) *warden.AllowListUser {
-		select {
-		case <-ctx.Done():
-		default:
-			t.Fatal("Warden lookup did not receive the canceled request context")
-		}
-		return &warden.AllowListUser{UserID: "user1", Phone: phone, Mail: mail}
+		providerContext = ctx
+		<-ctx.Done()
+		return nil
 	}
 
-	result, err := trustedHeaderAuthResult(requestCtx, "13800138000", "")
+	app := fiber.New()
+	app.Use(requestcontext.Middleware(25 * time.Millisecond))
+	app.Get("/lookup", func(c fiber.Ctx) error {
+		result, err := trustedHeaderAuthResult(c.Context(), "13800138000", "")
+		testza.AssertNil(t, result)
+		testza.AssertEqual(t, forwardauth.ErrUserNotFound, err)
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/lookup", nil))
 	testza.AssertNoError(t, err)
-	testza.AssertEqual(t, "user1", result.UserID)
+	testza.AssertEqual(t, fiber.StatusNoContent, resp.StatusCode)
+	deadline, ok := providerContext.Deadline()
+	testza.AssertTrue(t, ok)
+	testza.AssertTrue(t, !deadline.IsZero())
+	testza.AssertEqual(t, context.DeadlineExceeded, providerContext.Err())
 }
 
 // TestCheckRoute_HandlerNil verifies that when GetForwardAuthHandler returns nil,

--- a/src/internal/handlers/forwardauth.go
+++ b/src/internal/handlers/forwardauth.go
@@ -94,7 +94,7 @@ func InitForwardAuthHandler(l *logger.Logger) {
 		// Trusted identity headers are checked in CheckRoute, where the active
 		// request context can be propagated to Warden. forwardauth-kit v2.1.0
 		// exposes context-free callbacks, so enabling its header checker here
-		// would detach Warden calls from client cancellation.
+		// would detach Warden calls from the request deadline and handler cleanup.
 		HeaderAuthEnabled:   false,
 		HeaderAuthUserPhone: "X-User-Phone",
 		HeaderAuthUserMail:  "X-User-Mail",

--- a/src/internal/handlers/login.go
+++ b/src/internal/handlers/login.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"fmt"
 	"html"
 	"net/http"
@@ -141,12 +140,9 @@ func (a *AuthAuthenticator) Authenticate(sess *session.Session) error {
 
 // loginAPIHandler is the internal handler that can be tested with mocked dependencies.
 func loginAPIHandler(ctx fiber.Ctx, sessionGetter SessionGetter, authenticator Authenticator) error {
-	// Get trace context from middleware
-	traceCtx := ctx.Locals("trace_context")
-	if traceCtx == nil {
-		traceCtx = ctx.Context()
-	}
-	spanCtx := traceCtx.(context.Context)
+	// Tracing publishes its span through Fiber's standard Context/SetContext
+	// API; when tracing is disabled this still carries the request deadline.
+	spanCtx := ctx.Context()
 
 	// Start span for login
 	loginCtx, loginSpan := tracing.StartSpan(spanCtx, "auth.login")

--- a/src/internal/handlers/send_verify_code.go
+++ b/src/internal/handlers/send_verify_code.go
@@ -112,12 +112,9 @@ func selectVerificationDestination(userInfo *warden.AllowListUser, deliverVia st
 // SendVerifyCodeAPI handles POST requests to /_send_verify_code for sending verification codes via Herald
 func SendVerifyCodeAPI() func(c fiber.Ctx) error {
 	return func(ctx fiber.Ctx) error {
-		// Get trace context from middleware
-		traceCtx := ctx.Locals("trace_context")
-		if traceCtx == nil {
-			traceCtx = ctx.Context()
-		}
-		spanCtx := traceCtx.(context.Context)
+		// Tracing publishes its span through Fiber's standard Context/SetContext
+		// API; when tracing is disabled this still carries the request deadline.
+		spanCtx := ctx.Context()
 
 		// Start span for send verify code
 		sendCodeCtx, sendCodeSpan := tracing.StartSpan(spanCtx, "auth.send_verify_code")

--- a/src/internal/requestcontext/middleware.go
+++ b/src/internal/requestcontext/middleware.go
@@ -1,0 +1,26 @@
+// Package requestcontext provides a standard Go request context for Fiber
+// handlers and the upstream calls they make.
+package requestcontext
+
+import (
+	"context"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// Middleware installs a request-scoped standard Go context with a deadline.
+//
+// Fiber's Ctx implements context.Context, but its Done channel is nil. The
+// underlying fasthttp request context is also not canceled for an ordinary
+// client disconnect. This middleware therefore provides a real deadline and
+// guarantees cancellation when the handler returns. It does not claim to turn
+// client disconnects into per-request cancellation signals.
+func Middleware(timeout time.Duration) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		ctx, cancel := context.WithTimeout(c.Context(), timeout)
+		c.SetContext(ctx)
+		defer cancel()
+		return c.Next()
+	}
+}

--- a/src/internal/requestcontext/middleware_test.go
+++ b/src/internal/requestcontext/middleware_test.go
@@ -1,0 +1,90 @@
+package requestcontext
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeProvider struct {
+	call func(context.Context) error
+}
+
+func (p fakeProvider) Call(ctx context.Context) error {
+	return p.call(ctx)
+}
+
+func TestMiddlewareProvidersObserveDeadlineAndKeepResults(t *testing.T) {
+	providerErr := errors.New("provider error")
+	for _, test := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "warden success", want: fiber.StatusNoContent},
+		{name: "warden error", err: providerErr, want: fiber.StatusBadGateway},
+		{name: "herald success", want: fiber.StatusNoContent},
+		{name: "herald error", err: providerErr, want: fiber.StatusBadGateway},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var captured context.Context
+			provider := fakeProvider{call: func(ctx context.Context) error {
+				captured = ctx
+				deadline, ok := ctx.Deadline()
+				require.True(t, ok, "provider must receive a context deadline")
+				assert.WithinDuration(t, time.Now().Add(time.Second), deadline, 200*time.Millisecond)
+				return test.err
+			}}
+
+			app := fiber.New()
+			app.Use(Middleware(time.Second))
+			app.Get("/provider", func(c fiber.Ctx) error {
+				if err := provider.Call(c.Context()); err != nil {
+					return c.SendStatus(fiber.StatusBadGateway)
+				}
+				return c.SendStatus(fiber.StatusNoContent)
+			})
+
+			resp, err := app.Test(httptest.NewRequest("GET", "/provider", nil))
+			require.NoError(t, err)
+			assert.Equal(t, test.want, resp.StatusCode)
+			require.NotNil(t, captured)
+			select {
+			case <-captured.Done():
+				assert.ErrorIs(t, captured.Err(), context.Canceled)
+			case <-time.After(time.Second):
+				t.Fatal("request context was not canceled after the handler returned")
+			}
+		})
+	}
+}
+
+func TestMiddlewareTimeoutCancelsBlockedProvider(t *testing.T) {
+	const timeout = 25 * time.Millisecond
+	provider := fakeProvider{call: func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}}
+
+	app := fiber.New()
+	app.Use(Middleware(timeout))
+	app.Get("/provider", func(c fiber.Ctx) error {
+		if err := provider.Call(c.Context()); !errors.Is(err, context.DeadlineExceeded) {
+			return c.Status(fiber.StatusInternalServerError).SendString("unexpected provider result")
+		}
+		return c.SendStatus(fiber.StatusGatewayTimeout)
+	})
+
+	started := time.Now()
+	resp, err := app.Test(httptest.NewRequest("GET", "/provider", nil))
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusGatewayTimeout, resp.StatusCode)
+	assert.GreaterOrEqual(t, time.Since(started), timeout)
+	assert.Less(t, time.Since(started), time.Second)
+}

--- a/src/internal/tracing/middleware.go
+++ b/src/internal/tracing/middleware.go
@@ -60,7 +60,11 @@ func TracingMiddleware(serviceName string) fiber.Handler {
 		}
 		defer span.End()
 
-		// Store context in Fiber context
+		// Publish the traced standard context through Fiber's Context/SetContext
+		// API. Handlers using c.Context() now retain the request deadline,
+		// cancellation signal, context values, and active span. Locals are kept for
+		// compatibility with libraries that still read the historical key.
+		c.SetContext(ctx)
 		c.Locals("trace_context", ctx)
 		c.Locals("trace_span", span)
 

--- a/src/internal/tracing/middleware_test.go
+++ b/src/internal/tracing/middleware_test.go
@@ -1,12 +1,17 @@
 package tracing
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/soulteary/stargate/src/internal/requestcontext"
 	common_tracing "github.com/soulteary/tracing-kit"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestTracingMiddleware(t *testing.T) {
@@ -66,6 +71,42 @@ func TestTracingMiddleware(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 200, resp.StatusCode)
 	})
+}
+
+type tracingContextKey struct{}
+
+func TestTracingMiddlewarePreservesDeadlineCancellationAndValues(t *testing.T) {
+	defer common_tracing.TeardownTestTracer()
+	_, _ = common_tracing.SetupTestTracer(t)
+
+	var captured context.Context
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.SetContext(context.WithValue(c.Context(), tracingContextKey{}, "preserved"))
+		return c.Next()
+	})
+	app.Use(requestcontext.Middleware(time.Second))
+	app.Use(TracingMiddleware("test-service"))
+	app.Get("/context", func(c fiber.Ctx) error {
+		captured = c.Context()
+		deadline, ok := captured.Deadline()
+		require.True(t, ok)
+		assert.WithinDuration(t, time.Now().Add(time.Second), deadline, 200*time.Millisecond)
+		assert.Equal(t, "preserved", captured.Value(tracingContextKey{}))
+		assert.True(t, trace.SpanFromContext(captured).SpanContext().IsValid())
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/context", nil))
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+	require.NotNil(t, captured)
+	select {
+	case <-captured.Done():
+		assert.ErrorIs(t, captured.Err(), context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("traced request context was not canceled after handler return")
+	}
 }
 
 // TestHeaderCarrier_Keys covers headerCarrier.Keys() (OpenTelemetry TextMapCarrier) for coverage.


### PR DESCRIPTION
## Summary

Fixes the remaining context-propagation issue identified in [PR #133 review](https://github.com/soulteary/stargate/pull/133#discussion_r3869970301).

- install a standard Go `context.WithTimeout` before OpenTelemetry tracing
- publish the traced child context with Fiber v3's `SetContext` / `Context` API
- guarantee `cancel()` when each handler chain returns
- make Warden, Herald, TOTP, auth-refresh, and audit/store calls inherit the same request deadline and active span
- replace handler reliance on the historical `trace_context` local while retaining that local for library compatibility
- add strict `REQUEST_CONTEXT_TIMEOUT` validation and document it in all seven configuration references
- keep Fiber/fasthttp; this does not migrate the server to `net/http`

## Fiber/fasthttp boundary

This PR deliberately does **not** claim client-disconnect cancellation.

Fiber v3.5.0's `fiber.Ctx` has no cancelable `Done` signal, and fasthttp's request-context `Done` closes for server shutdown rather than an ordinary per-request client disconnect. The concrete guarantees added here are:

1. a real standard Go context with a deadline;
2. cancellation when that deadline expires;
3. cancellation when the handler returns;
4. preservation of context values and the active tracing span.

Immediate cancellation on a normal client disconnect remains outside Fiber/fasthttp's request-context capability.

## Configuration and compatibility

`REQUEST_CONTEXT_TIMEOUT` defaults to **10s**. It must be a positive Go duration. The default matches the existing Herald client timeout and remains below Stargate's 15-second response write timeout.

Existing routes, response formats, provider error mapping, and Warden/Herald client configuration are unchanged. Requests that complete within the existing provider limits behave as before; runaway request-scoped work is now bounded by the shared deadline.

## Tests

Added coverage verifies:

- fake Warden and Herald providers observe a deadline
- blocked provider work is canceled at timeout
- captured contexts are canceled after handler return
- tracing spans, context values, deadlines, and cancellation survive the middleware chain
- the trusted-header Warden production path receives the request-derived deadline
- Warden, Herald, and TOTP success/error behavior remains compatible

Validated locally with:

- `go test` for all non-handler packages
- focused handler tests covering Warden, Herald, TOTP, and password success/error paths
- `go test -race` for request-context, tracing, config, and focused handler coverage
- `go vet ./...`
- `gofmt` and `git diff --check`
- seven-language documentation contract checks

GitHub CI will run the repository's complete test matrix.