### PR TITLE
fix: normalize local launcher port values

### DIFF
--- a/.github/scripts/test-start-local.sh
+++ b/.github/scripts/test-start-local.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+launcher="$repo_root/start-local.sh"
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local output=$1
+  local expected=$2
+  local description=$3
+  grep -Fq -- "$expected" <<< "$output" || fail "$description: missing '$expected'"
+}
+
+bash -n "$launcher"
+bash -n "$repo_root/.github/scripts/test-start-local.sh"
+
+fake_bin="$temp_dir/bin"
+mkdir -p "$fake_bin"
+fake_go="$fake_bin/go"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "EXPORTED_PORT=%s\n" "${PORT-}"' \
+  'printf "EXPORTED_AUTH_HOST=%s\n" "${AUTH_HOST-}"' \
+  'printf "EXPORTED_CALLBACK_ALLOWED_HOSTS=%s\n" "${CALLBACK_ALLOWED_HOSTS-}"' \
+  > "$fake_go"
+chmod +x "$fake_go"
+
+run_case() {
+  local description=$1
+  local expected_port=$2
+  local expected_host_port=$3
+  shift 3
+
+  local output
+  if ! output=$(cd "$repo_root" && env -u PORT -u AUTH_HOST -u CALLBACK_ALLOWED_HOSTS \
+      PATH="$fake_bin:$PATH" "$@" 2>&1); then
+    fail "$description: launcher unexpectedly failed: $output"
+  fi
+
+  assert_contains "$output" "EXPORTED_PORT=$expected_port" "$description"
+  assert_contains "$output" "EXPORTED_AUTH_HOST=localhost:$expected_host_port" "$description"
+  assert_contains "$output" "EXPORTED_CALLBACK_ALLOWED_HOSTS=localhost:$expected_host_port" "$description"
+  assert_contains "$output" "AUTH_HOST: localhost:$expected_host_port" "$description"
+  assert_contains "$output" \
+    "http://localhost:$expected_host_port/_login?callback=localhost:$expected_host_port" \
+    "$description"
+
+  if grep -Fq "localhost::$expected_host_port" <<< "$output"; then
+    fail "$description: output contains a double-colon host"
+  fi
+}
+
+assert_invalid() {
+  local description=$1
+  local expected=$2
+  shift 2
+
+  local output
+  if output=$(cd "$repo_root" && env -u PORT -u AUTH_HOST -u CALLBACK_ALLOWED_HOSTS \
+      PATH="$fake_bin:$PATH" "$@" 2>&1); then
+    fail "$description: invalid port unexpectedly succeeded"
+  fi
+  assert_contains "$output" "$expected" "$description"
+}
+
+# Empty PORT keeps the documented default.
+run_case "empty environment port" "8080" "8080" env PORT= bash "$launcher"
+
+# Both supported service-listener forms produce the same URL/host port.
+run_case "numeric environment port" "8080" "8080" env PORT=8080 bash "$launcher"
+run_case "colon-prefixed environment port" ":8080" "8080" env PORT=:8080 bash "$launcher"
+
+# CLI values override the environment and preserve the selected listener form.
+run_case "numeric CLI port" "8080" "8080" env PORT=:9090 bash "$launcher" --port 8080
+run_case "colon-prefixed CLI port" ":8080" "8080" env PORT=9090 bash "$launcher" --port :8080
+
+# Invalid inputs fail before the launcher can generate or export malformed hosts.
+assert_invalid "non-numeric environment port" "错误: 无效端口: nope" \
+  env PORT=nope bash "$launcher"
+assert_invalid "out-of-range CLI port" "错误: 无效端口: :65536" \
+  bash "$launcher" --port :65536
+assert_invalid "missing CLI port" "错误: --port 需要端口值" \
+  bash "$launcher" --port
+
+echo "Local launcher port tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
           bash .github/scripts/test-release-notes.sh
           bash .github/scripts/test-release-workflow.sh
 
