### PR TITLE
fix(config): reject control characters in step-up paths

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -501,7 +501,7 @@ func Initialize(l *logger.Logger) error {
 			}
 			usablePatterns++
 			if !ValidStepUpPathPattern(pattern) {
-				return NewValidationError(StepUpPaths.Name, "must contain only local absolute path patterns without queries, fragments, backslashes, or dot segments", StepUpPaths.PossibleValues)
+				return NewValidationError(StepUpPaths.Name, "must contain only local absolute path patterns without control characters, fragments, backslashes, or dot segments", StepUpPaths.PossibleValues)
 			}
 		}
 		if usablePatterns == 0 {

--- a/src/internal/config/stepup.go
+++ b/src/internal/config/stepup.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // StepUpMatcher handles step-up authentication path matching
@@ -20,7 +21,7 @@ var stepUpMatcher *StepUpMatcher
 // backslashes.
 func ValidStepUpPathPattern(raw string) bool {
 	decoded, err := url.PathUnescape(raw)
-	if err != nil || strings.IndexFunc(decoded, unicode.IsControl) >= 0 {
+	if err != nil || !utf8.ValidString(decoded) || strings.IndexFunc(decoded, unicode.IsControl) >= 0 {
 		return false
 	}
 

--- a/src/internal/config/stepup.go
+++ b/src/internal/config/stepup.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 // StepUpMatcher handles step-up authentication path matching
@@ -15,18 +16,21 @@ type StepUpMatcher struct {
 var stepUpMatcher *StepUpMatcher
 
 // ValidStepUpPathPattern reports whether a configured step-up pattern is a
-// local absolute path without ambiguous dot segments or backslashes.
+// local absolute path without control characters, ambiguous dot segments, or
+// backslashes.
 func ValidStepUpPathPattern(raw string) bool {
+	decoded, err := url.PathUnescape(raw)
+	if err != nil || strings.IndexFunc(decoded, unicode.IsControl) >= 0 {
+		return false
+	}
+
 	raw = strings.TrimSpace(raw)
 	if raw == "" || !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") || strings.ContainsAny(raw, "\\#") {
 		return false
 	}
 	// Do not parse the pattern as a request URI: '?' is a documented
 	// single-character glob here, not a query delimiter.
-	decoded, err := url.PathUnescape(raw)
-	if err != nil {
-		return false
-	}
+	decoded, _ = url.PathUnescape(raw)
 	for _, segment := range strings.Split(decoded, "/") {
 		if segment == "." || segment == ".." {
 			return false

--- a/src/internal/config/stepup_test.go
+++ b/src/internal/config/stepup_test.go
@@ -59,6 +59,39 @@ func TestInitializeStepUpAcceptsQuestionMarkGlob(t *testing.T) {
 	testza.AssertFalse(t, matcher.RequiresStepUp("/users/ab/settings"))
 }
 
+func TestValidStepUpPathPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		valid   bool
+	}{
+		{name: "question mark glob", pattern: "/users/?/settings", valid: true},
+		{name: "star glob", pattern: "/admin/*", valid: true},
+		{name: "literal newline", pattern: "/ad\nmin", valid: false},
+		{name: "trailing literal newline", pattern: "/admin\n", valid: false},
+		{name: "embedded NUL", pattern: "/ad\x00min", valid: false},
+		{name: "embedded control", pattern: "/ad\x1fmin", valid: false},
+		{name: "Unicode control", pattern: "/ad\u0085min", valid: false},
+		{name: "encoded NUL", pattern: "/admin/%00", valid: false},
+		{name: "encoded LF uppercase", pattern: "/admin/%0A", valid: false},
+		{name: "encoded LF lowercase", pattern: "/admin/%0a", valid: false},
+		{name: "encoded CR uppercase", pattern: "/admin/%0D", valid: false},
+		{name: "encoded CR lowercase", pattern: "/admin/%0d", valid: false},
+		{name: "backslash", pattern: `/admin\\users`, valid: false},
+		{name: "fragment", pattern: "/admin#users", valid: false},
+		{name: "dot segment", pattern: "/admin/../public", valid: false},
+		{name: "encoded dot segment", pattern: "/admin/%2e%2e/public", valid: false},
+		{name: "invalid escape", pattern: "/admin/%zz", valid: false},
+		{name: "non-local absolute path", pattern: "//evil.example/admin", valid: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testza.AssertEqual(t, test.valid, ValidStepUpPathPattern(test.pattern))
+		})
+	}
+}
+
 func TestInitStepUpMatcher_Enabled_SinglePath(t *testing.T) {
 	t.Setenv("AUTH_HOST", "auth.example.com")
 	t.Setenv("PASSWORDS", "plaintext:test123")

--- a/src/internal/config/stepup_test.go
+++ b/src/internal/config/stepup_test.go
@@ -72,6 +72,8 @@ func TestValidStepUpPathPattern(t *testing.T) {
 		{name: "embedded NUL", pattern: "/ad\x00min", valid: false},
 		{name: "embedded control", pattern: "/ad\x1fmin", valid: false},
 		{name: "Unicode control", pattern: "/ad\u0085min", valid: false},
+		{name: "encoded UTF-8 control", pattern: "/admin/%C2%85", valid: false},
+		{name: "encoded non-UTF-8 C1 byte", pattern: "/admin/%85", valid: false},
 		{name: "encoded NUL", pattern: "/admin/%00", valid: false},
 		{name: "encoded LF uppercase", pattern: "/admin/%0A", valid: false},
 		{name: "encoded LF lowercase", pattern: "/admin/%0a", valid: false},


### PR DESCRIPTION
## Summary

- reject decoded control characters in `STEP_UP_PATHS`, including literal and percent-encoded NUL, CR, LF, and C0/C1 controls
- reject invalid UTF-8 after path unescaping so single-byte encoded C1 values cannot bypass rune-level checks
- preserve `?` and `*` glob semantics and the existing rejection of fragments, backslashes, dot segments, invalid escapes, and non-local absolute paths
- clarify the validation error without echoing the configured input
- add table-driven regression coverage for control characters, mixed-case escapes, valid globs, and existing unsafe forms

## Verification

- `go test ./src/internal/config`
- `go vet ./...`
- repository-wide `gofmt -s -l .`
- documentation, Go-version, release-note, and release-workflow contract tests
- GitHub PR checks: `go test -short ./...` and golangci-lint v2.13.1
- `go test -run '^TestE2E_CompleteLoginFlow$' -count=1 ./src/internal/handlers` against a temporary local Redis-compatible server (the only test skipped by `-short`)
