### PR TITLE
docs: align login and TOTP API contracts

### DIFF
--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -156,11 +156,16 @@ contract_violation_count() {
       }
 
       my ($confirm_section) = $text =~ /^### `POST \/totp\/enroll\/confirm`\s*\n(.*?)(?=^### |\z)/ms;
+      my ($confirm_request_section) = defined($confirm_section)
+        ? ($confirm_section =~ /<!-- api-contract: totp-enroll-confirm-request-body -->\s*\n^#### [^\n]+\n(.*?)(?=^#### |\z)/ms)
+        : undef;
       if (!defined($confirm_section) ||
+          !defined($confirm_request_section) ||
           $confirm_section !~ /`enroll_id`/ ||
           $confirm_section !~ /`code`/ ||
-          $confirm_section !~ /application\/x-www-form-urlencoded/ ||
-          $confirm_section !~ /multipart\/form-data/ ||
+          $confirm_request_section !~ /^\|\s*`application\/x-www-form-urlencoded`\s*\|\s*✅\s*\|/m ||
+          $confirm_request_section !~ /^\|\s*`multipart\/form-data`\s*\|\s*✅\s*\|/m ||
+          $confirm_request_section !~ /^\|\s*`application\/json`\s*\|\s*❌\s*\|/m ||
           $confirm_section !~ /`401 Unauthorized`/ ||
           $confirm_section !~ /10/) {
         warn "Incomplete TOTP confirmation form or authentication contract in $file\n";
@@ -196,12 +201,9 @@ contract_violation_count() {
       }
 
       my ($send_section) = $text =~ /^### `POST \/_send_verify_code`\s*\n(.*?)(?=^### |\z)/ms;
-      my @send_subsections = defined($send_section)
-        ? ($send_section =~ /^#### [^\n]+\n(.*?)(?=^#### |\z)/msg)
-        : ();
-      my ($send_request_section) = grep {
-        /application\/x-www-form-urlencoded/ && /multipart\/form-data/
-      } @send_subsections;
+      my ($send_request_section) = defined($send_section)
+        ? ($send_section =~ /<!-- api-contract: send-verify-code-request-body -->\s*\n^#### [^\n]+\n(.*?)(?=^#### |\z)/ms)
+        : undef;
       if (!defined($send_section) ||
           !defined($send_request_section) ||
           $send_section !~ /`deliver_via`/ ||

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -196,12 +196,20 @@ contract_violation_count() {
       }
 
       my ($send_section) = $text =~ /^### `POST \/_send_verify_code`\s*\n(.*?)(?=^### |\z)/ms;
+      my @send_subsections = defined($send_section)
+        ? ($send_section =~ /^#### [^\n]+\n(.*?)(?=^#### |\z)/msg)
+        : ();
+      my ($send_request_section) = grep {
+        /application\/x-www-form-urlencoded/ && /multipart\/form-data/
+      } @send_subsections;
       if (!defined($send_section) ||
+          !defined($send_request_section) ||
           $send_section !~ /`deliver_via`/ ||
           $send_section !~ /`deliver_via=dingtalk`/ ||
           $send_section !~ /`phone` \+ `mail`/ ||
-          $send_section !~ /application\/x-www-form-urlencoded/ ||
-          $send_section !~ /multipart\/form-data/ ||
+          $send_request_section !~ /^\|\s*`application\/x-www-form-urlencoded`\s*\|\s*✅\s*\|/m ||
+          $send_request_section !~ /^\|\s*`multipart\/form-data`\s*\|\s*✅\s*\|/m ||
+          $send_request_section !~ /^\|\s*`application\/json`\s*\|\s*❌\s*\|/m ||
           $send_section !~ /`401 Unauthorized`/ ||
           $send_section !~ /`503 Service Unavailable`/) {
         warn "Incomplete verification-send form or status contract in $file\n";

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -176,18 +176,22 @@ contract_violation_count() {
       }
       my $missing_login_field = grep {
         ($login_fields{$_} // 0) < 1
-      } qw(password phone mail challenge_id verify_code);
+      } qw(password phone mail challenge_id verify_code use_otp otp_code);
       if (!defined($login_section) ||
           ($login_fields{auth_method} // 0) < 2 ||
           ($login_fields{callback} // 0) < 2 ||
           $missing_login_field ||
           $login_section !~ /`phone` \+ `mail`/ ||
+          $login_section !~ /`HERALD_TOTP_ENABLED=true`/ ||
           $login_section !~ /auth_method=password&password=yourpassword/ ||
           $login_section !~ /auth_method=warden&mail=user\@example\.com&challenge_id=ch_xxx&verify_code=123456&callback=app\.example\.com/ ||
+          $login_section !~ /auth_method=warden&mail=user\@example\.com&use_otp=true&otp_code=123456&callback=app\.example\.com/ ||
           $login_section !~ /`400 Bad Request`/ ||
           $login_section !~ /`401 Unauthorized`/ ||
+          $login_section !~ /`502 Bad Gateway`/ ||
+          $login_section !~ /`503 Service Unavailable`/ ||
           $login_section !~ /`500 Internal Server Error`/) {
-        warn "Incomplete password/Warden login contract in $file\n";
+        warn "Incomplete password/Warden challenge/TOTP login contract in $file\n";
         $count++;
       }
 
@@ -198,7 +202,6 @@ contract_violation_count() {
           $send_section !~ /`phone` \+ `mail`/ ||
           $send_section !~ /application\/x-www-form-urlencoded/ ||
           $send_section !~ /multipart\/form-data/ ||
-          $send_section =~ /application\/json/ ||
           $send_section !~ /`401 Unauthorized`/ ||
           $send_section !~ /`503 Service Unavailable`/) {
         warn "Incomplete verification-send form or status contract in $file\n";

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -159,24 +159,74 @@ contract_violation_count() {
       if (!defined($confirm_section) ||
           $confirm_section !~ /`enroll_id`/ ||
           $confirm_section !~ /`code`/ ||
-          $confirm_section !~ /application\/x-www-form-urlencoded/) {
-        warn "Incomplete TOTP confirmation form contract in $file\n";
+          $confirm_section !~ /application\/x-www-form-urlencoded/ ||
+          $confirm_section !~ /multipart\/form-data/ ||
+          $confirm_section !~ /`401 Unauthorized`/ ||
+          $confirm_section !~ /10/) {
+        warn "Incomplete TOTP confirmation form or authentication contract in $file\n";
         $count++;
       }
 
       my ($login_section) = $text =~ /^### `POST \/_login`\s*\n(.*?)(?=^### |\z)/ms;
+      my %login_fields;
+      if (defined($login_section)) {
+        while ($login_section =~ /^\|\s*`([^`]+)`\s*\|/mg) {
+          $login_fields{$1}++;
+        }
+      }
+      my $missing_login_field = grep {
+        ($login_fields{$_} // 0) < 1
+      } qw(password phone mail challenge_id verify_code);
       if (!defined($login_section) ||
-          $login_section !~ /challenge_id=ch_xxx&verify_code=123456/) {
-        warn "Missing executable Warden verification login example in $file\n";
+          ($login_fields{auth_method} // 0) < 2 ||
+          ($login_fields{callback} // 0) < 2 ||
+          $missing_login_field ||
+          $login_section !~ /`phone` \+ `mail`/ ||
+          $login_section !~ /auth_method=password&password=yourpassword/ ||
+          $login_section !~ /auth_method=warden&mail=user\@example\.com&challenge_id=ch_xxx&verify_code=123456&callback=app\.example\.com/ ||
+          $login_section !~ /`400 Bad Request`/ ||
+          $login_section !~ /`401 Unauthorized`/ ||
+          $login_section !~ /`500 Internal Server Error`/) {
+        warn "Incomplete password/Warden login contract in $file\n";
         $count++;
       }
 
       my ($send_section) = $text =~ /^### `POST \/_send_verify_code`\s*\n(.*?)(?=^### |\z)/ms;
       if (!defined($send_section) ||
           $send_section !~ /`deliver_via`/ ||
+          $send_section !~ /`deliver_via=dingtalk`/ ||
+          $send_section !~ /`phone` \+ `mail`/ ||
+          $send_section !~ /application\/x-www-form-urlencoded/ ||
+          $send_section !~ /multipart\/form-data/ ||
+          $send_section =~ /application\/json/ ||
           $send_section !~ /`401 Unauthorized`/ ||
           $send_section !~ /`503 Service Unavailable`/) {
         warn "Incomplete verification-send form or status contract in $file\n";
+        $count++;
+      }
+
+      my ($enroll_page_section) = $text =~ /^### `GET \/totp\/enroll`\s*\n(.*?)(?=^### |\z)/ms;
+      my ($enroll_start_section) = $text =~ /^### `POST \/totp\/enroll`\s*\n(.*?)(?=^### |\z)/ms;
+      my ($revoke_page_section) = $text =~ /^### `GET \/totp\/revoke`\s*\n(.*?)(?=^### |\z)/ms;
+      my ($revoke_confirm_section) = $text =~ /^### `POST \/totp\/revoke`\s*\n(.*?)(?=^### |\z)/ms;
+      if (!defined($enroll_page_section) ||
+          $enroll_page_section !~ /10/ ||
+          $enroll_page_section !~ /`\/_login`/ ||
+          $enroll_page_section !~ /`302 Found`/ ||
+          $enroll_page_section !~ /`401 Unauthorized`/ ||
+          !defined($enroll_start_section) ||
+          $enroll_start_section !~ /10/ ||
+          $enroll_start_section !~ /`\/_login`/ ||
+          $enroll_start_section !~ /`302 Found`/ ||
+          $enroll_start_section !~ /`401 Unauthorized`/ ||
+          !defined($revoke_page_section) ||
+          $revoke_page_section !~ /`\/_login`/ ||
+          $revoke_page_section !~ /`302 Found`/ ||
+          !defined($revoke_confirm_section) ||
+          $revoke_confirm_section !~ /`password`/ ||
+          $revoke_confirm_section !~ /`code`/ ||
+          $revoke_confirm_section !~ /`401 Unauthorized`/) {
+        warn "Incomplete TOTP session or reauthentication contract in $file\n";
         $count++;
       }
     }

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -12,7 +12,7 @@ git -C "$repo_root" archive HEAD | tar -x -C "$temp_dir"
 cp "$repo_root/.github/scripts/check-doc-contracts.sh" "$temp_dir/.github/scripts/check-doc-contracts.sh"
 cp "$repo_root/CHANGELOG.md" "$temp_dir/CHANGELOG.md"
 cp "$repo_root/docker-compose.yml" "$temp_dir/docker-compose.yml"
-for file in "$repo_root"/docs/*/CONFIG.md "$repo_root"/docs/*/SECURITY.md "$repo_root"/docs/*/DEPLOYMENT.md; do
+for file in "$repo_root"/docs/*/API.md "$repo_root"/docs/*/CONFIG.md "$repo_root"/docs/*/SECURITY.md "$repo_root"/docs/*/DEPLOYMENT.md; do
   relative=${file#"$repo_root"/}
   cp "$file" "$temp_dir/$relative"
 done
@@ -22,6 +22,9 @@ git -C "$temp_dir" config user.email "doc-contract-test@example.invalid"
 git -C "$temp_dir" add .
 git -C "$temp_dir" commit -qm "test baseline"
 base_sha=$(git -C "$temp_dir" rev-parse HEAD)
+
+# A failing baseline would make every negative mutation below look successful.
+(cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null)
 
 # An exact route check must not let /healthz satisfy the /health contract.
 perl -0pi -e 's/`GET \/health`/`GET \/healthz`/' "$temp_dir/docs/enUS/API.md"
@@ -69,6 +72,53 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 git -C "$temp_dir" checkout -q -- docs/enUS/API.md
+
+# Both browser-supported form encodings must remain documented in every locale.
+perl -0pi -e 's/(^### `POST \/_send_verify_code`.*?)(`multipart\/form-data`)/$1`unsupported-form-type`/ms' "$temp_dir/docs/deDE/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a localized send-form encoding contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/deDE/API.md
+
+perl -0pi -e 's/(^### `POST \/totp\/enroll\/confirm`.*?)(`multipart\/form-data`)/$1`unsupported-form-type`/ms' "$temp_dir/docs/frFR/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a localized TOTP form encoding contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/frFR/API.md
+
+# Warden fields must be documented as table rows, not only appear in examples.
+perl -0pi -e 's/^\| `challenge_id` .*\n//m' "$temp_dir/docs/itIT/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a localized Warden field contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/itIT/API.md
+
+# Both Warden identifiers may be supplied together; do not regress to exactly-one validation.
+perl -0pi -e 's/(^### `POST \/_login`.*?)(`phone` \+ `mail`)/$1`phone` only/ms' "$temp_dir/docs/deDE/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a combined Warden identifier contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/deDE/API.md
+
+# DingTalk delivery must remain explicitly opt-in.
+perl -0pi -e 's/(^### `POST \/_send_verify_code`.*?)(`deliver_via=dingtalk`)/$1`deliver_via=implicit`/ms' "$temp_dir/docs/jaJP/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an explicit DingTalk delivery contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/jaJP/API.md
+
+# Revoke requires an authenticated session plus password or TOTP reauthentication.
+perl -0pi -e 's/(^### `POST \/totp\/revoke`.*?)(`401 Unauthorized`)/$1`authentication failure`/ms' "$temp_dir/docs/koKR/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a localized TOTP reauthentication contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/koKR/API.md
 
 # Configuration checks must work in both directions.
 printf '\n| `REMOVED_RUNTIME_SETTING` | string | - | test-only invalid setting |\n' >> "$temp_dir/docs/enUS/CONFIG.md"

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -96,6 +96,21 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
 fi
 git -C "$temp_dir" checkout -q -- docs/itIT/API.md
 
+# The Warden TOTP variant needs its own conditional fields and executable example.
+perl -0pi -e 's/^\| `otp_code` .*\n//m' "$temp_dir/docs/frFR/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a localized Warden TOTP field contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/frFR/API.md
+
+perl -0pi -e 's/(auth_method=warden&mail=user\@example\.com&)use_otp=true&otp_code=123456/$1use_otp=false&missing_otp_code=123456/' "$temp_dir/docs/jaJP/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a localized Warden TOTP example contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/jaJP/API.md
+
 # Both Warden identifiers may be supplied together; do not regress to exactly-one validation.
 perl -0pi -e 's/(^### `POST \/_login`.*?)(`phone` \+ `mail`)/$1`phone` only/ms' "$temp_dir/docs/deDE/API.md"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
@@ -103,6 +118,15 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 git -C "$temp_dir" checkout -q -- docs/deDE/API.md
+
+# Explicitly naming an unsupported JSON request media type or a JSON response must not fail the form contract.
+perl -0pi -e 's/JSON request bodies are not supported/`application\/json` request bodies are not supported/g' "$temp_dir/docs/enUS/API.md"
+perl -0pi -e 's/(^### `POST \/_send_verify_code`.*?\*\*Success Response \(200 OK\)\*\*)/$1\n\nResponse media type: `application\/json`./ms' "$temp_dir/docs/enUS/API.md"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected explicit unsupported application/json wording to remain valid" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/API.md
 
 # DingTalk delivery must remain explicitly opt-in.
 perl -0pi -e 's/(^### `POST \/_send_verify_code`.*?)(`deliver_via=dingtalk`)/$1`deliver_via=implicit`/ms' "$temp_dir/docs/jaJP/API.md"

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -88,6 +88,22 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
 fi
 git -C "$temp_dir" checkout -q -- docs/frFR/API.md
 
+# TOTP confirmation must reject application/json request bodies.
+perl -0pi -e 's/(^### `POST \/totp\/enroll\/confirm`.*?\| `application\/json` \|) ❌ \|/$1 ✅ |/ms' "$temp_dir/docs/frFR/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a TOTP confirmation application/json contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/frFR/API.md
+
+# The send matrix must remain under the marked request-body heading, not another subsection.
+perl -0pi -e 's/<!-- api-contract: send-verify-code-request-body -->\n//; s/(^### `POST \/_send_verify_code`.*?)(^#### Response)/$1<!-- api-contract: send-verify-code-request-body -->\n$2/ms' "$temp_dir/docs/enUS/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a misplaced send request-body contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/API.md
+
 # Warden fields must be documented as table rows, not only appear in examples.
 perl -0pi -e 's/^\| `challenge_id` .*\n//m' "$temp_dir/docs/itIT/API.md"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -119,11 +119,18 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
 fi
 git -C "$temp_dir" checkout -q -- docs/deDE/API.md
 
-# Explicitly naming an unsupported JSON request media type or a JSON response must not fail the form contract.
-perl -0pi -e 's/JSON request bodies are not supported/`application\/json` request bodies are not supported/g' "$temp_dir/docs/enUS/API.md"
+# A supported-JSON claim in the request-body matrix must fail the form contract.
+perl -0pi -e 's/(^### `POST \/_send_verify_code`.*?\| `application\/json` \|) ❌ \|/$1 ✅ |/ms' "$temp_dir/docs/koKR/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a supported application/json request contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/koKR/API.md
+
+# Explicitly naming an application/json response must not fail the request-body contract.
 perl -0pi -e 's/(^### `POST \/_send_verify_code`.*?\*\*Success Response \(200 OK\)\*\*)/$1\n\nResponse media type: `application\/json`./ms' "$temp_dir/docs/enUS/API.md"
 if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
-  echo "Expected explicit unsupported application/json wording to remain valid" >&2
+  echo "Expected an application/json response mention to remain valid" >&2
   exit 1
 fi
 git -C "$temp_dir" checkout -q -- docs/enUS/API.md

--- a/docs/deDE/API.md
+++ b/docs/deDE/API.md
@@ -126,7 +126,7 @@ curl http://auth.example.com/_login?callback=app.example.com
 Verarbeitet Anmeldeanfragen und unterstützt zwei Authentifizierungsmodi:
 
 1. **Passwort-Authentifizierung**: Prüft das Passwort und erstellt eine Sitzung
-2. **Warden + Herald OTP-Authentifizierung**: Prüft den Verifizierungscode und erstellt eine Sitzung
+2. **Warden-Authentifizierung**: Prüft entweder einen Herald-Challenge-Code oder einen bereits eingerichteten TOTP-Code und erstellt eine Sitzung
 
 #### Anfrage-Text
 
@@ -140,18 +140,21 @@ Formulardaten (`application/x-www-form-urlencoded`):
 | `password` | String | Ja | Benutzerpasswort |
 | `callback` | String | Nein | Callback-URL nach erfolgreicher Anmeldung |
 
-**Warden + Herald OTP-Authentifizierung:**
+**Warden-Authentifizierung:**
 
 | Feld | Typ | Erforderlich | Beschreibung |
 |------|-----|--------------|--------------|
 | `auth_method` | String | Ja | Authentifizierungsmethode; Wert `warden` |
 | `phone` | String | Nein | Telefonnummer des Benutzers; mindestens eines von `phone` oder `mail` ist erforderlich |
 | `mail` | String | Nein | E-Mail-Adresse des Benutzers; mindestens eines von `mail` oder `phone` ist erforderlich |
-| `challenge_id` | String | Ja | Von `POST /_send_verify_code` zurückgegebene Challenge-ID |
-| `verify_code` | String | Ja | Vom Benutzer eingegebener Verifizierungscode |
+| `challenge_id` | String | Bedingt | Mit `verify_code` erforderlich; bei `use_otp=true` optional |
+| `verify_code` | String | Bedingt | Für die Herald-Challenge erforderlich, wenn `use_otp` fehlt oder `false` ist |
+| `use_otp` | Boolean | Nein | Auf `true` setzen, um einen eingerichteten TOTP-Authentifikator statt einer Herald-Challenge zu verwenden |
+| `otp_code` | String | Bedingt | Erforderlich, wenn `use_otp=true` |
 | `callback` | String | Nein | Callback-URL nach erfolgreicher Anmeldung |
 
 Der Handler akzeptiert in derselben Warden-Anfrage auch `phone` + `mail`.
+Die TOTP-Variante setzt `HERALD_TOTP_ENABLED=true` und einen bereits eingerichteten Benutzer voraus. Andernfalls ist die Variante `challenge_id` + `verify_code` zu verwenden.
 
 #### Callback-Abrufpriorität
 
@@ -186,8 +189,10 @@ Die Antwort variiert je nachdem, ob ein Callback vorhanden ist und welcher Anfra
 
 | Statuscode | Beschreibung | Antwort-Text |
 |------------|--------------|--------------|
-| `400 Bad Request` | Ungültige oder fehlende Warden-Felder, Challenge-ID oder Verifizierungscode | Fehlermeldung im JSON/XML/Text-Format je nach Accept-Header |
-| `401 Unauthorized` | Falsches Passwort, inaktiver/fehlender Warden-Benutzer oder fehlgeschlagene Codeprüfung | Fehlermeldung im JSON/XML/Text-Format je nach Accept-Header |
+| `400 Bad Request` | Ungültige oder fehlende Warden- beziehungsweise Verifizierungsfelder oder nicht eingerichtetes TOTP | Fehlermeldung im JSON/XML/Text-Format je nach Accept-Header |
+| `401 Unauthorized` | Falsches Passwort, inaktiver/fehlender Warden-Benutzer oder fehlgeschlagene Challenge-/TOTP-Prüfung | Fehlermeldung im JSON/XML/Text-Format je nach Accept-Header |
+| `502 Bad Gateway` | Abfrage des Herald-TOTP-Status fehlgeschlagen | Fehlermeldung |
+| `503 Service Unavailable` | Herald-Verifizierungsdienst ist nicht verfügbar | Fehlermeldung |
 | `500 Internal Server Error` | Server-Fehler | Fehlermeldung |
 
 #### Beispiele
@@ -209,6 +214,12 @@ curl -X POST \
 # Warden + Herald: mit dem von /_send_verify_code zurückgegebenen Challenge-Wert anmelden
 curl -X POST \
      -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
+
+# Warden + TOTP: mit einem bereits eingerichteten Authentifikator anmelden
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&use_otp=true&otp_code=123456&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 ```

--- a/docs/deDE/API.md
+++ b/docs/deDE/API.md
@@ -236,6 +236,7 @@ Anfrage zum Senden eines Verifizierungscodes. Dieser Endpunkt wird im Warden + H
 |--------|--------------|
 | `Idempotency-Key` | Optional. Wenn gesetzt, leitet Stargate den Wert an Herald weiter; Herald liefert innerhalb der TTL für Duplikatanfragen mit gleichem Key dieselbe Challenge-Antwort. |
 
+<!-- api-contract: send-verify-code-request-body -->
 #### Anfragekörper
 
 Unterstützte Medientypen für den Anfragekörper:
@@ -416,7 +417,22 @@ Startet die Registrierung und zeigt die TOTP-Bindungsseite an. Erfordert eine du
 
 ### `POST /totp/enroll/confirm`
 
-Bestätigt die Registrierung mit `application/x-www-form-urlencoded`- oder `multipart/form-data`-Formulardaten; JSON-Anfragekörper werden nicht unterstützt. Eine authentifizierte Sitzung aus den letzten 10 Minuten sowie `enroll_id` und der sechsstellige TOTP-`code` sind erforderlich. Fehlende oder nicht aktuelle Authentifizierung gibt `401 Unauthorized` zurück; bei Erfolg enthält die JSON-Antwort die einmalig ausgegebenen Backup-Codes.
+Bestätigt die Registrierung. Eine authentifizierte Sitzung aus den letzten 10 Minuten ist erforderlich.
+
+<!-- api-contract: totp-enroll-confirm-request-body -->
+#### Anfragekörper
+
+| Medientyp des Anfragekörpers | Unterstützt |
+|------------------------------|-------------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
+
+Das Formular muss `enroll_id` und den sechsstelligen TOTP-`code` enthalten.
+
+#### Antwort
+
+Fehlende oder nicht aktuelle Authentifizierung gibt `401 Unauthorized` zurück; bei Erfolg enthält die JSON-Antwort die einmalig ausgegebenen Backup-Codes.
 
 ### `GET /totp/revoke`
 

--- a/docs/deDE/API.md
+++ b/docs/deDE/API.md
@@ -123,16 +123,35 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 ### `POST /_login`
 
-Verarbeitet Anmeldeanfragen, überprüft das Passwort und erstellt eine Sitzung.
+Verarbeitet Anmeldeanfragen und unterstützt zwei Authentifizierungsmodi:
+
+1. **Passwort-Authentifizierung**: Prüft das Passwort und erstellt eine Sitzung
+2. **Warden + Herald OTP-Authentifizierung**: Prüft den Verifizierungscode und erstellt eine Sitzung
 
 #### Anfrage-Text
 
 Formulardaten (`application/x-www-form-urlencoded`):
 
+**Passwort-Authentifizierung:**
+
 | Feld | Typ | Erforderlich | Beschreibung |
 |------|-----|--------------|--------------|
+| `auth_method` | String | Nein | Authentifizierungsmethode; `password` ist der Standardwert |
 | `password` | String | Ja | Benutzerpasswort |
 | `callback` | String | Nein | Callback-URL nach erfolgreicher Anmeldung |
+
+**Warden + Herald OTP-Authentifizierung:**
+
+| Feld | Typ | Erforderlich | Beschreibung |
+|------|-----|--------------|--------------|
+| `auth_method` | String | Ja | Authentifizierungsmethode; Wert `warden` |
+| `phone` | String | Nein | Telefonnummer des Benutzers; mindestens eines von `phone` oder `mail` ist erforderlich |
+| `mail` | String | Nein | E-Mail-Adresse des Benutzers; mindestens eines von `mail` oder `phone` ist erforderlich |
+| `challenge_id` | String | Ja | Von `POST /_send_verify_code` zurückgegebene Challenge-ID |
+| `verify_code` | String | Ja | Vom Benutzer eingegebener Verifizierungscode |
+| `callback` | String | Nein | Callback-URL nach erfolgreicher Anmeldung |
+
+Der Handler akzeptiert in derselben Warden-Anfrage auch `phone` + `mail`.
 
 #### Callback-Abrufpriorität
 
@@ -167,7 +186,8 @@ Die Antwort variiert je nachdem, ob ein Callback vorhanden ist und welcher Anfra
 
 | Statuscode | Beschreibung | Antwort-Text |
 |------------|--------------|--------------|
-| `401 Unauthorized` | Falsches Passwort | Fehlermeldung im JSON/XML/Text-Format je nach Accept-Header |
+| `400 Bad Request` | Ungültige oder fehlende Warden-Felder, Challenge-ID oder Verifizierungscode | Fehlermeldung im JSON/XML/Text-Format je nach Accept-Header |
+| `401 Unauthorized` | Falsches Passwort, inaktiver/fehlender Warden-Benutzer oder fehlgeschlagene Codeprüfung | Fehlermeldung im JSON/XML/Text-Format je nach Accept-Header |
 | `500 Internal Server Error` | Server-Fehler | Fehlermeldung |
 
 #### Beispiele
@@ -175,13 +195,13 @@ Die Antwort variiert je nachdem, ob ein Callback vorhanden ist und welcher Anfra
 ```bash
 # Anmeldeformular absenden (mit Callback)
 curl -X POST \
-     -d "password=yourpassword&callback=app.example.com" \
+     -d "auth_method=password&password=yourpassword&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 
 # Anmeldeformular absenden (ohne Callback, wird automatisch inferiert)
 curl -X POST \
-     -d "password=yourpassword" \
+     -d "auth_method=password&password=yourpassword" \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
@@ -207,13 +227,15 @@ Anfrage zum Senden eines Verifizierungscodes. Dieser Endpunkt wird im Warden + H
 
 #### Anfragekörper
 
-Nur Formulardaten (`application/x-www-form-urlencoded`):
+Formulardaten als `application/x-www-form-urlencoded` oder `multipart/form-data`; JSON-Anfragekörper werden nicht unterstützt:
 
 | Feld | Typ | Erforderlich | Beschreibung |
 |------|-----|--------------|--------------|
-| `phone` | String | Nein | Benutzertelefonnummer (eines von `phone` oder `mail`) |
-| `mail` | String | Nein | Benutzer-E-Mail (eines von `phone` oder `mail`) |
-| `deliver_via` | String | Nein | Bevorzugter Kanal: `sms`, `email` oder `dingtalk`; ohne Angabe wird ein aktivierter Kanal aus dem Warden-Datensatz gewählt. |
+| `phone` | String | Nein | Benutzertelefonnummer; mindestens eines von `phone` oder `mail` ist erforderlich |
+| `mail` | String | Nein | Benutzer-E-Mail; mindestens eines von `mail` oder `phone` ist erforderlich |
+| `deliver_via` | String | Nein | Bevorzugter Kanal: `sms`, `email` oder `dingtalk`. Ohne Angabe versucht Stargate zuerst ein aktiviertes SMS-Ziel und danach E-Mail. DingTalk wird nie automatisch gewählt; Aufrufer müssen `deliver_via=dingtalk` senden. |
+
+Der Handler akzeptiert in derselben Verifizierungscode-Anfrage auch `phone` + `mail`.
 
 #### Verarbeitungsablauf
 
@@ -223,9 +245,9 @@ Nur Formulardaten (`application/x-www-form-urlencoded`):
    - E-Mail und Telefon des Benutzers abrufen
 
 2. **Stargate → Herald** : Challenge erstellen und Verifizierungscode senden
-   - E-Mail/Telefon von Warden als Ziel verwenden
+   - Von Warden zurückgegebene E-Mail, Telefonnummer oder DingTalk-Kennung als Ziel verwenden
    - Herald-API aufrufen, um Challenge zu erstellen
-   - Herald sendet Verifizierungscode (SMS oder E-Mail)
+   - Herald sendet den Verifizierungscode über den ausgewählten SMS-, E-Mail- oder DingTalk-Kanal
 
 3. **Ergebnis zurückgeben** : challenge_id und zugehörige Informationen zurückgeben
 
@@ -365,27 +387,27 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## TOTP-Endpunkte
 
-Diese Endpunkte sind verfügbar, wenn Herald und Herald-TOTP aktiviert sind. Die Registrierung muss innerhalb von 10 Minuten nach der Anmeldung gestartet und abgeschlossen werden.
+Diese Endpunkte sind verfügbar, wenn Herald und Herald-TOTP aktiviert sind. Alle erfordern eine authentifizierte Sitzung. Die Registrierung muss innerhalb von 10 Minuten nach der Anmeldung, die die Sitzung erstellt hat, gestartet und abgeschlossen werden.
 
 ### `GET /totp/enroll`
 
-Zeigt eine Bestätigungsseite an, ohne Registrierungsstatus zu erzeugen. Erfordert eine innerhalb der letzten 10 Minuten erstellte authentifizierte Sitzung.
+Zeigt eine Bestätigungsseite an, ohne Registrierungsstatus zu erzeugen. Erfordert eine durch eine erfolgreiche Anmeldung innerhalb der letzten 10 Minuten erstellte Sitzung. Nicht authentifizierte Benutzer werden mit `302 Found` zu `/_login` umgeleitet; eine ältere Sitzung erhält `401 Unauthorized`.
 
 ### `POST /totp/enroll`
 
-Startet die Registrierung und zeigt die TOTP-Bindungsseite an. Erfordert eine innerhalb der letzten 10 Minuten erstellte Sitzung.
+Startet die Registrierung und zeigt die TOTP-Bindungsseite an. Erfordert eine durch eine erfolgreiche Anmeldung innerhalb der letzten 10 Minuten erstellte Sitzung. Nicht authentifizierte Benutzer werden mit `302 Found` zu `/_login` umgeleitet; eine ältere Sitzung erhält `401 Unauthorized`.
 
 ### `POST /totp/enroll/confirm`
 
-Bestätigt die Registrierung mit Formulardaten (`application/x-www-form-urlencoded`). Sowohl `enroll_id` als auch der sechsstellige TOTP-`code` sind erforderlich. Die Antwort ist JSON und enthält bei Erfolg auch die einmalig ausgegebenen Backup-Codes.
+Bestätigt die Registrierung mit `application/x-www-form-urlencoded`- oder `multipart/form-data`-Formulardaten; JSON-Anfragekörper werden nicht unterstützt. Eine authentifizierte Sitzung aus den letzten 10 Minuten sowie `enroll_id` und der sechsstellige TOTP-`code` sind erforderlich. Fehlende oder nicht aktuelle Authentifizierung gibt `401 Unauthorized` zurück; bei Erfolg enthält die JSON-Antwort die einmalig ausgegebenen Backup-Codes.
 
 ### `GET /totp/revoke`
 
-Zeigt die Bestätigungsseite zum Entfernen der TOTP-Bindung an.
+Zeigt die Bestätigungsseite zum Entfernen der TOTP-Bindung an. Eine authentifizierte Sitzung ist erforderlich; nicht authentifizierte Benutzer werden mit `302 Found` zu `/_login` umgeleitet. Für diese Seite gilt keine 10-Minuten-Grenze.
 
 ### `POST /totp/revoke`
 
-Entfernt die TOTP-Bindung nach Bestätigung mit `password` oder einem aktuellen `code`.
+Entfernt die TOTP-Bindung. Eine authentifizierte Sitzung ist erforderlich, und der Aufrufer muss sich erneut mit `password` oder einem gültigen aktuellen TOTP-`code` bestätigen. Fehlende oder fehlgeschlagene erneute Authentifizierung gibt `401 Unauthorized` zurück.
 
 ## Gesundheitsprüfungs-Endpunkte
 

--- a/docs/deDE/API.md
+++ b/docs/deDE/API.md
@@ -238,7 +238,13 @@ Anfrage zum Senden eines Verifizierungscodes. Dieser Endpunkt wird im Warden + H
 
 #### Anfragekörper
 
-Formulardaten als `application/x-www-form-urlencoded` oder `multipart/form-data`; JSON-Anfragekörper werden nicht unterstützt:
+Unterstützte Medientypen für den Anfragekörper:
+
+| Medientyp des Anfragekörpers | Unterstützt |
+|------------------------------|-------------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
 
 | Feld | Typ | Erforderlich | Beschreibung |
 |------|-----|--------------|--------------|

--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -256,7 +256,13 @@ Send verification code request. This endpoint is used in the Warden + Herald OTP
 
 #### Request Body
 
-Form data using either `application/x-www-form-urlencoded` or `multipart/form-data`. JSON request bodies are not supported.
+Supported request-body media types:
+
+| Request media type | Supported |
+|--------------------|-----------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -149,11 +149,13 @@ Form data (`application/x-www-form-urlencoded`):
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `auth_method` | String | Yes | Authentication method, value is `warden` |
-| `phone` | String | No | User phone number (one of `phone` or `mail`) |
-| `mail` | String | No | User email (one of `phone` or `mail`) |
+| `phone` | String | No | User phone number; at least one of `phone` or `mail` is required |
+| `mail` | String | No | User email; at least one of `mail` or `phone` is required |
 | `challenge_id` | String | Yes | challenge_id returned by Herald |
 | `verify_code` | String | Yes | Verification code entered by user |
 | `callback` | String | No | Callback URL after successful login |
+
+The handler also accepts `phone` + `mail` in the same Warden request.
 
 #### Callback Retrieval Priority
 
@@ -188,7 +190,8 @@ The response varies depending on whether there is a callback and the request typ
 
 | Status Code | Description | Response Body |
 |-------------|-------------|---------------|
-| `401 Unauthorized` | Incorrect password | Error message in JSON/XML/text format based on Accept header |
+| `400 Bad Request` | Invalid or missing Warden identifier, challenge ID, or verification code | Error message in JSON/XML/text format based on Accept header |
+| `401 Unauthorized` | Incorrect password, absent/inactive Warden user, or failed code verification | Error message in JSON/XML/text format based on Accept header |
 | `500 Internal Server Error` | Server error | Error message |
 
 #### Examples
@@ -236,13 +239,15 @@ Send verification code request. This endpoint is used in the Warden + Herald OTP
 
 #### Request Body
 
-Form data (`application/x-www-form-urlencoded`) only:
+Form data using either `application/x-www-form-urlencoded` or `multipart/form-data`. JSON request bodies are not supported.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `phone` | String | No | User phone number (one of `phone` or `mail`) |
-| `mail` | String | No | User email (one of `phone` or `mail`) |
-| `deliver_via` | String | No | Preferred channel: `sms`, `email`, or `dingtalk`. If omitted, Stargate selects an enabled channel backed by the Warden record. |
+| `phone` | String | No | User phone number; at least one of `phone` or `mail` is required |
+| `mail` | String | No | User email; at least one of `mail` or `phone` is required |
+| `deliver_via` | String | No | Preferred channel: `sms`, `email`, or `dingtalk`. If omitted, Stargate tries an enabled SMS destination first, then email. DingTalk is never selected implicitly; callers must send `deliver_via=dingtalk`. |
+
+The handler also accepts `phone` + `mail` in the same verification-code request.
 
 #### Processing Flow
 
@@ -252,9 +257,9 @@ Form data (`application/x-www-form-urlencoded`) only:
    - Get user's email and phone
 
 2. **Stargate → Herald**: Create challenge and send verification code
-   - Use email/phone returned by Warden as destination
+   - Use the email, phone, or DingTalk identifier returned by Warden as the destination
    - Call Herald API to create challenge
-   - Herald sends verification code (SMS or Email)
+   - Herald sends the verification code through the selected SMS, email, or DingTalk channel
 
 3. **Return Result**: Return challenge_id and related information
 
@@ -398,29 +403,29 @@ When Herald TOTP is enabled (`HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`),
 
 ### `GET /totp/enroll`
 
-Displays a confirmation page without creating enrollment state. It requires a recently authenticated session; unauthenticated users are redirected to `/_login`, while an older session receives `401 Unauthorized`.
+Displays a confirmation page without creating enrollment state. It requires a session created by a successful login within the last 10 minutes; unauthenticated users are redirected with `302 Found` to `/_login`, while an older session receives `401 Unauthorized`.
 
 ### `POST /totp/enroll`
 
 Starts enrollment and displays the TOTP bind page. POST prevents cross-site navigation from creating enrollment state.
 
-- **Authentication**: A session created by a successful login within the last 10 minutes. Unauthenticated users are redirected to `/_login`; older sessions receive `401 Unauthorized`.
-- **Response**: 200 OK with enrollment page HTML; or 302 to `/_login` if not authenticated; or 400/503 on configuration or Herald errors.
+- **Authentication**: A session created by a successful login within the last 10 minutes. Unauthenticated users are redirected with `302 Found` to `/_login`; older sessions receive `401 Unauthorized`.
+- **Response**: 200 OK with enrollment page HTML; `302 Found` to `/_login` if not authenticated; or 400/503 on configuration or Herald errors.
 
 ### `POST /totp/enroll/confirm`
 
 Confirms TOTP binding with the code from the authenticator app.
 
 - **Authentication**: A session created by a successful login within the last 10 minutes.
-- **Request Body**: Form data (`application/x-www-form-urlencoded`) containing the `enroll_id` returned by the enrollment page and the 6-digit TOTP `code`.
-- **Response**: JSON. Success returns `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`; invalid or expired enrollment state returns `400`, and missing recent authentication returns `401`.
+- **Request Body**: Form data using either `application/x-www-form-urlencoded` or `multipart/form-data`, containing the `enroll_id` returned by the enrollment page and the 6-digit TOTP `code`. JSON request bodies are not supported.
+- **Response**: JSON. Success returns `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`; invalid or expired enrollment state returns `400 Bad Request`, and missing recent authentication returns `401 Unauthorized`.
 
 ### `GET /totp/revoke`
 
 Displays the TOTP unbind confirmation page.
 
-- **Authentication**: Required (session cookie). Unauthenticated users are redirected to `/_login`.
-- **Response**: 200 OK with revoke confirmation page; or 302 to `/_login` if not authenticated.
+- **Authentication**: Required (session cookie). Unauthenticated users are redirected with `302 Found` to `/_login`.
+- **Response**: 200 OK with revoke confirmation page; or `302 Found` to `/_login` if not authenticated.
 
 ### `POST /totp/revoke`
 
@@ -428,7 +433,7 @@ Confirms TOTP unbind (removes TOTP from the account).
 
 - **Authentication**: Required (session cookie).
 - **Request Body**: `password` or a valid current TOTP `code` is required to prove recent authentication.
-- **Response**: JSON. Success returns `{"ok":true,"subject":"..."}`; failed reauthentication returns `401`, and an upstream revoke failure returns `502`.
+- **Response**: JSON. Success returns `{"ok":true,"subject":"..."}`; failed reauthentication returns `401 Unauthorized`, and an upstream revoke failure returns `502 Bad Gateway`.
 
 **Notes:** TOTP creation and verification are performed by Herald (which may proxy to herald-totp). Stargate only orchestrates the UI and session; it does not implement OTP algorithms.
 

--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -254,6 +254,7 @@ Send verification code request. This endpoint is used in the Warden + Herald OTP
 |--------|-------------|
 | `Idempotency-Key` | Optional. If present, Stargate forwards it to Herald; Herald returns the same challenge response for duplicate requests with the same key within TTL. |
 
+<!-- api-contract: send-verify-code-request-body -->
 #### Request Body
 
 Supported request-body media types:
@@ -440,8 +441,21 @@ Starts enrollment and displays the TOTP bind page. POST prevents cross-site navi
 Confirms TOTP binding with the code from the authenticator app.
 
 - **Authentication**: A session created by a successful login within the last 10 minutes.
-- **Request Body**: Form data using either `application/x-www-form-urlencoded` or `multipart/form-data`, containing the `enroll_id` returned by the enrollment page and the 6-digit TOTP `code`. JSON request bodies are not supported.
-- **Response**: JSON. Success returns `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`; invalid or expired enrollment state returns `400 Bad Request`, and missing recent authentication returns `401 Unauthorized`.
+
+<!-- api-contract: totp-enroll-confirm-request-body -->
+#### Request Body
+
+| Request media type | Supported |
+|--------------------|-----------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
+
+The form must contain the `enroll_id` returned by the enrollment page and the 6-digit TOTP `code`.
+
+#### Response
+
+JSON. Success returns `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`; invalid or expired enrollment state returns `400 Bad Request`, and missing recent authentication returns `401 Unauthorized`.
 
 ### `GET /totp/revoke`
 

--- a/docs/enUS/API.md
+++ b/docs/enUS/API.md
@@ -130,7 +130,7 @@ curl http://auth.example.com/_login?callback=app.example.com
 Handles login requests, supports two authentication modes:
 
 1. **Password Authentication Mode**: Verifies password and creates session
-2. **Warden + Herald OTP Authentication Mode**: Verifies code and creates session
+2. **Warden Authentication Mode**: Verifies either a Herald challenge code or an enrolled TOTP code and creates a session
 
 #### Request Body
 
@@ -144,18 +144,21 @@ Form data (`application/x-www-form-urlencoded`):
 | `password` | String | Yes | User password |
 | `callback` | String | No | Callback URL after successful login |
 
-**Warden + Herald OTP Authentication Mode:**
+**Warden Authentication Mode:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `auth_method` | String | Yes | Authentication method, value is `warden` |
 | `phone` | String | No | User phone number; at least one of `phone` or `mail` is required |
 | `mail` | String | No | User email; at least one of `mail` or `phone` is required |
-| `challenge_id` | String | Yes | challenge_id returned by Herald |
-| `verify_code` | String | Yes | Verification code entered by user |
+| `challenge_id` | String | Conditional | Required with `verify_code`; optional when `use_otp=true` |
+| `verify_code` | String | Conditional | Required for Herald challenge verification when `use_otp` is absent or `false` |
+| `use_otp` | Boolean | No | Set to `true` to use an enrolled TOTP authenticator instead of a Herald challenge code |
+| `otp_code` | String | Conditional | Required when `use_otp=true` |
 | `callback` | String | No | Callback URL after successful login |
 
 The handler also accepts `phone` + `mail` in the same Warden request.
+The TOTP variant requires `HERALD_TOTP_ENABLED=true` and an already enrolled user. Otherwise, use the `challenge_id` + `verify_code` variant.
 
 #### Callback Retrieval Priority
 
@@ -190,8 +193,10 @@ The response varies depending on whether there is a callback and the request typ
 
 | Status Code | Description | Response Body |
 |-------------|-------------|---------------|
-| `400 Bad Request` | Invalid or missing Warden identifier, challenge ID, or verification code | Error message in JSON/XML/text format based on Accept header |
-| `401 Unauthorized` | Incorrect password, absent/inactive Warden user, or failed code verification | Error message in JSON/XML/text format based on Accept header |
+| `400 Bad Request` | Invalid or missing Warden identifier or selected verification fields, or TOTP is not enrolled | Error message in JSON/XML/text format based on Accept header |
+| `401 Unauthorized` | Incorrect password, absent/inactive Warden user, or failed challenge/TOTP verification | Error message in JSON/XML/text format based on Accept header |
+| `502 Bad Gateway` | Herald TOTP status lookup failed | Error message |
+| `503 Service Unavailable` | Herald verification service is unavailable | Error message |
 | `500 Internal Server Error` | Server error | Error message |
 
 #### Examples
@@ -206,12 +211,22 @@ curl -X POST \
      http://auth.example.com/_login
 ```
 
-**Warden + Herald OTP Authentication:**
+**Warden + Herald Challenge Authentication:**
 
 ```bash
 # Submit login form (with verification code)
 curl -X POST \
      -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
+```
+
+**Warden + TOTP Authenticator Authentication:**
+
+```bash
+# Submit login form with an enrolled authenticator code
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&use_otp=true&otp_code=123456&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 ```
@@ -224,6 +239,8 @@ curl -X POST \
 4. User enters verification code, calls `POST /_login` for verification
 5. Stargate calls Herald to verify the code
 6. After successful verification, Stargate creates session and returns
+
+With the TOTP variant, the client sets `use_otp=true` and supplies `otp_code`; no prior `POST /_send_verify_code` call is required.
 
 ## Send Verification Code Endpoint
 

--- a/docs/frFR/API.md
+++ b/docs/frFR/API.md
@@ -127,7 +127,7 @@ curl http://auth.example.com/_login?callback=app.example.com
 Traite les requêtes de connexion et prend en charge deux modes d'authentification :
 
 1. **Authentification par mot de passe** : vérifie le mot de passe et crée une session
-2. **Authentification OTP Warden + Herald** : vérifie le code et crée une session
+2. **Authentification Warden** : vérifie soit un code de challenge Herald, soit un code TOTP déjà configuré, puis crée une session
 
 #### Corps de Requête
 
@@ -141,18 +141,21 @@ Données de formulaire (`application/x-www-form-urlencoded`) :
 | `password` | String | Oui | Mot de passe utilisateur |
 | `callback` | String | Non | URL de callback après connexion réussie |
 
-**Authentification OTP Warden + Herald :**
+**Authentification Warden :**
 
 | Champ | Type | Requis | Description |
 |-------|------|--------|-------------|
 | `auth_method` | String | Oui | Méthode d'authentification ; valeur `warden` |
 | `phone` | String | Non | Numéro de téléphone ; au moins l'un de `phone` ou `mail` est requis |
 | `mail` | String | Non | Adresse e-mail ; au moins l'un de `mail` ou `phone` est requis |
-| `challenge_id` | String | Oui | Identifiant du challenge renvoyé par `POST /_send_verify_code` |
-| `verify_code` | String | Oui | Code de vérification saisi par l'utilisateur |
+| `challenge_id` | String | Conditionnel | Requis avec `verify_code` ; facultatif lorsque `use_otp=true` |
+| `verify_code` | String | Conditionnel | Requis pour le challenge Herald lorsque `use_otp` est absent ou vaut `false` |
+| `use_otp` | Boolean | Non | Définir à `true` pour utiliser un authentificateur TOTP configuré au lieu d'un challenge Herald |
+| `otp_code` | String | Conditionnel | Requis lorsque `use_otp=true` |
 | `callback` | String | Non | URL de callback après connexion réussie |
 
 Le gestionnaire accepte également `phone` + `mail` dans la même requête Warden.
+La variante TOTP nécessite `HERALD_TOTP_ENABLED=true` et un utilisateur déjà inscrit. Sinon, utilisez la variante `challenge_id` + `verify_code`.
 
 #### Priorité de Récupération du Callback
 
@@ -187,8 +190,10 @@ La réponse varie selon qu'il y a un callback et le type de requête :
 
 | Code de Statut | Description | Corps de Réponse |
 |----------------|-------------|-------------------|
-| `400 Bad Request` | Champs Warden, identifiant de challenge ou code de vérification invalides ou manquants | Message d'erreur au format JSON/XML/texte selon l'en-tête Accept |
-| `401 Unauthorized` | Mot de passe incorrect, utilisateur Warden absent/inactif ou échec de vérification du code | Message d'erreur au format JSON/XML/texte selon l'en-tête Accept |
+| `400 Bad Request` | Identifiant Warden ou champs de la méthode choisie invalides/manquants, ou TOTP non inscrit | Message d'erreur au format JSON/XML/texte selon l'en-tête Accept |
+| `401 Unauthorized` | Mot de passe incorrect, utilisateur Warden absent/inactif ou échec du challenge/TOTP | Message d'erreur au format JSON/XML/texte selon l'en-tête Accept |
+| `502 Bad Gateway` | Échec de la consultation du statut TOTP auprès de Herald | Message d'erreur |
+| `503 Service Unavailable` | Service de vérification Herald indisponible | Message d'erreur |
 | `500 Internal Server Error` | Erreur serveur | Message d'erreur |
 
 #### Exemples
@@ -210,6 +215,12 @@ curl -X POST \
 # Warden + Herald : connexion avec le challenge renvoyé par /_send_verify_code
 curl -X POST \
      -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
+
+# Warden + TOTP : connexion avec un authentificateur déjà configuré
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&use_otp=true&otp_code=123456&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 ```

--- a/docs/frFR/API.md
+++ b/docs/frFR/API.md
@@ -124,16 +124,35 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 ### `POST /_login`
 
-Traite les requêtes de connexion, vérifie le mot de passe et crée une session.
+Traite les requêtes de connexion et prend en charge deux modes d'authentification :
+
+1. **Authentification par mot de passe** : vérifie le mot de passe et crée une session
+2. **Authentification OTP Warden + Herald** : vérifie le code et crée une session
 
 #### Corps de Requête
 
 Données de formulaire (`application/x-www-form-urlencoded`) :
 
+**Authentification par mot de passe :**
+
 | Champ | Type | Requis | Description |
 |-------|------|--------|-------------|
+| `auth_method` | String | Non | Méthode d'authentification ; `password` est la valeur par défaut |
 | `password` | String | Oui | Mot de passe utilisateur |
 | `callback` | String | Non | URL de callback après connexion réussie |
+
+**Authentification OTP Warden + Herald :**
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `auth_method` | String | Oui | Méthode d'authentification ; valeur `warden` |
+| `phone` | String | Non | Numéro de téléphone ; au moins l'un de `phone` ou `mail` est requis |
+| `mail` | String | Non | Adresse e-mail ; au moins l'un de `mail` ou `phone` est requis |
+| `challenge_id` | String | Oui | Identifiant du challenge renvoyé par `POST /_send_verify_code` |
+| `verify_code` | String | Oui | Code de vérification saisi par l'utilisateur |
+| `callback` | String | Non | URL de callback après connexion réussie |
+
+Le gestionnaire accepte également `phone` + `mail` dans la même requête Warden.
 
 #### Priorité de Récupération du Callback
 
@@ -168,7 +187,8 @@ La réponse varie selon qu'il y a un callback et le type de requête :
 
 | Code de Statut | Description | Corps de Réponse |
 |----------------|-------------|-------------------|
-| `401 Unauthorized` | Mot de passe incorrect | Message d'erreur au format JSON/XML/texte selon l'en-tête Accept |
+| `400 Bad Request` | Champs Warden, identifiant de challenge ou code de vérification invalides ou manquants | Message d'erreur au format JSON/XML/texte selon l'en-tête Accept |
+| `401 Unauthorized` | Mot de passe incorrect, utilisateur Warden absent/inactif ou échec de vérification du code | Message d'erreur au format JSON/XML/texte selon l'en-tête Accept |
 | `500 Internal Server Error` | Erreur serveur | Message d'erreur |
 
 #### Exemples
@@ -176,13 +196,13 @@ La réponse varie selon qu'il y a un callback et le type de requête :
 ```bash
 # Soumettre le formulaire de connexion (avec callback)
 curl -X POST \
-     -d "password=yourpassword&callback=app.example.com" \
+     -d "auth_method=password&password=yourpassword&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 
 # Soumettre le formulaire de connexion (sans callback, inférera automatiquement)
 curl -X POST \
-     -d "password=yourpassword" \
+     -d "auth_method=password&password=yourpassword" \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
@@ -208,13 +228,15 @@ Requête d'envoi de code de vérification. Ce point de terminaison est utilisé 
 
 #### Corps de Requête
 
-Données de formulaire (`application/x-www-form-urlencoded`) uniquement :
+Données de formulaire `application/x-www-form-urlencoded` ou `multipart/form-data` ; les corps JSON ne sont pas pris en charge :
 
 | Champ | Type | Requis | Description |
 |-------|------|--------|-------------|
-| `phone` | String | Non | Numéro de téléphone utilisateur (un parmi `phone` ou `mail`) |
-| `mail` | String | Non | Email utilisateur (un parmi `phone` ou `mail`) |
-| `deliver_via` | String | Non | Canal préféré : `sms`, `email` ou `dingtalk`. Sans valeur, Stargate choisit un canal activé du compte Warden. |
+| `phone` | String | Non | Numéro de téléphone ; au moins l'un de `phone` ou `mail` est requis |
+| `mail` | String | Non | Adresse e-mail ; au moins l'un de `mail` ou `phone` est requis |
+| `deliver_via` | String | Non | Canal préféré : `sms`, `email` ou `dingtalk`. Sans valeur, Stargate essaie d'abord une destination SMS activée, puis l'e-mail. DingTalk n'est jamais choisi implicitement ; le client doit envoyer `deliver_via=dingtalk`. |
+
+Le gestionnaire accepte également `phone` + `mail` dans la même requête d'envoi de code.
 
 #### Flux de Traitement
 
@@ -224,9 +246,9 @@ Données de formulaire (`application/x-www-form-urlencoded`) uniquement :
    - Obtenir l'email et le téléphone de l'utilisateur
 
 2. **Stargate → Herald** : Créer un challenge et envoyer un code de vérification
-   - Utiliser l'email/téléphone retourné par Warden comme destination
+   - Utiliser l'e-mail, le téléphone ou l'identifiant DingTalk renvoyé par Warden comme destination
    - Appeler l'API Herald pour créer un challenge
-   - Herald envoie un code de vérification (SMS ou Email)
+   - Herald envoie le code via le canal SMS, e-mail ou DingTalk sélectionné
 
 3. **Retourner le Résultat** : Retourner challenge_id et informations associées
 
@@ -366,27 +388,27 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## Points de Terminaison TOTP
 
-Ces points de terminaison sont disponibles lorsque Herald et Herald TOTP sont activés. L'inscription doit commencer et se terminer dans les 10 minutes suivant la connexion qui a créé la session.
+Ces points de terminaison sont disponibles lorsque Herald et Herald TOTP sont activés. Ils exigent tous une session authentifiée. L'inscription doit commencer et se terminer dans les 10 minutes suivant la connexion qui a créé la session.
 
 ### `GET /totp/enroll`
 
-Affiche une page de confirmation sans créer d'état d'inscription. Nécessite une session créée par une connexion réussie au cours des 10 dernières minutes.
+Affiche une page de confirmation sans créer d'état d'inscription. Nécessite une session créée par une connexion réussie au cours des 10 dernières minutes. Un utilisateur non authentifié est redirigé avec `302 Found` vers `/_login` ; une session plus ancienne reçoit `401 Unauthorized`.
 
 ### `POST /totp/enroll`
 
-Démarre l'inscription et affiche la page d'association TOTP. Nécessite une session créée au cours des 10 dernières minutes.
+Démarre l'inscription et affiche la page d'association TOTP. Nécessite une session créée par une connexion réussie au cours des 10 dernières minutes. Un utilisateur non authentifié est redirigé avec `302 Found` vers `/_login` ; une session plus ancienne reçoit `401 Unauthorized`.
 
 ### `POST /totp/enroll/confirm`
 
-Confirme l'inscription avec des données de formulaire (`application/x-www-form-urlencoded`). `enroll_id` et le `code` TOTP à six chiffres sont tous deux obligatoires. La réponse est en JSON et inclut les codes de secours à usage unique en cas de succès.
+Confirme l'inscription avec des données de formulaire `application/x-www-form-urlencoded` ou `multipart/form-data` ; les corps JSON ne sont pas pris en charge. Une session authentifiée créée au cours des 10 dernières minutes, `enroll_id` et le `code` TOTP à six chiffres sont obligatoires. Une authentification absente ou trop ancienne renvoie `401 Unauthorized` ; en cas de succès, la réponse JSON inclut les codes de secours affichés une seule fois.
 
 ### `GET /totp/revoke`
 
-Affiche la page de confirmation de suppression de l'association TOTP.
+Affiche la page de confirmation de suppression de l'association TOTP. Une session authentifiée est requise ; un utilisateur non authentifié est redirigé avec `302 Found` vers `/_login`. La limite de 10 minutes ne s'applique pas à cette page.
 
 ### `POST /totp/revoke`
 
-Supprime l'association TOTP après confirmation avec `password` ou un `code` actuel.
+Supprime l'association TOTP. Une session authentifiée est requise et le client doit se réauthentifier avec `password` ou un `code` TOTP actuel valide. Une réauthentification absente ou échouée renvoie `401 Unauthorized`.
 
 ## Points de Terminaison de Santé
 

--- a/docs/frFR/API.md
+++ b/docs/frFR/API.md
@@ -239,7 +239,13 @@ Requête d'envoi de code de vérification. Ce point de terminaison est utilisé 
 
 #### Corps de Requête
 
-Données de formulaire `application/x-www-form-urlencoded` ou `multipart/form-data` ; les corps JSON ne sont pas pris en charge :
+Types de média pris en charge pour le corps de requête :
+
+| Type de média du corps | Pris en charge |
+|------------------------|----------------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
 
 | Champ | Type | Requis | Description |
 |-------|------|--------|-------------|

--- a/docs/frFR/API.md
+++ b/docs/frFR/API.md
@@ -237,6 +237,7 @@ Requête d'envoi de code de vérification. Ce point de terminaison est utilisé 
 |---------|-------------|
 | `Idempotency-Key` | Optionnel. Si présent, Stargate le transmet à Herald ; Herald renvoie la même réponse de défi pour les requêtes en double avec la même clé dans la TTL. |
 
+<!-- api-contract: send-verify-code-request-body -->
 #### Corps de Requête
 
 Types de média pris en charge pour le corps de requête :
@@ -417,7 +418,22 @@ Démarre l'inscription et affiche la page d'association TOTP. Nécessite une ses
 
 ### `POST /totp/enroll/confirm`
 
-Confirme l'inscription avec des données de formulaire `application/x-www-form-urlencoded` ou `multipart/form-data` ; les corps JSON ne sont pas pris en charge. Une session authentifiée créée au cours des 10 dernières minutes, `enroll_id` et le `code` TOTP à six chiffres sont obligatoires. Une authentification absente ou trop ancienne renvoie `401 Unauthorized` ; en cas de succès, la réponse JSON inclut les codes de secours affichés une seule fois.
+Confirme l'inscription. Une session authentifiée créée au cours des 10 dernières minutes est obligatoire.
+
+<!-- api-contract: totp-enroll-confirm-request-body -->
+#### Corps de Requête
+
+| Type de média du corps | Pris en charge |
+|------------------------|----------------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
+
+Le formulaire doit contenir `enroll_id` et le `code` TOTP à six chiffres.
+
+#### Réponse
+
+Une authentification absente ou trop ancienne renvoie `401 Unauthorized` ; en cas de succès, la réponse JSON inclut les codes de secours affichés une seule fois.
 
 ### `GET /totp/revoke`
 

--- a/docs/itIT/API.md
+++ b/docs/itIT/API.md
@@ -236,6 +236,7 @@ Richiesta di invio codice di verifica. Questo endpoint è utilizzato nel flusso 
 |---------------|-------------|
 | `Idempotency-Key` | Opzionale. Se presente, Stargate la inoltra a Herald; Herald restituisce la stessa risposta di challenge per richieste duplicate con la stessa chiave entro la TTL. |
 
+<!-- api-contract: send-verify-code-request-body -->
 #### Corpo della Richiesta
 
 Tipi di media supportati per il corpo della richiesta:
@@ -416,7 +417,22 @@ Avvia la registrazione e mostra la pagina di associazione TOTP. Richiede una ses
 
 ### `POST /totp/enroll/confirm`
 
-Conferma la registrazione con dati del form `application/x-www-form-urlencoded` o `multipart/form-data`; i corpi JSON non sono supportati. Sono richiesti una sessione autenticata creata negli ultimi 10 minuti, `enroll_id` e il `code` TOTP a sei cifre. Un'autenticazione assente o non recente restituisce `401 Unauthorized`; in caso di successo la risposta JSON include i codici di backup mostrati una sola volta.
+Conferma la registrazione. È richiesta una sessione autenticata creata negli ultimi 10 minuti.
+
+<!-- api-contract: totp-enroll-confirm-request-body -->
+#### Corpo Richiesta
+
+| Tipo di media del corpo | Supportato |
+|-------------------------|------------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
+
+Il modulo deve contenere `enroll_id` e il `code` TOTP a sei cifre.
+
+#### Risposta
+
+Un'autenticazione assente o non recente restituisce `401 Unauthorized`; in caso di successo la risposta JSON include i codici di backup mostrati una sola volta.
 
 ### `GET /totp/revoke`
 

--- a/docs/itIT/API.md
+++ b/docs/itIT/API.md
@@ -238,7 +238,13 @@ Richiesta di invio codice di verifica. Questo endpoint è utilizzato nel flusso 
 
 #### Corpo della Richiesta
 
-Dati del form `application/x-www-form-urlencoded` o `multipart/form-data`; i corpi JSON non sono supportati:
+Tipi di media supportati per il corpo della richiesta:
+
+| Tipo di media del corpo | Supportato |
+|-------------------------|------------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
 
 | Campo | Tipo | Richiesto | Descrizione |
 |-------|------|-----------|-------------|

--- a/docs/itIT/API.md
+++ b/docs/itIT/API.md
@@ -123,16 +123,35 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 ### `POST /_login`
 
-Elabora le richieste di login, verifica la password e crea una sessione.
+Elabora le richieste di login e supporta due modalità di autenticazione:
+
+1. **Autenticazione con password**: verifica la password e crea una sessione
+2. **Autenticazione OTP Warden + Herald**: verifica il codice e crea una sessione
 
 #### Corpo Richiesta
 
 Dati form (`application/x-www-form-urlencoded`):
 
+**Autenticazione con password:**
+
 | Campo | Tipo | Richiesto | Descrizione |
 |-------|------|-----------|-------------|
+| `auth_method` | String | No | Metodo di autenticazione; `password` è il valore predefinito |
 | `password` | String | Sì | Password utente |
 | `callback` | String | No | URL callback dopo login riuscito |
+
+**Autenticazione OTP Warden + Herald:**
+
+| Campo | Tipo | Richiesto | Descrizione |
+|-------|------|-----------|-------------|
+| `auth_method` | String | Sì | Metodo di autenticazione; valore `warden` |
+| `phone` | String | No | Numero di telefono; è richiesto almeno uno tra `phone` e `mail` |
+| `mail` | String | No | Indirizzo email; è richiesto almeno uno tra `mail` e `phone` |
+| `challenge_id` | String | Sì | ID del challenge restituito da `POST /_send_verify_code` |
+| `verify_code` | String | Sì | Codice di verifica inserito dall'utente |
+| `callback` | String | No | URL callback dopo login riuscito |
+
+Il gestore accetta anche `phone` + `mail` nella stessa richiesta Warden.
 
 #### Priorità Recupero Callback
 
@@ -167,7 +186,8 @@ La risposta varia a seconda che ci sia un callback e il tipo di richiesta:
 
 | Codice di Stato | Descrizione | Corpo Risposta |
 |----------------|-------------|----------------|
-| `401 Unauthorized` | Password errata | Messaggio di errore in formato JSON/XML/testo secondo header Accept |
+| `400 Bad Request` | Campi Warden, ID del challenge o codice di verifica mancanti o non validi | Messaggio di errore in formato JSON/XML/testo secondo header Accept |
+| `401 Unauthorized` | Password errata, utente Warden assente/inattivo o verifica del codice fallita | Messaggio di errore in formato JSON/XML/testo secondo header Accept |
 | `500 Internal Server Error` | Errore server | Messaggio di errore |
 
 #### Esempi
@@ -175,13 +195,13 @@ La risposta varia a seconda che ci sia un callback e il tipo di richiesta:
 ```bash
 # Inviare form di login (con callback)
 curl -X POST \
-     -d "password=yourpassword&callback=app.example.com" \
+     -d "auth_method=password&password=yourpassword&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 
 # Inviare form di login (senza callback, inferirà automaticamente)
 curl -X POST \
-     -d "password=yourpassword" \
+     -d "auth_method=password&password=yourpassword" \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
@@ -207,13 +227,15 @@ Richiesta di invio codice di verifica. Questo endpoint è utilizzato nel flusso 
 
 #### Corpo della Richiesta
 
-Solo dati del form (`application/x-www-form-urlencoded`):
+Dati del form `application/x-www-form-urlencoded` o `multipart/form-data`; i corpi JSON non sono supportati:
 
 | Campo | Tipo | Richiesto | Descrizione |
 |-------|------|-----------|-------------|
-| `phone` | String | No | Numero di telefono utente (uno tra `phone` o `mail`) |
-| `mail` | String | No | Email utente (uno tra `phone` o `mail`) |
-| `deliver_via` | String | No | Canale preferito: `sms`, `email` o `dingtalk`; se omesso, Stargate sceglie un canale abilitato dal record Warden. |
+| `phone` | String | No | Numero di telefono; è richiesto almeno uno tra `phone` e `mail` |
+| `mail` | String | No | Indirizzo email; è richiesto almeno uno tra `mail` e `phone` |
+| `deliver_via` | String | No | Canale preferito: `sms`, `email` o `dingtalk`. Se omesso, Stargate prova prima una destinazione SMS abilitata e poi l'email. DingTalk non viene mai selezionato implicitamente; il client deve inviare `deliver_via=dingtalk`. |
+
+Il gestore accetta anche `phone` + `mail` nella stessa richiesta di codice di verifica.
 
 #### Flusso di Elaborazione
 
@@ -223,9 +245,9 @@ Solo dati del form (`application/x-www-form-urlencoded`):
    - Ottenere email e telefono dell'utente
 
 2. **Stargate → Herald** : Creare challenge e inviare codice di verifica
-   - Utilizzare email/telefono restituito da Warden come destinazione
+   - Utilizzare email, telefono o identificativo DingTalk restituito da Warden come destinazione
    - Chiamare API Herald per creare challenge
-   - Herald invia codice di verifica (SMS o Email)
+   - Herald invia il codice tramite il canale SMS, email o DingTalk selezionato
 
 3. **Restituire Risultato** : Restituire challenge_id e informazioni correlate
 
@@ -365,27 +387,27 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## Endpoint TOTP
 
-Questi endpoint sono disponibili quando Herald e Herald TOTP sono abilitati. La registrazione deve iniziare e terminare entro 10 minuti dal login che ha creato la sessione.
+Questi endpoint sono disponibili quando Herald e Herald TOTP sono abilitati. Tutti richiedono una sessione autenticata. La registrazione deve iniziare e terminare entro 10 minuti dal login che ha creato la sessione.
 
 ### `GET /totp/enroll`
 
-Mostra una pagina di conferma senza creare lo stato di registrazione. Richiede una sessione creata da un login riuscito negli ultimi 10 minuti.
+Mostra una pagina di conferma senza creare lo stato di registrazione. Richiede una sessione creata da un login riuscito negli ultimi 10 minuti. Un utente non autenticato viene reindirizzato con `302 Found` a `/_login`; una sessione più vecchia riceve `401 Unauthorized`.
 
 ### `POST /totp/enroll`
 
-Avvia la registrazione e mostra la pagina di associazione TOTP. Richiede una sessione creata negli ultimi 10 minuti.
+Avvia la registrazione e mostra la pagina di associazione TOTP. Richiede una sessione creata da un login riuscito negli ultimi 10 minuti. Un utente non autenticato viene reindirizzato con `302 Found` a `/_login`; una sessione più vecchia riceve `401 Unauthorized`.
 
 ### `POST /totp/enroll/confirm`
 
-Conferma la registrazione con dati del form (`application/x-www-form-urlencoded`). Sono obbligatori sia `enroll_id` sia il `code` TOTP a sei cifre. La risposta è JSON e, in caso di successo, include i codici di backup mostrati una sola volta.
+Conferma la registrazione con dati del form `application/x-www-form-urlencoded` o `multipart/form-data`; i corpi JSON non sono supportati. Sono richiesti una sessione autenticata creata negli ultimi 10 minuti, `enroll_id` e il `code` TOTP a sei cifre. Un'autenticazione assente o non recente restituisce `401 Unauthorized`; in caso di successo la risposta JSON include i codici di backup mostrati una sola volta.
 
 ### `GET /totp/revoke`
 
-Mostra la pagina di conferma per rimuovere l'associazione TOTP.
+Mostra la pagina di conferma per rimuovere l'associazione TOTP. È richiesta una sessione autenticata; un utente non autenticato viene reindirizzato con `302 Found` a `/_login`. A questa pagina non si applica il limite di 10 minuti.
 
 ### `POST /totp/revoke`
 
-Rimuove l'associazione TOTP dopo la conferma con `password` o con un `code` corrente.
+Rimuove l'associazione TOTP. È richiesta una sessione autenticata e il client deve riautenticarsi con `password` o con un `code` TOTP corrente valido. Una riautenticazione assente o fallita restituisce `401 Unauthorized`.
 
 ## Endpoint di Salute
 

--- a/docs/itIT/API.md
+++ b/docs/itIT/API.md
@@ -126,7 +126,7 @@ curl http://auth.example.com/_login?callback=app.example.com
 Elabora le richieste di login e supporta due modalità di autenticazione:
 
 1. **Autenticazione con password**: verifica la password e crea una sessione
-2. **Autenticazione OTP Warden + Herald**: verifica il codice e crea una sessione
+2. **Autenticazione Warden**: verifica un codice challenge Herald oppure un codice TOTP già configurato e crea una sessione
 
 #### Corpo Richiesta
 
@@ -140,18 +140,21 @@ Dati form (`application/x-www-form-urlencoded`):
 | `password` | String | Sì | Password utente |
 | `callback` | String | No | URL callback dopo login riuscito |
 
-**Autenticazione OTP Warden + Herald:**
+**Autenticazione Warden:**
 
 | Campo | Tipo | Richiesto | Descrizione |
 |-------|------|-----------|-------------|
 | `auth_method` | String | Sì | Metodo di autenticazione; valore `warden` |
 | `phone` | String | No | Numero di telefono; è richiesto almeno uno tra `phone` e `mail` |
 | `mail` | String | No | Indirizzo email; è richiesto almeno uno tra `mail` e `phone` |
-| `challenge_id` | String | Sì | ID del challenge restituito da `POST /_send_verify_code` |
-| `verify_code` | String | Sì | Codice di verifica inserito dall'utente |
+| `challenge_id` | String | Condizionale | Richiesto con `verify_code`; facoltativo quando `use_otp=true` |
+| `verify_code` | String | Condizionale | Richiesto per il challenge Herald quando `use_otp` è assente o `false` |
+| `use_otp` | Boolean | No | Impostare a `true` per usare un autenticatore TOTP configurato invece di un challenge Herald |
+| `otp_code` | String | Condizionale | Richiesto quando `use_otp=true` |
 | `callback` | String | No | URL callback dopo login riuscito |
 
 Il gestore accetta anche `phone` + `mail` nella stessa richiesta Warden.
+La variante TOTP richiede `HERALD_TOTP_ENABLED=true` e un utente già registrato. In caso contrario, usare la variante `challenge_id` + `verify_code`.
 
 #### Priorità Recupero Callback
 
@@ -186,8 +189,10 @@ La risposta varia a seconda che ci sia un callback e il tipo di richiesta:
 
 | Codice di Stato | Descrizione | Corpo Risposta |
 |----------------|-------------|----------------|
-| `400 Bad Request` | Campi Warden, ID del challenge o codice di verifica mancanti o non validi | Messaggio di errore in formato JSON/XML/testo secondo header Accept |
-| `401 Unauthorized` | Password errata, utente Warden assente/inattivo o verifica del codice fallita | Messaggio di errore in formato JSON/XML/testo secondo header Accept |
+| `400 Bad Request` | Identificatore Warden o campi del metodo scelto mancanti/non validi, oppure TOTP non registrato | Messaggio di errore in formato JSON/XML/testo secondo header Accept |
+| `401 Unauthorized` | Password errata, utente Warden assente/inattivo o verifica challenge/TOTP fallita | Messaggio di errore in formato JSON/XML/testo secondo header Accept |
+| `502 Bad Gateway` | Lettura dello stato TOTP da Herald non riuscita | Messaggio di errore |
+| `503 Service Unavailable` | Servizio di verifica Herald non disponibile | Messaggio di errore |
 | `500 Internal Server Error` | Errore server | Messaggio di errore |
 
 #### Esempi
@@ -209,6 +214,12 @@ curl -X POST \
 # Warden + Herald: login con il challenge restituito da /_send_verify_code
 curl -X POST \
      -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
+
+# Warden + TOTP: login con un autenticatore già configurato
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&use_otp=true&otp_code=123456&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 ```

--- a/docs/jaJP/API.md
+++ b/docs/jaJP/API.md
@@ -123,16 +123,35 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 ### `POST /_login`
 
-ログインリクエストを処理し、パスワードを検証してセッションを作成します。
+ログインリクエストを処理し、次の 2 つの認証モードをサポートします：
+
+1. **パスワード認証**：パスワードを検証してセッションを作成
+2. **Warden + Herald OTP 認証**：検証コードを確認してセッションを作成
 
 #### リクエスト本文
 
 フォームデータ（`application/x-www-form-urlencoded`）：
 
+**パスワード認証：**
+
 | フィールド | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
+| `auth_method` | String | いいえ | 認証方式。既定値は `password` |
 | `password` | String | はい | ユーザーパスワード |
 | `callback` | String | いいえ | ログイン成功後のコールバック URL |
+
+**Warden + Herald OTP 認証：**
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `auth_method` | String | はい | 認証方式。値は `warden` |
+| `phone` | String | いいえ | ユーザーの電話番号。`phone` または `mail` の少なくとも一方が必要 |
+| `mail` | String | いいえ | ユーザーのメールアドレス。`mail` または `phone` の少なくとも一方が必要 |
+| `challenge_id` | String | はい | `POST /_send_verify_code` が返したチャレンジ ID |
+| `verify_code` | String | はい | ユーザーが入力した検証コード |
+| `callback` | String | いいえ | ログイン成功後のコールバック URL |
+
+ハンドラーは同じ Warden リクエストで `phone` + `mail` を同時に送ることも許可します。
 
 #### コールバック取得の優先順位
 
@@ -167,7 +186,8 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 | ステータスコード | 説明 | レスポンス本文 |
 |----------------|------|----------------|
-| `401 Unauthorized` | パスワードが間違っている | Accept ヘッダーに応じて JSON/XML/テキスト形式のエラーメッセージ |
+| `400 Bad Request` | Warden フィールド、チャレンジ ID、または検証コードが不正または不足 | Accept ヘッダーに応じて JSON/XML/テキスト形式のエラーメッセージ |
+| `401 Unauthorized` | パスワード誤り、Warden ユーザーの不在/無効、またはコード検証失敗 | Accept ヘッダーに応じて JSON/XML/テキスト形式のエラーメッセージ |
 | `500 Internal Server Error` | サーバーエラー | エラーメッセージ |
 
 #### 例
@@ -175,13 +195,13 @@ curl http://auth.example.com/_login?callback=app.example.com
 ```bash
 # ログインフォームを送信（コールバックあり）
 curl -X POST \
-     -d "password=yourpassword&callback=app.example.com" \
+     -d "auth_method=password&password=yourpassword&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 
 # ログインフォームを送信（コールバックなし、自動推論）
 curl -X POST \
-     -d "password=yourpassword" \
+     -d "auth_method=password&password=yourpassword" \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
@@ -207,13 +227,15 @@ curl -X POST \
 
 #### リクエストボディ
 
-フォームデータ（`application/x-www-form-urlencoded`）のみ：
+`application/x-www-form-urlencoded` または `multipart/form-data` のフォームデータに対応します。JSON リクエストボディには対応しません：
 
 | フィールド | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
-| `phone` | String | いいえ | ユーザーの電話番号 (`phone` または `mail` のいずれか) |
-| `mail` | String | いいえ | ユーザーのメール (`phone` または `mail` のいずれか) |
-| `deliver_via` | String | いいえ | 希望するチャネル：`sms`、`email`、`dingtalk`。省略時は Warden レコードから有効なチャネルを選択します。 |
+| `phone` | String | いいえ | ユーザーの電話番号。`phone` または `mail` の少なくとも一方が必要 |
+| `mail` | String | いいえ | ユーザーのメール。`mail` または `phone` の少なくとも一方が必要 |
+| `deliver_via` | String | いいえ | 希望するチャネル：`sms`、`email`、`dingtalk`。省略時は有効な SMS 宛先、次にメールを試します。DingTalk は暗黙に選択されないため、呼び出し側は `deliver_via=dingtalk` を明示する必要があります。 |
+
+ハンドラーは同じ検証コード送信リクエストで `phone` + `mail` を同時に送ることも許可します。
 
 #### 処理フロー
 
@@ -223,9 +245,9 @@ curl -X POST \
    - ユーザーのメールと電話を取得
 
 2. **Stargate → Herald** : チャレンジを作成し、検証コードを送信
-   - Wardenから返されたメール/電話を宛先として使用
+   - Warden から返されたメール、電話番号、または DingTalk 識別子を宛先として使用
    - Herald APIを呼び出してチャレンジを作成
-   - Heraldが検証コードを送信（SMSまたはメール）
+   - Herald が選択された SMS、メール、または DingTalk チャネルで検証コードを送信
 
 3. **結果を返す** : challenge_idと関連情報を返す
 
@@ -365,27 +387,27 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## TOTP エンドポイント
 
-Herald と Herald TOTP が有効な場合に利用できます。登録は、セッションを作成したログインから 10 分以内に開始して完了する必要があります。
+Herald と Herald TOTP が有効な場合に利用できます。すべてのエンドポイントで認証済みセッションが必要です。登録は、そのセッションを作成したログインから 10 分以内に開始して完了する必要があります。
 
 ### `GET /totp/enroll`
 
-登録状態を作成せずに確認ページを表示します。直近 10 分以内のログインで作成されたセッションが必要です。
+登録状態を作成せずに確認ページを表示します。直近 10 分以内のログインで作成されたセッションが必要です。未認証の場合は `302 Found` で `/_login` にリダイレクトされ、古いセッションには `401 Unauthorized` が返されます。
 
 ### `POST /totp/enroll`
 
-登録を開始し、TOTP の関連付けページを表示します。直近 10 分以内に作成されたセッションが必要です。
+登録を開始し、TOTP の関連付けページを表示します。直近 10 分以内のログインで作成されたセッションが必要です。未認証の場合は `302 Found` で `/_login` にリダイレクトされ、古いセッションには `401 Unauthorized` が返されます。
 
 ### `POST /totp/enroll/confirm`
 
-フォームデータ（`application/x-www-form-urlencoded`）で登録を確定します。`enroll_id` と 6 桁の TOTP `code` の両方が必要です。レスポンスは JSON で、成功時には一度だけ表示されるバックアップコードを含みます。
+`application/x-www-form-urlencoded` または `multipart/form-data` のフォームデータで登録を確定します。JSON リクエストボディには対応しません。直近 10 分以内のログインで作成された認証済みセッション、`enroll_id`、6 桁の TOTP `code` が必要です。認証がないか古い場合は `401 Unauthorized` を返し、成功時の JSON には一度だけ表示されるバックアップコードが含まれます。
 
 ### `GET /totp/revoke`
 
-TOTP の関連付けを解除する確認ページを表示します。
+TOTP の関連付けを解除する確認ページを表示します。認証済みセッションが必要で、未認証の場合は `302 Found` で `/_login` にリダイレクトされます。このページに 10 分制限はありません。
 
 ### `POST /totp/revoke`
 
-`password` または現在の `code` で確認した後、TOTP の関連付けを解除します。
+TOTP の関連付けを解除します。認証済みセッションに加え、`password` または有効な現在の TOTP `code` による再認証が必要です。再認証がない、または失敗した場合は `401 Unauthorized` を返します。
 
 ## ヘルスチェックエンドポイント
 

--- a/docs/jaJP/API.md
+++ b/docs/jaJP/API.md
@@ -238,7 +238,13 @@ curl -X POST \
 
 #### リクエストボディ
 
-`application/x-www-form-urlencoded` または `multipart/form-data` のフォームデータに対応します。JSON リクエストボディには対応しません：
+リクエストボディのメディアタイプ対応状況：
+
+| リクエストボディのメディアタイプ | 対応 |
+|----------------------------------|------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
 
 | フィールド | 型 | 必須 | 説明 |
 |-----------|-----|------|------|

--- a/docs/jaJP/API.md
+++ b/docs/jaJP/API.md
@@ -126,7 +126,7 @@ curl http://auth.example.com/_login?callback=app.example.com
 ログインリクエストを処理し、次の 2 つの認証モードをサポートします：
 
 1. **パスワード認証**：パスワードを検証してセッションを作成
-2. **Warden + Herald OTP 認証**：検証コードを確認してセッションを作成
+2. **Warden 認証**：Herald challenge コードまたは登録済み TOTP コードを検証してセッションを作成
 
 #### リクエスト本文
 
@@ -140,18 +140,21 @@ curl http://auth.example.com/_login?callback=app.example.com
 | `password` | String | はい | ユーザーパスワード |
 | `callback` | String | いいえ | ログイン成功後のコールバック URL |
 
-**Warden + Herald OTP 認証：**
+**Warden 認証：**
 
 | フィールド | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
 | `auth_method` | String | はい | 認証方式。値は `warden` |
 | `phone` | String | いいえ | ユーザーの電話番号。`phone` または `mail` の少なくとも一方が必要 |
 | `mail` | String | いいえ | ユーザーのメールアドレス。`mail` または `phone` の少なくとも一方が必要 |
-| `challenge_id` | String | はい | `POST /_send_verify_code` が返したチャレンジ ID |
-| `verify_code` | String | はい | ユーザーが入力した検証コード |
+| `challenge_id` | String | 条件付き | `verify_code` とともに使用する場合は必須。`use_otp=true` の場合は任意 |
+| `verify_code` | String | 条件付き | `use_otp` が未指定または `false` の場合、Herald challenge の検証に必須 |
+| `use_otp` | Boolean | いいえ | Herald challenge の代わりに登録済み TOTP 認証器を使う場合は `true` |
+| `otp_code` | String | 条件付き | `use_otp=true` の場合は必須 |
 | `callback` | String | いいえ | ログイン成功後のコールバック URL |
 
 ハンドラーは同じ Warden リクエストで `phone` + `mail` を同時に送ることも許可します。
+TOTP 方式には `HERALD_TOTP_ENABLED=true` と登録済みユーザーが必要です。それ以外では `challenge_id` + `verify_code` 方式を使用します。
 
 #### コールバック取得の優先順位
 
@@ -186,8 +189,10 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 | ステータスコード | 説明 | レスポンス本文 |
 |----------------|------|----------------|
-| `400 Bad Request` | Warden フィールド、チャレンジ ID、または検証コードが不正または不足 | Accept ヘッダーに応じて JSON/XML/テキスト形式のエラーメッセージ |
-| `401 Unauthorized` | パスワード誤り、Warden ユーザーの不在/無効、またはコード検証失敗 | Accept ヘッダーに応じて JSON/XML/テキスト形式のエラーメッセージ |
+| `400 Bad Request` | Warden 識別子または選択した検証方式のフィールドが不正/不足、あるいは TOTP 未登録 | Accept ヘッダーに応じて JSON/XML/テキスト形式のエラーメッセージ |
+| `401 Unauthorized` | パスワード誤り、Warden ユーザーの不在/無効、または challenge/TOTP 検証失敗 | Accept ヘッダーに応じて JSON/XML/テキスト形式のエラーメッセージ |
+| `502 Bad Gateway` | Herald の TOTP 状態取得に失敗 | エラーメッセージ |
+| `503 Service Unavailable` | Herald 検証サービスが利用不可 | エラーメッセージ |
 | `500 Internal Server Error` | サーバーエラー | エラーメッセージ |
 
 #### 例
@@ -209,6 +214,12 @@ curl -X POST \
 # Warden + Herald：/_send_verify_code が返した challenge でログイン
 curl -X POST \
      -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
+
+# Warden + TOTP：登録済み認証器でログイン
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&use_otp=true&otp_code=123456&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 ```

--- a/docs/jaJP/API.md
+++ b/docs/jaJP/API.md
@@ -236,6 +236,7 @@ curl -X POST \
 |----------|------|
 | `Idempotency-Key` | 任意。指定した場合、Stargate が Herald に転送する。Herald は TTL 内で同じ key の重複リクエストに同じ challenge 応答を返す。 |
 
+<!-- api-contract: send-verify-code-request-body -->
 #### リクエストボディ
 
 リクエストボディのメディアタイプ対応状況：
@@ -416,7 +417,22 @@ Herald と Herald TOTP が有効な場合に利用できます。すべてのエ
 
 ### `POST /totp/enroll/confirm`
 
-`application/x-www-form-urlencoded` または `multipart/form-data` のフォームデータで登録を確定します。JSON リクエストボディには対応しません。直近 10 分以内のログインで作成された認証済みセッション、`enroll_id`、6 桁の TOTP `code` が必要です。認証がないか古い場合は `401 Unauthorized` を返し、成功時の JSON には一度だけ表示されるバックアップコードが含まれます。
+登録を確定します。直近 10 分以内のログインで作成された認証済みセッションが必要です。
+
+<!-- api-contract: totp-enroll-confirm-request-body -->
+#### リクエストボディ
+
+| リクエストボディのメディアタイプ | 対応 |
+|----------------------------------|------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
+
+フォームには `enroll_id` と 6 桁の TOTP `code` が必要です。
+
+#### レスポンス
+
+認証がないか古い場合は `401 Unauthorized` を返し、成功時の JSON には一度だけ表示されるバックアップコードが含まれます。
 
 ### `GET /totp/revoke`
 

--- a/docs/koKR/API.md
+++ b/docs/koKR/API.md
@@ -123,16 +123,35 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 ### `POST /_login`
 
-로그인 요청을 처리하고 비밀번호를 검증하여 세션을 생성합니다.
+로그인 요청을 처리하며 다음 두 가지 인증 모드를 지원합니다:
+
+1. **비밀번호 인증**: 비밀번호를 검증하고 세션 생성
+2. **Warden + Herald OTP 인증**: 인증 코드를 검증하고 세션 생성
 
 #### 요청 본문
 
 폼 데이터 (`application/x-www-form-urlencoded`):
 
+**비밀번호 인증:**
+
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|------|------|
+| `auth_method` | String | 아니오 | 인증 방식이며 기본값은 `password` |
 | `password` | String | 예 | 사용자 비밀번호 |
 | `callback` | String | 아니오 | 로그인 성공 후 콜백 URL |
+
+**Warden + Herald OTP 인증:**
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `auth_method` | String | 예 | 인증 방식이며 값은 `warden` |
+| `phone` | String | 아니오 | 사용자 전화번호. `phone` 또는 `mail` 중 하나 이상 필요 |
+| `mail` | String | 아니오 | 사용자 이메일. `mail` 또는 `phone` 중 하나 이상 필요 |
+| `challenge_id` | String | 예 | `POST /_send_verify_code`가 반환한 challenge ID |
+| `verify_code` | String | 예 | 사용자가 입력한 인증 코드 |
+| `callback` | String | 아니오 | 로그인 성공 후 콜백 URL |
+
+핸들러는 같은 Warden 요청에 `phone` + `mail`을 함께 보내는 것도 허용합니다.
 
 #### 콜백 가져오기 우선순위
 
@@ -167,7 +186,8 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 | 상태 코드 | 설명 | 응답 본문 |
 |-----------|------|-----------|
-| `401 Unauthorized` | 잘못된 비밀번호 | Accept 헤더에 따라 JSON/XML/텍스트 형식의 오류 메시지 |
+| `400 Bad Request` | Warden 필드, challenge ID 또는 인증 코드가 잘못되었거나 누락됨 | Accept 헤더에 따라 JSON/XML/텍스트 형식의 오류 메시지 |
+| `401 Unauthorized` | 잘못된 비밀번호, Warden 사용자 없음/비활성 또는 코드 검증 실패 | Accept 헤더에 따라 JSON/XML/텍스트 형식의 오류 메시지 |
 | `500 Internal Server Error` | 서버 오류 | 오류 메시지 |
 
 #### 예제
@@ -175,13 +195,13 @@ curl http://auth.example.com/_login?callback=app.example.com
 ```bash
 # 로그인 폼 제출 (콜백 있음)
 curl -X POST \
-     -d "password=yourpassword&callback=app.example.com" \
+     -d "auth_method=password&password=yourpassword&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 
 # 로그인 폼 제출 (콜백 없음, 자동 추론)
 curl -X POST \
-     -d "password=yourpassword" \
+     -d "auth_method=password&password=yourpassword" \
      -H "X-Forwarded-Host: app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
@@ -207,13 +227,15 @@ curl -X POST \
 
 #### 요청 본문
 
-폼 데이터(`application/x-www-form-urlencoded`)만 지원합니다:
+`application/x-www-form-urlencoded` 또는 `multipart/form-data` 폼 데이터를 지원하며 JSON 요청 본문은 지원하지 않습니다:
 
 | 필드 | 유형 | 필수 | 설명 |
 |------|------|------|------|
-| `phone` | String | 아니오 | 사용자 전화번호 (`phone` 또는 `mail` 중 하나) |
-| `mail` | String | 아니오 | 사용자 이메일 (`phone` 또는 `mail` 중 하나) |
-| `deliver_via` | String | 아니오 | 선호 채널: `sms`, `email`, `dingtalk`. 생략하면 Warden 레코드에서 활성화된 채널을 선택합니다. |
+| `phone` | String | 아니오 | 사용자 전화번호. `phone` 또는 `mail` 중 하나 이상 필요 |
+| `mail` | String | 아니오 | 사용자 이메일. `mail` 또는 `phone` 중 하나 이상 필요 |
+| `deliver_via` | String | 아니오 | 선호 채널: `sms`, `email`, `dingtalk`. 생략하면 활성화된 SMS 대상을 먼저 시도한 뒤 이메일을 시도합니다. DingTalk는 암묵적으로 선택되지 않으므로 호출자는 `deliver_via=dingtalk`를 명시해야 합니다. |
+
+핸들러는 같은 인증 코드 요청에 `phone` + `mail`을 함께 보내는 것도 허용합니다.
 
 #### 처리 흐름
 
@@ -223,9 +245,9 @@ curl -X POST \
    - 사용자의 이메일과 전화 가져오기
 
 2. **Stargate → Herald** : 챌린지 생성 및 인증 코드 전송
-   - Warden에서 반환된 이메일/전화를 대상으로 사용
+   - Warden에서 반환된 이메일, 전화번호 또는 DingTalk 식별자를 대상으로 사용
    - Herald API를 호출하여 챌린지 생성
-   - Herald가 인증 코드 전송 (SMS 또는 이메일)
+   - Herald가 선택된 SMS, 이메일 또는 DingTalk 채널로 인증 코드 전송
 
 3. **결과 반환** : challenge_id 및 관련 정보 반환
 
@@ -365,27 +387,27 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ## TOTP 엔드포인트
 
-Herald와 Herald TOTP가 활성화된 경우 사용할 수 있습니다. 등록은 세션을 만든 로그인 후 10분 이내에 시작하고 완료해야 합니다.
+Herald와 Herald TOTP가 활성화된 경우 사용할 수 있습니다. 모든 엔드포인트에는 인증된 세션이 필요합니다. 등록은 해당 세션을 만든 로그인 후 10분 이내에 시작하고 완료해야 합니다.
 
 ### `GET /totp/enroll`
 
-등록 상태를 만들지 않고 확인 페이지를 표시합니다. 최근 10분 이내의 로그인으로 생성된 세션이 필요합니다.
+등록 상태를 만들지 않고 확인 페이지를 표시합니다. 최근 10분 이내의 로그인으로 생성된 세션이 필요합니다. 인증되지 않은 사용자는 `302 Found`로 `/_login`에 리디렉션되고 오래된 세션에는 `401 Unauthorized`가 반환됩니다.
 
 ### `POST /totp/enroll`
 
-등록을 시작하고 TOTP 연결 페이지를 표시합니다. 최근 10분 이내에 생성된 세션이 필요합니다.
+등록을 시작하고 TOTP 연결 페이지를 표시합니다. 최근 10분 이내의 로그인으로 생성된 세션이 필요합니다. 인증되지 않은 사용자는 `302 Found`로 `/_login`에 리디렉션되고 오래된 세션에는 `401 Unauthorized`가 반환됩니다.
 
 ### `POST /totp/enroll/confirm`
 
-폼 데이터(`application/x-www-form-urlencoded`)로 등록을 확인합니다. `enroll_id`와 6자리 TOTP `code`가 모두 필요합니다. 응답은 JSON이며 성공 시 한 번만 표시되는 백업 코드를 포함합니다.
+`application/x-www-form-urlencoded` 또는 `multipart/form-data` 폼 데이터로 등록을 확인하며 JSON 요청 본문은 지원하지 않습니다. 최근 10분 이내의 로그인으로 생성된 인증 세션, `enroll_id`, 6자리 TOTP `code`가 필요합니다. 인증이 없거나 오래된 경우 `401 Unauthorized`를 반환하며 성공 JSON에는 한 번만 표시되는 백업 코드가 포함됩니다.
 
 ### `GET /totp/revoke`
 
-TOTP 연결 해제 확인 페이지를 표시합니다.
+TOTP 연결 해제 확인 페이지를 표시합니다. 인증된 세션이 필요하며 인증되지 않은 사용자는 `302 Found`로 `/_login`에 리디렉션됩니다. 이 페이지에는 10분 제한이 적용되지 않습니다.
 
 ### `POST /totp/revoke`
 
-`password` 또는 현재 `code`로 확인한 후 TOTP 연결을 해제합니다.
+TOTP 연결을 해제합니다. 인증된 세션과 함께 `password` 또는 유효한 현재 TOTP `code`로 재인증해야 합니다. 재인증이 없거나 실패하면 `401 Unauthorized`를 반환합니다.
 
 ## 헬스 체크 엔드포인트
 

--- a/docs/koKR/API.md
+++ b/docs/koKR/API.md
@@ -236,6 +236,7 @@ curl -X POST \
 |------|------|
 | `Idempotency-Key` | 선택. 있으면 Stargate가 Herald로 전달하며, Herald는 TTL 내 동일 key 중복 요청에 같은 challenge 응답을 반환한다. |
 
+<!-- api-contract: send-verify-code-request-body -->
 #### 요청 본문
 
 요청 본문 미디어 타입 지원 여부:
@@ -416,7 +417,22 @@ Herald와 Herald TOTP가 활성화된 경우 사용할 수 있습니다. 모든 
 
 ### `POST /totp/enroll/confirm`
 
-`application/x-www-form-urlencoded` 또는 `multipart/form-data` 폼 데이터로 등록을 확인하며 JSON 요청 본문은 지원하지 않습니다. 최근 10분 이내의 로그인으로 생성된 인증 세션, `enroll_id`, 6자리 TOTP `code`가 필요합니다. 인증이 없거나 오래된 경우 `401 Unauthorized`를 반환하며 성공 JSON에는 한 번만 표시되는 백업 코드가 포함됩니다.
+등록을 확인합니다. 최근 10분 이내의 로그인으로 생성된 인증 세션이 필요합니다.
+
+<!-- api-contract: totp-enroll-confirm-request-body -->
+#### 요청 본문
+
+| 요청 본문 미디어 타입 | 지원 |
+|----------------------|------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
+
+폼에는 `enroll_id`와 6자리 TOTP `code`가 필요합니다.
+
+#### 응답
+
+인증이 없거나 오래된 경우 `401 Unauthorized`를 반환하며 성공 JSON에는 한 번만 표시되는 백업 코드가 포함됩니다.
 
 ### `GET /totp/revoke`
 

--- a/docs/koKR/API.md
+++ b/docs/koKR/API.md
@@ -238,7 +238,13 @@ curl -X POST \
 
 #### 요청 본문
 
-`application/x-www-form-urlencoded` 또는 `multipart/form-data` 폼 데이터를 지원하며 JSON 요청 본문은 지원하지 않습니다:
+요청 본문 미디어 타입 지원 여부:
+
+| 요청 본문 미디어 타입 | 지원 |
+|----------------------|------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
 
 | 필드 | 유형 | 필수 | 설명 |
 |------|------|------|------|

--- a/docs/koKR/API.md
+++ b/docs/koKR/API.md
@@ -126,7 +126,7 @@ curl http://auth.example.com/_login?callback=app.example.com
 로그인 요청을 처리하며 다음 두 가지 인증 모드를 지원합니다:
 
 1. **비밀번호 인증**: 비밀번호를 검증하고 세션 생성
-2. **Warden + Herald OTP 인증**: 인증 코드를 검증하고 세션 생성
+2. **Warden 인증**: Herald challenge 코드 또는 등록된 TOTP 코드를 검증하고 세션 생성
 
 #### 요청 본문
 
@@ -140,18 +140,21 @@ curl http://auth.example.com/_login?callback=app.example.com
 | `password` | String | 예 | 사용자 비밀번호 |
 | `callback` | String | 아니오 | 로그인 성공 후 콜백 URL |
 
-**Warden + Herald OTP 인증:**
+**Warden 인증:**
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|------|------|
 | `auth_method` | String | 예 | 인증 방식이며 값은 `warden` |
 | `phone` | String | 아니오 | 사용자 전화번호. `phone` 또는 `mail` 중 하나 이상 필요 |
 | `mail` | String | 아니오 | 사용자 이메일. `mail` 또는 `phone` 중 하나 이상 필요 |
-| `challenge_id` | String | 예 | `POST /_send_verify_code`가 반환한 challenge ID |
-| `verify_code` | String | 예 | 사용자가 입력한 인증 코드 |
+| `challenge_id` | String | 조건부 | `verify_code`와 함께 사용할 때 필수이며 `use_otp=true`일 때 선택 사항 |
+| `verify_code` | String | 조건부 | `use_otp`가 없거나 `false`일 때 Herald challenge 검증에 필수 |
+| `use_otp` | Boolean | 아니오 | Herald challenge 대신 등록된 TOTP 인증기를 사용하려면 `true`로 설정 |
+| `otp_code` | String | 조건부 | `use_otp=true`일 때 필수 |
 | `callback` | String | 아니오 | 로그인 성공 후 콜백 URL |
 
 핸들러는 같은 Warden 요청에 `phone` + `mail`을 함께 보내는 것도 허용합니다.
+TOTP 방식에는 `HERALD_TOTP_ENABLED=true`와 이미 등록된 사용자가 필요합니다. 그렇지 않으면 `challenge_id` + `verify_code` 방식을 사용합니다.
 
 #### 콜백 가져오기 우선순위
 
@@ -186,8 +189,10 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 | 상태 코드 | 설명 | 응답 본문 |
 |-----------|------|-----------|
-| `400 Bad Request` | Warden 필드, challenge ID 또는 인증 코드가 잘못되었거나 누락됨 | Accept 헤더에 따라 JSON/XML/텍스트 형식의 오류 메시지 |
-| `401 Unauthorized` | 잘못된 비밀번호, Warden 사용자 없음/비활성 또는 코드 검증 실패 | Accept 헤더에 따라 JSON/XML/텍스트 형식의 오류 메시지 |
+| `400 Bad Request` | Warden 식별자 또는 선택한 검증 방식의 필드가 잘못되었거나 누락됨, 또는 TOTP 미등록 | Accept 헤더에 따라 JSON/XML/텍스트 형식의 오류 메시지 |
+| `401 Unauthorized` | 잘못된 비밀번호, Warden 사용자 없음/비활성 또는 challenge/TOTP 검증 실패 | Accept 헤더에 따라 JSON/XML/텍스트 형식의 오류 메시지 |
+| `502 Bad Gateway` | Herald TOTP 상태 조회 실패 | 오류 메시지 |
+| `503 Service Unavailable` | Herald 검증 서비스를 사용할 수 없음 | 오류 메시지 |
 | `500 Internal Server Error` | 서버 오류 | 오류 메시지 |
 
 #### 예제
@@ -209,6 +214,12 @@ curl -X POST \
 # Warden + Herald: /_send_verify_code가 반환한 challenge로 로그인
 curl -X POST \
      -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
+
+# Warden + TOTP: 등록된 인증기로 로그인
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&use_otp=true&otp_code=123456&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 ```

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -254,6 +254,7 @@ TOTP 分支直接提交 `use_otp=true` 和 `otp_code`，不需要预先调用 `P
 |--------|------|
 | `Idempotency-Key` | 可选。若提供，Stargate 会将其透传给 Herald；Herald 在 TTL 内对相同 key 的重复请求返回同一 challenge 响应。 |
 
+<!-- api-contract: send-verify-code-request-body -->
 #### 请求体
 
 请求体媒体类型支持情况：
@@ -440,8 +441,21 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 使用认证器应用生成的 6 位码确认 TOTP 绑定。
 
 - **认证**：要求会话由最近 10 分钟内成功登录创建。
-- **请求体**：`application/x-www-form-urlencoded` 或 `multipart/form-data` 表单数据，同时包含绑定页返回的 `enroll_id` 和 6 位 TOTP `code`；不支持 JSON 请求体。
-- **响应**：JSON。成功返回 `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`；绑定状态无效或过期返回 `400 Bad Request`，缺少最近认证返回 `401 Unauthorized`。
+
+<!-- api-contract: totp-enroll-confirm-request-body -->
+#### 请求体
+
+| 请求体媒体类型 | 支持 |
+|---------------|------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
+
+表单必须同时包含绑定页返回的 `enroll_id` 和 6 位 TOTP `code`。
+
+#### 响应
+
+JSON。成功返回 `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`；绑定状态无效或过期返回 `400 Bad Request`，缺少最近认证返回 `401 Unauthorized`。
 
 ### `GET /totp/revoke`
 

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -256,7 +256,13 @@ TOTP 分支直接提交 `use_otp=true` 和 `otp_code`，不需要预先调用 `P
 
 #### 请求体
 
-支持 `application/x-www-form-urlencoded` 或 `multipart/form-data` 表单数据，不支持 JSON 请求体：
+请求体媒体类型支持情况：
+
+| 请求体媒体类型 | 支持 |
+|---------------|------|
+| `application/x-www-form-urlencoded` | ✅ |
+| `multipart/form-data` | ✅ |
+| `application/json` | ❌ |
 
 | 字段 | 类型 | 必需 | 说明 |
 |------|------|------|------|

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -149,11 +149,13 @@ curl http://auth.example.com/_login?callback=app.example.com
 | 字段 | 类型 | 必需 | 说明 |
 |------|------|------|------|
 | `auth_method` | String | 是 | 认证方式，值为 `warden` |
-| `phone` | String | 否 | 用户手机号（与 `mail` 二选一） |
-| `mail` | String | 否 | 用户邮箱（与 `phone` 二选一） |
+| `phone` | String | 否 | 用户手机号；`phone` 与 `mail` 至少提供一项 |
+| `mail` | String | 否 | 用户邮箱；`mail` 与 `phone` 至少提供一项 |
 | `challenge_id` | String | 是 | Herald 返回的 challenge_id |
 | `verify_code` | String | 是 | 用户输入的验证码 |
 | `callback` | String | 否 | 登录成功后的回调 URL |
+
+Warden 请求也允许同时提交 `phone` + `mail`。
 
 #### Callback 获取优先级
 
@@ -188,7 +190,8 @@ curl http://auth.example.com/_login?callback=app.example.com
 
 | 状态码 | 说明 | 响应体 |
 |--------|------|--------|
-| `401 Unauthorized` | 密码错误 | 根据 Accept 头返回 JSON/XML/文本格式的错误消息 |
+| `400 Bad Request` | Warden 标识、challenge ID 或验证码无效或缺失 | 根据 Accept 头返回 JSON/XML/文本格式的错误消息 |
+| `401 Unauthorized` | 密码错误、Warden 用户不存在/未激活或验证码校验失败 | 根据 Accept 头返回 JSON/XML/文本格式的错误消息 |
 | `500 Internal Server Error` | 服务器错误 | 错误消息 |
 
 #### 示例
@@ -236,13 +239,15 @@ curl -X POST \
 
 #### 请求体
 
-仅支持表单数据（`application/x-www-form-urlencoded`）：
+支持 `application/x-www-form-urlencoded` 或 `multipart/form-data` 表单数据，不支持 JSON 请求体：
 
 | 字段 | 类型 | 必需 | 说明 |
 |------|------|------|------|
-| `phone` | String | 否 | 用户手机号（与 `mail` 二选一） |
-| `mail` | String | 否 | 用户邮箱（与 `phone` 二选一） |
-| `deliver_via` | String | 否 | 首选通道：`sms`、`email` 或 `dingtalk`。省略时，从 Warden 用户记录中选择已启用的可用通道。 |
+| `phone` | String | 否 | 用户手机号；`phone` 与 `mail` 至少提供一项 |
+| `mail` | String | 否 | 用户邮箱；`mail` 与 `phone` 至少提供一项 |
+| `deliver_via` | String | 否 | 首选通道：`sms`、`email` 或 `dingtalk`。省略时先尝试已启用的短信目标，再尝试邮件；不会自动选择钉钉，调用方必须显式发送 `deliver_via=dingtalk`。 |
+
+验证码请求也允许同时提交 `phone` + `mail`。
 
 #### 处理流程
 
@@ -252,9 +257,9 @@ curl -X POST \
    - 获取用户的 email 和 phone
 
 2. **Stargate → Herald**：创建 challenge 并发送验证码
-   - 使用 Warden 返回的 email/phone 作为 destination
+   - 使用 Warden 返回的 email、phone 或钉钉标识作为 destination
    - 调用 Herald API 创建 challenge
-   - Herald 发送验证码（SMS 或 Email）
+   - Herald 通过选定的短信、邮件或钉钉通道发送验证码
 
 3. **返回结果**：返回 challenge_id 和相关信息
 
@@ -398,37 +403,37 @@ curl "https://app.example.com/_session_exchange?ticket=<opaque_ticket>"
 
 ### `GET /totp/enroll`
 
-显示绑定确认页，但不创建绑定状态。要求最近认证的会话；未认证用户重定向到 `/_login`，超过 10 分钟的会话返回 `401 Unauthorized`。
+显示绑定确认页，但不创建绑定状态。要求最近认证的会话；未认证用户以 `302 Found` 重定向到 `/_login`，超过 10 分钟的会话返回 `401 Unauthorized`。
 
 ### `POST /totp/enroll`
 
 启动绑定并展示 TOTP 页面。使用 POST 可避免跨站导航创建绑定状态。
 
-- **认证**：要求会话由最近 10 分钟内成功登录创建。未认证用户重定向到 `/_login`，过期会话返回 `401 Unauthorized`。
-- **响应**：200 OK 返回绑定页 HTML；未认证时 302 到 `/_login`；配置或 Herald 错误时 400/503。
+- **认证**：要求会话由最近 10 分钟内成功登录创建。未认证用户以 `302 Found` 重定向到 `/_login`，过期会话返回 `401 Unauthorized`。
+- **响应**：200 OK 返回绑定页 HTML；未认证时以 `302 Found` 跳转到 `/_login`；配置或 Herald 错误时 400/503。
 
 ### `POST /totp/enroll/confirm`
 
 使用认证器应用生成的 6 位码确认 TOTP 绑定。
 
 - **认证**：要求会话由最近 10 分钟内成功登录创建。
-- **请求体**：表单数据（`application/x-www-form-urlencoded`），同时包含绑定页返回的 `enroll_id` 和 6 位 TOTP `code`。
-- **响应**：JSON。成功返回 `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`；绑定状态无效或过期返回 `400`，缺少最近认证返回 `401`。
+- **请求体**：`application/x-www-form-urlencoded` 或 `multipart/form-data` 表单数据，同时包含绑定页返回的 `enroll_id` 和 6 位 TOTP `code`；不支持 JSON 请求体。
+- **响应**：JSON。成功返回 `{"ok":true,"subject":"...","totp_enabled":true,"backup_codes":[...]}`；绑定状态无效或过期返回 `400 Bad Request`，缺少最近认证返回 `401 Unauthorized`。
 
 ### `GET /totp/revoke`
 
 展示 TOTP 解绑确认页。
 
-- **认证**：需要（会话 Cookie）。未认证用户会重定向到 `/_login`。
-- **响应**：200 OK 返回解绑确认页；未认证时 302 到 `/_login`。
+- **认证**：需要（会话 Cookie）。未认证用户会以 `302 Found` 重定向到 `/_login`。
+- **响应**：200 OK 返回解绑确认页；未认证时以 `302 Found` 跳转到 `/_login`。
 
 ### `POST /totp/revoke`
 
 确认 TOTP 解绑（从账号移除 TOTP）。
 
 - **认证**：需要（会话 Cookie）。
-- **请求体**：必须提供密码或当前有效的 TOTP `code`，用于最近认证确认。
-- **响应**：JSON。成功返回 `{"ok":true,"subject":"..."}`；重新认证失败返回 `401`，上游解绑失败返回 `502`。
+- **请求体**：必须提供 `password` 或当前有效的 TOTP `code`，用于重新认证确认。
+- **响应**：JSON。成功返回 `{"ok":true,"subject":"..."}`；重新认证失败返回 `401 Unauthorized`，上游解绑失败返回 `502 Bad Gateway`。
 
 **说明**：TOTP 的创建与校验由 Herald（可能代理到 herald-totp）完成。Stargate 仅负责页面与会话编排，不实现 OTP 算法。
 

--- a/docs/zhCN/API.md
+++ b/docs/zhCN/API.md
@@ -130,7 +130,7 @@ curl http://auth.example.com/_login?callback=app.example.com
 处理登录请求，支持两种认证模式：
 
 1. **密码认证模式**：验证密码并创建会话
-2. **Warden + Herald OTP 认证模式**：验证验证码并创建会话
+2. **Warden 认证模式**：验证 Herald challenge 验证码或已绑定的 TOTP 验证码并创建会话
 
 #### 请求体
 
@@ -144,18 +144,21 @@ curl http://auth.example.com/_login?callback=app.example.com
 | `password` | String | 是 | 用户密码 |
 | `callback` | String | 否 | 登录成功后的回调 URL |
 
-**Warden + Herald OTP 认证模式：**
+**Warden 认证模式：**
 
 | 字段 | 类型 | 必需 | 说明 |
 |------|------|------|------|
 | `auth_method` | String | 是 | 认证方式，值为 `warden` |
 | `phone` | String | 否 | 用户手机号；`phone` 与 `mail` 至少提供一项 |
 | `mail` | String | 否 | 用户邮箱；`mail` 与 `phone` 至少提供一项 |
-| `challenge_id` | String | 是 | Herald 返回的 challenge_id |
-| `verify_code` | String | 是 | 用户输入的验证码 |
+| `challenge_id` | String | 条件必需 | 使用 `verify_code` 时必需；`use_otp=true` 时可选 |
+| `verify_code` | String | 条件必需 | `use_otp` 未提供或为 `false` 时，用于 Herald challenge 验证且必须提供 |
+| `use_otp` | Boolean | 否 | 设为 `true` 时使用已绑定的 TOTP 认证器，而不是 Herald challenge 验证码 |
+| `otp_code` | String | 条件必需 | `use_otp=true` 时必须提供 |
 | `callback` | String | 否 | 登录成功后的回调 URL |
 
 Warden 请求也允许同时提交 `phone` + `mail`。
+TOTP 分支要求 `HERALD_TOTP_ENABLED=true` 且用户已经完成绑定；否则应使用 `challenge_id` + `verify_code` 分支。
 
 #### Callback 获取优先级
 
@@ -190,8 +193,10 @@ Warden 请求也允许同时提交 `phone` + `mail`。
 
 | 状态码 | 说明 | 响应体 |
 |--------|------|--------|
-| `400 Bad Request` | Warden 标识、challenge ID 或验证码无效或缺失 | 根据 Accept 头返回 JSON/XML/文本格式的错误消息 |
-| `401 Unauthorized` | 密码错误、Warden 用户不存在/未激活或验证码校验失败 | 根据 Accept 头返回 JSON/XML/文本格式的错误消息 |
+| `400 Bad Request` | Warden 标识或所选验证分支字段无效/缺失，或者用户尚未绑定 TOTP | 根据 Accept 头返回 JSON/XML/文本格式的错误消息 |
+| `401 Unauthorized` | 密码错误、Warden 用户不存在/未激活，或 challenge/TOTP 验证失败 | 根据 Accept 头返回 JSON/XML/文本格式的错误消息 |
+| `502 Bad Gateway` | Herald TOTP 状态查询失败 | 错误消息 |
+| `503 Service Unavailable` | Herald 验证服务不可用 | 错误消息 |
 | `500 Internal Server Error` | 服务器错误 | 错误消息 |
 
 #### 示例
@@ -206,12 +211,22 @@ curl -X POST \
      http://auth.example.com/_login
 ```
 
-**Warden + Herald OTP 认证：**
+**Warden + Herald challenge 认证：**
 
 ```bash
 # 提交登录表单（使用验证码）
 curl -X POST \
      -d "auth_method=warden&mail=user@example.com&challenge_id=ch_xxx&verify_code=123456&callback=app.example.com" \
+     -c cookies.txt \
+     http://auth.example.com/_login
+```
+
+**Warden + TOTP 认证器认证：**
+
+```bash
+# 使用已绑定认证器生成的 TOTP 验证码登录
+curl -X POST \
+     -d "auth_method=warden&mail=user@example.com&use_otp=true&otp_code=123456&callback=app.example.com" \
      -c cookies.txt \
      http://auth.example.com/_login
 ```
@@ -224,6 +239,8 @@ curl -X POST \
 4. 用户输入验证码，调用 `POST /_login` 进行验证
 5. Stargate 调用 Herald 验证验证码
 6. 验证成功后，Stargate 创建 session 并返回
+
+TOTP 分支直接提交 `use_otp=true` 和 `otp_code`，不需要预先调用 `POST /_send_verify_code`。
 
 ## 发送验证码端点
 


### PR DESCRIPTION
## Summary

- document both `application/x-www-form-urlencoded` and `multipart/form-data` for `POST /_send_verify_code` and `POST /totp/enroll/confirm` in all seven locales, while explicitly excluding JSON bodies
- align the German, French, Italian, Japanese, and Korean `POST /_login` contracts with the English and Chinese password/Warden field tables, required fields, status codes, and executable examples
- document the exact TOTP session rules: enrollment requires a login-created session no older than 10 minutes; revoke requires an authenticated session plus password or valid TOTP reauthentication
- clarify that omitted `deliver_via` falls back only across SMS/email and that DingTalk requires explicit `deliver_via=dingtalk`
- strengthen documentation contract checks and add localized negative self-tests so regressions outside English/Chinese fail CI

## Implementation facts verified

- the handlers read these payloads through Fiber `FormValue`
- the bundled Warden login and TOTP enrollment pages submit `FormData` (`multipart/form-data`)
- `selectVerificationDestination` never selects DingTalk from an omitted `deliver_via`
- enrollment routes enforce the 10-minute session age; revoke uses an authenticated session and explicit reauthentication

## Tests

- `bash .github/scripts/check-doc-contracts.sh`
- `bash .github/scripts/test-doc-contracts.sh`
- `bash -n .github/scripts/check-doc-contracts.sh`
- `bash -n .github/scripts/test-doc-contracts.sh`
- `git diff --check`

`go test -short ./...` was not run because the Go toolchain is unavailable in the execution environment; this PR changes documentation and shell contract checks only.