+      - name: Check local launcher
+        run: bash .github/scripts/test-start-local.sh
+
       - name: Set up Go
         if: steps.changes.outputs.code == 'true'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -69,7 +72,7 @@ jobs:
 
       - name: Run golangci-lint
         if: steps.changes.outputs.code == 'true'
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06c5925ef5d2fc7ad053ef454303e # v9
         with:
           version: v2.13.1
           args: --timeout=5m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run golangci-lint
         if: steps.changes.outputs.code == 'true'
-        uses: golangci/golangci-lint-action@ba0d7d2ec06c5925ef5d2fc7ad053ef454303e # v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.13.1
           args: --timeout=5m

--- a/start-local.sh
+++ b/start-local.sh
@@ -21,6 +21,10 @@ CUSTOM_PORT=""
 while [[ $# -gt 0 ]]; do
     case $1 in
         -port|--port)
+            if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+                echo -e "${RED}错误: $1 需要端口值（1-65535，可选冒号前缀）${NC}"
+                exit 1
+            fi
             CUSTOM_PORT="$2"
             shift 2
             ;;
@@ -74,18 +78,27 @@ fi
 # 端口设置：命令行参数 > 环境变量 > 默认值
 if [ -n "$CUSTOM_PORT" ]; then
     PORT="$CUSTOM_PORT"
-elif [ -z "$PORT" ]; then
-    PORT="8080"
+else
+    PORT=${PORT:-"8080"}
+fi
+
+# 服务监听同时支持 8080 和 :8080；URL/host 拼接始终使用纯数字端口。
+HOST_PORT=${PORT#:}
+if [[ ! "$PORT" =~ ^:?[0-9]+$ ]] ||
+    [[ ! "$HOST_PORT" =~ ^[0-9]{1,5}$ ]] ||
+    ((10#$HOST_PORT < 1 || 10#$HOST_PORT > 65535)); then
+    echo -e "${RED}错误: 无效端口: $PORT（应为 1-65535，可选冒号前缀）${NC}"
+    exit 1
 fi
 
 # 设置默认值（命令行参数优先级最高，然后是环境变量，最后是默认值）
 # 本地认证主机和回调必须包含实际监听端口，否则登录后会跳到端口 80。
-AUTH_HOST=${AUTH_HOST:-"localhost:$PORT"}
+AUTH_HOST=${AUTH_HOST:-"localhost:$HOST_PORT"}
 PASSWORDS=${PASSWORDS:-"plaintext:test123|admin123"}
 DEBUG=${DEBUG:-"true"}
 LANGUAGE=${LANGUAGE:-"zh"}
 COOKIE_SECURE=${COOKIE_SECURE:-"false"}
-CALLBACK_ALLOWED_HOSTS=${CALLBACK_ALLOWED_HOSTS:-"localhost:$PORT"}
+CALLBACK_ALLOWED_HOSTS=${CALLBACK_ALLOWED_HOSTS:-"localhost:$HOST_PORT"}
 SESSION_EXCHANGE_SECRET=${SESSION_EXCHANGE_SECRET:-"local-development-session-secret-change-me"}
 
 # Warden 配置（可选）
@@ -116,7 +129,7 @@ echo ""
 
 # 提示用户
 echo -e "${YELLOW}提示:${NC}"
-echo "  1. 访问登录页面: http://localhost:$PORT/_login?callback=localhost:$PORT"
+echo "  1. 访问登录页面: http://localhost:$HOST_PORT/_login?callback=localhost:$HOST_PORT"
 echo "  2. 测试密码: test123 或 admin123"
 if [ "$WARDEN_ENABLED" = "true" ]; then
     echo "  3. Warden 模式已启用，可以使用用户列表认证"


### PR DESCRIPTION
## Summary

- keep the original `PORT` value for the service listener while deriving a numeric-only `HOST_PORT` for host and URL construction
- reject malformed, zero, and out-of-range ports with a clear error
- cover empty/default, numeric, colon-prefixed, environment, and CLI port behavior with automated shell tests
- run the launcher test in PR checks, including `bash -n` validation

## Validation

- `bash -n start-local.sh`
- `bash -n .github/scripts/test-start-local.sh`
- `bash .github/scripts/test-start-local.sh`

Related review: https://github.com/soulteary/stargate/pull/120#discussion_r3869244324