### PR TITLE
docs(deployment): clarify session storage and v1 upgrades

### DIFF
--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -255,6 +255,72 @@ contract_violation_count() {
       }
     }
 
+    for my $file (glob "$root/docs/*/DEPLOYMENT.md") {
+      open my $fh, "<", $file or die "open $file: $!";
+      local $/;
+      my $text = <$fh>;
+      for my $term (
+        "SESSION_STORAGE_ENABLED=false",
+        "SESSION_STORAGE_ENABLED=true",
+        "SESSION_STORAGE_REDIS_*",
+        "SESSION_EXCHANGE_SECRET",
+      ) {
+        next if index($text, $term) >= 0;
+        warn "Missing session-storage deployment scope $term in $file\n";
+        $count++;
+      }
+      for my $term (
+        "stargate-v0.12.0.env",
+        "stargate-v1.env",
+        "WARDEN_OTP_ENABLED",
+        "WARDEN_OTP_SECRET_KEY",
+        "HERALD_ENABLED=true",
+        "HERALD_TOTP_ENABLED=true",
+        "HERALD_URL",
+        "HERALD_TOTP_ENCRYPTION_KEY",
+        "--env-file ./stargate-v1.env",
+        q{chmod 600 "$old_env"},
+        q{set -C; cat "$old_env" > "$rollback_env"},
+        qq{awk \x27!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/\x27 "\$old_env" > "\$v1_env"},
+      ) {
+        next if index($text, $term) >= 0;
+        warn "Missing safe v1 environment migration contract $term in $file\n";
+        $count++;
+      }
+      if ($text !~ /`WARDEN_ENABLED=true`[^\n]*`WARDEN_URL`/) {
+        warn "Missing Warden prerequisites for Herald TOTP migration in $file\n";
+        $count++;
+      }
+    }
+
+    for my $file (glob "$root/docs/*/MIGRATION_V1.md") {
+      open my $fh, "<", $file or die "open $file: $!";
+      local $/;
+      my $text = <$fh>;
+      for my $term (
+        "stargate-v0.12.0.env",
+        "stargate-v1.env",
+        "WARDEN_OTP_ENABLED",
+        "WARDEN_OTP_SECRET_KEY",
+        "HERALD_ENABLED=true",
+        "HERALD_TOTP_ENABLED=true",
+        "HERALD_URL",
+        "HERALD_TOTP_ENCRYPTION_KEY",
+        "--env-file ./stargate-v1.env",
+        q{chmod 600 "$old_env"},
+        q{set -C; cat "$old_env" > "$rollback_env"},
+        qq{awk \x27!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/\x27 "\$old_env" > "\$v1_env"},
+      ) {
+        next if index($text, $term) >= 0;
+        warn "Missing v1 migration environment contract $term in $file\n";
+        $count++;
+      }
+      if ($text !~ /`WARDEN_ENABLED=true`[^\n]*`WARDEN_URL`/) {
+        warn "Missing Warden prerequisites for Herald TOTP migration in $file\n";
+        $count++;
+      }
+    }
+
     my $changelog_path = "$root/CHANGELOG.md";
     open my $changelog_fh, "<", $changelog_path or die "open $changelog_path: $!";
     local $/;
@@ -278,7 +344,6 @@ contract_violation_count() {
     }
 
     my @patterns = (
-      ["retired Warden OTP setting", qr/\bWARDEN_OTP_(?:ENABLED|SECRET_KEY)\b/],
       ["legacy Redis setting", qr/\b(?:REDIS_ENABLED|REDIS_ADDR|REDIS_PASSWORD)\b/],
       ["stale Fiber version", qr/Fiber v2\.52/],
       ["invalid bcrypt command", qr/go run -c [^\n]*golang\.org\/x\/crypto\/bcrypt/],
@@ -299,6 +364,19 @@ contract_violation_count() {
         open my $fh, "<", $file or die "open $file: $!";
         local $/;
         my $text = <$fh>;
+
+        my $retired_text = $text;
+        if ($file =~ m{/(?:DEPLOYMENT|MIGRATION_V1)\.md$}) {
+          # Migration guidance may name retired settings only as exact inline-code
+          # identifiers. Any remaining occurrence is an executable or ambiguous
+          # use and would make v1 reject the environment at startup.
+          $retired_text =~ s/`WARDEN_OTP_ENABLED`//g;
+          $retired_text =~ s/`WARDEN_OTP_SECRET_KEY`//g;
+        }
+        while ($retired_text =~ /\bWARDEN_OTP_(?:ENABLED|SECRET_KEY)\b/g) {
+          warn "active or ambiguous retired Warden OTP setting in $file\n";
+          $count++;
+        }
 
         for my $entry (@patterns) {
           my ($label, $pattern) = @$entry;

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -279,9 +279,15 @@ contract_violation_count() {
         "HERALD_URL",
         "HERALD_TOTP_ENCRYPTION_KEY",
         "--env-file ./stargate-v1.env",
+        q{old_container=${STARGATE_OLD_CONTAINER:-stargate}},
+        q{mktemp "${old_env}.tmp.XXXXXX"},
+        qq{docker inspect --format \x27{{range .Config.Env}}{{println .}}{{end}}\x27 "\$old_container"},
+        q{ln "$export_tmp" "$old_env"},
         q{chmod 600 "$old_env"},
         q{set -C; cat "$old_env" > "$rollback_env"},
-        qq{awk \x27!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|\$)/\x27 "\$old_env" > "\$v1_env"},
+        q{WARDEN_OTP_(ENABLED|SECRET_KEY)},
+        q{PORT[[:space:]]*(=|$)},
+        q{print "PORT=8080"},
       ) {
         next if index($text, $term) >= 0;
         warn "Missing safe v1 environment migration contract $term in $file\n";
@@ -307,9 +313,15 @@ contract_violation_count() {
         "HERALD_URL",
         "HERALD_TOTP_ENCRYPTION_KEY",
         "--env-file ./stargate-v1.env",
+        q{old_container=${STARGATE_OLD_CONTAINER:-stargate}},
+        q{mktemp "${old_env}.tmp.XXXXXX"},
+        qq{docker inspect --format \x27{{range .Config.Env}}{{println .}}{{end}}\x27 "\$old_container"},
+        q{ln "$export_tmp" "$old_env"},
         q{chmod 600 "$old_env"},
         q{set -C; cat "$old_env" > "$rollback_env"},
-        qq{awk \x27!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|\$)/\x27 "\$old_env" > "\$v1_env"},
+        q{WARDEN_OTP_(ENABLED|SECRET_KEY)},
+        q{PORT[[:space:]]*(=|$)},
+        q{print "PORT=8080"},
       ) {
         next if index($text, $term) >= 0;
         warn "Missing v1 migration environment contract $term in $file\n";

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -281,7 +281,7 @@ contract_violation_count() {
         "--env-file ./stargate-v1.env",
         q{chmod 600 "$old_env"},
         q{set -C; cat "$old_env" > "$rollback_env"},
-        qq{awk \x27!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/\x27 "\$old_env" > "\$v1_env"},
+        qq{awk \x27!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|\$)/\x27 "\$old_env" > "\$v1_env"},
       ) {
         next if index($text, $term) >= 0;
         warn "Missing safe v1 environment migration contract $term in $file\n";
@@ -309,7 +309,7 @@ contract_violation_count() {
         "--env-file ./stargate-v1.env",
         q{chmod 600 "$old_env"},
         q{set -C; cat "$old_env" > "$rollback_env"},
-        qq{awk \x27!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/\x27 "\$old_env" > "\$v1_env"},
+        qq{awk \x27!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|\$)/\x27 "\$old_env" > "\$v1_env"},
       ) {
         next if index($text, $term) >= 0;
         warn "Missing v1 migration environment contract $term in $file\n";

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -133,11 +133,18 @@ printf '%s\n' \
   'WARDEN_OTP_SECRET_KEY' \
   'WARDEN_OTP_ENABLED=false' \
   'WARDEN_OTP_SECRET_KEY=retired-secret' \
+  'PORT=80' \
   > "$env_test_dir/stargate.env"
 chmod 644 "$env_test_dir/stargate.env"
 (cd "$env_test_dir" && sh -c "$migration_script")
 cmp "$env_test_dir/stargate.env" "$env_test_dir/stargate-v0.12.0.env"
 grep -q '^KEEP_SETTING=kept$' "$env_test_dir/stargate-v1.env"
+grep -q '^PORT=80$' "$env_test_dir/stargate-v0.12.0.env"
+grep -q '^PORT=8080$' "$env_test_dir/stargate-v1.env"
+if grep -q '^PORT=80$' "$env_test_dir/stargate-v1.env"; then
+  echo "Documented v1 environment retained the legacy container port" >&2
+  exit 1
+fi
 if grep -q '^WARDEN_OTP_\(ENABLED\|SECRET_KEY\)\($\|=\)' "$env_test_dir/stargate-v1.env"; then
   echo "Documented v1 environment retained a retired Warden OTP setting" >&2
   exit 1
@@ -156,6 +163,30 @@ if (cd "$env_test_dir" && sh -c "$migration_script" >/dev/null 2>&1); then
 fi
 [[ "$rollback_checksum" == "$(cksum "$env_test_dir/stargate-v0.12.0.env")" ]]
 [[ "$v1_checksum" == "$(cksum "$env_test_dir/stargate-v1.env")" ]]
+
+# A deployment without an existing env file must be recoverable from the old
+# container without exposing secrets or leaving a partial output on failure.
+export_test_dir="$temp_dir/env-export-test"
+mkdir -p "$export_test_dir/bin"
+printf '%s\n' \
+  '#!/bin/sh' \
+  'printf "%s\\n" KEEP_SETTING=from-container WARDEN_OTP_ENABLED=true PORT=80' \
+  > "$export_test_dir/bin/docker"
+chmod +x "$export_test_dir/bin/docker"
+(cd "$export_test_dir" && PATH="$export_test_dir/bin:$PATH" sh -c "$migration_script")
+cmp "$export_test_dir/stargate.env" "$export_test_dir/stargate-v0.12.0.env"
+grep -q '^KEEP_SETTING=from-container$' "$export_test_dir/stargate-v1.env"
+grep -q '^PORT=8080$' "$export_test_dir/stargate-v1.env"
+if grep -q '^WARDEN_OTP_ENABLED\($\|=\)' "$export_test_dir/stargate-v1.env"; then
+  echo "Exported v1 environment retained a retired Warden OTP setting" >&2
+  exit 1
+fi
+for file in stargate.env stargate-v0.12.0.env stargate-v1.env; do
+  if [[ "$(stat -c '%a' "$export_test_dir/$file")" != "600" ]]; then
+    echo "Exported environment migration left $file with non-private permissions" >&2
+    exit 1
+  fi
+done
 
 perl -0pi -e 's/^- `Stargate-Password` request-header authentication .*\n//m' "$temp_dir/CHANGELOG.md"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -12,7 +12,9 @@ git -C "$repo_root" archive HEAD | tar -x -C "$temp_dir"
 cp "$repo_root/.github/scripts/check-doc-contracts.sh" "$temp_dir/.github/scripts/check-doc-contracts.sh"
 cp "$repo_root/CHANGELOG.md" "$temp_dir/CHANGELOG.md"
 cp "$repo_root/docker-compose.yml" "$temp_dir/docker-compose.yml"
-for file in "$repo_root"/docs/*/API.md "$repo_root"/docs/*/CONFIG.md "$repo_root"/docs/*/SECURITY.md "$repo_root"/docs/*/DEPLOYMENT.md; do
+for file in "$repo_root"/docs/*/API.md "$repo_root"/docs/*/CONFIG.md \
+  "$repo_root"/docs/*/DEPLOYMENT.md "$repo_root"/docs/*/MIGRATION_V1.md \
+  "$repo_root"/docs/*/SECURITY.md; do
   relative=${file#"$repo_root"/}
   cp "$file" "$temp_dir/$relative"
 done
@@ -57,6 +59,101 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 git -C "$temp_dir" checkout -q -- CHANGELOG.md
+
+# Cross-domain support in one process must not regress to a blanket Redis requirement.
+perl -0pi -e 's/SESSION_STORAGE_ENABLED=false/SESSION_STORAGE_IN_MEMORY=unknown/' "$temp_dir/docs/enUS/DEPLOYMENT.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a process-local session storage scope failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/DEPLOYMENT.md
+
+# The v1 environment must be separate and must omit both retired Warden OTP names.
+perl -0pi -e 's/--env-file \.\/stargate-v1\.env/--env-file .\/stargate.env/' "$temp_dir/docs/enUS/DEPLOYMENT.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a separate v1 environment-file contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/DEPLOYMENT.md
+
+perl -0pi -e 's/`WARDEN_OTP_SECRET_KEY`/`WARDEN_OTP_KEY`/' "$temp_dir/docs/enUS/MIGRATION_V1.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a retired Warden OTP removal contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/MIGRATION_V1.md
+
+# Herald-backed TOTP also requires Warden user resolution.
+perl -0pi -e 's/`WARDEN_URL`/`WARDEN_ENDPOINT`/' "$temp_dir/docs/enUS/MIGRATION_V1.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a Herald TOTP Warden prerequisite contract failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/MIGRATION_V1.md
+
+# Migration guidance may name retired variables, but must never make them active again.
+printf '\n```bash\nWARDEN_OTP_ENABLED=true\nWARDEN_OTP_SECRET_KEY=unsafe\n```\n' \
+  >> "$temp_dir/docs/enUS/DEPLOYMENT.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an active retired Warden OTP assignment failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/DEPLOYMENT.md
+
+# Compose mapping syntax is also an active environment assignment.
+printf '\n```yaml\nenvironment:\n  WARDEN_OTP_ENABLED: "true"\n  WARDEN_OTP_SECRET_KEY: "unsafe"\n```\n' \
+  >> "$temp_dir/docs/enUS/MIGRATION_V1.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a retired Warden OTP mapping assignment failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/MIGRATION_V1.md
+
+# A valueless export can forward a retired value inherited from the parent shell.
+printf '\n```bash\nexport WARDEN_OTP_ENABLED\n```\n' \
+  >> "$temp_dir/docs/enUS/MIGRATION_V1.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a valueless retired Warden OTP export failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/MIGRATION_V1.md
+
+# Execute the documented transformation and verify both filtering and no-clobber behavior.
+env_test_dir="$temp_dir/env-migration-test"
+mkdir "$env_test_dir"
+migration_script=$(perl -0ne 'print $1 if /```bash\n(set -eu\nold_env=\.\/stargate\.env.*?\n)```/s' \
+  "$temp_dir/docs/enUS/MIGRATION_V1.md")
+if [[ -z "$migration_script" ]]; then
+  echo "Could not extract the documented environment migration commands" >&2
+  exit 1
+fi
+printf '%s\n' \
+  'KEEP_SETTING=kept' \
+  'WARDEN_OTP_ENABLED=false' \
+  'WARDEN_OTP_SECRET_KEY=retired-secret' \
+  > "$env_test_dir/stargate.env"
+chmod 644 "$env_test_dir/stargate.env"
+(cd "$env_test_dir" && sh -c "$migration_script")
+cmp "$env_test_dir/stargate.env" "$env_test_dir/stargate-v0.12.0.env"
+grep -q '^KEEP_SETTING=kept$' "$env_test_dir/stargate-v1.env"
+if grep -q '^WARDEN_OTP_\(ENABLED\|SECRET_KEY\)=' "$env_test_dir/stargate-v1.env"; then
+  echo "Documented v1 environment retained a retired Warden OTP setting" >&2
+  exit 1
+fi
+for file in stargate.env stargate-v0.12.0.env stargate-v1.env; do
+  if [[ "$(stat -c '%a' "$env_test_dir/$file")" != "600" ]]; then
+    echo "Documented environment migration left $file with non-private permissions" >&2
+    exit 1
+  fi
+done
+rollback_checksum=$(cksum "$env_test_dir/stargate-v0.12.0.env")
+v1_checksum=$(cksum "$env_test_dir/stargate-v1.env")
+if (cd "$env_test_dir" && sh -c "$migration_script" >/dev/null 2>&1); then
+  echo "Documented environment migration unexpectedly overwrote existing files" >&2
+  exit 1
+fi
+[[ "$rollback_checksum" == "$(cksum "$env_test_dir/stargate-v0.12.0.env")" ]]
+[[ "$v1_checksum" == "$(cksum "$env_test_dir/stargate-v1.env")" ]]
 
 perl -0pi -e 's/^- `Stargate-Password` request-header authentication .*\n//m' "$temp_dir/CHANGELOG.md"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -129,6 +129,8 @@ if [[ -z "$migration_script" ]]; then
 fi
 printf '%s\n' \
   'KEEP_SETTING=kept' \
+  'WARDEN_OTP_ENABLED' \
+  'WARDEN_OTP_SECRET_KEY' \
   'WARDEN_OTP_ENABLED=false' \
   'WARDEN_OTP_SECRET_KEY=retired-secret' \
   > "$env_test_dir/stargate.env"
@@ -136,7 +138,7 @@ chmod 644 "$env_test_dir/stargate.env"
 (cd "$env_test_dir" && sh -c "$migration_script")
 cmp "$env_test_dir/stargate.env" "$env_test_dir/stargate-v0.12.0.env"
 grep -q '^KEEP_SETTING=kept$' "$env_test_dir/stargate-v1.env"
-if grep -q '^WARDEN_OTP_\(ENABLED\|SECRET_KEY\)=' "$env_test_dir/stargate-v1.env"; then
+if grep -q '^WARDEN_OTP_\(ENABLED\|SECRET_KEY\)\($\|=\)' "$env_test_dir/stargate-v1.env"; then
   echo "Documented v1 environment retained a retired Warden OTP setting" >&2
   exit 1
 fi

--- a/docs/deDE/DEPLOYMENT.md
+++ b/docs/deDE/DEPLOYMENT.md
@@ -674,14 +674,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# Falls die Datei fehlt, die Umgebung des vorhandenen Containers geschützt exportieren.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald-basiertes TOTP erfordert, dass Stargate authentifizierte Benutzer über Warden auflöst. Daher auch `WARDEN_ENABLED=true` und `WARDEN_URL` setzen.

--- a/docs/deDE/DEPLOYMENT.md
+++ b/docs/deDE/DEPLOYMENT.md
@@ -437,7 +437,12 @@ services:
       replicas: 3
 ```
 
-**Erforderlich:** Für mehrere Instanzen, Rolling Upgrades und domänenübergreifende Bereitstellungen muss Redis-Sitzungsspeicher aktiviert werden (`SESSION_STORAGE_ENABLED=true` und `SESSION_STORAGE_REDIS_*`). Redis teilt Sitzungen und den Replay-Status einmaliger Tickets zwischen allen Replikaten. Sticky Sessions allein werden nicht unterstützt und dürfen nur zusätzlich zur Routing-Optimierung eingesetzt werden.
+**Geltungsbereich des Sitzungsspeichers:**
+
+- **Ein Prozess / ein Replikat, einschließlich domänenübergreifender Callbacks:** Der In-Memory-Speicher (`SESSION_STORAGE_ENABLED=false`) wird unterstützt, wenn Ausstellung und Einlösung des Tickets sowie die anschließende Sitzungsnutzung denselben laufenden Stargate-Prozess erreichen. Sitzungen und Hashes verbrauchter Tickets existieren nur in diesem Prozess. Bei einem Neustart gehen beide Speicher verloren; aktive Sitzungen werden ungültig und der Einmalstatus der Tickets bleibt nicht erhalten.
+- **Mehrere Prozesse oder Replikate:** Redis ist zwingend, sobald Sitzungen oder Tickets von verschiedenen Prozessen verarbeitet werden können. `SESSION_STORAGE_ENABLED=true`, denselben `SESSION_STORAGE_REDIS_*`-Namensraum und dasselbe `SESSION_EXCHANGE_SECRET` auf allen Replikaten verwenden. Sticky Sessions sind nur eine Routing-Optimierung und kein Ersatz für gemeinsamen Zustand oder prozessübergreifenden Replay-Schutz.
+- **Rolling Upgrade:** Für einen unterbrechungsfreien Austausch ist Redis erforderlich, da alte und neue Prozesse gleichzeitig laufen. Ohne Redis Stop-then-Start verwenden und ungültige Sitzungen sowie erneute Anmeldung akzeptieren. v0.12.0 und v1.0.0 niemals im selben Serving-Pool mischen.
+- **Zustand über Prozessneustarts hinweg:** Redis ist erforderlich, wenn Sitzungen oder der Replay-Status verbrauchter Tickets einen Prozesswechsel oder Neustart überdauern müssen.
 
 #### 2. Lastverteilung
 
@@ -662,13 +667,28 @@ Wenn Sie Probleme haben:
 
 ### Aktualisierungsschritte
 
-1. **Wiederverwendbare Umgebungsdatei vorbereiten:** Die aktuelle Konfiguration in `stargate.env` speichern und die Datei schützen.
+1. **Getrennte Rollback- und v1-Umgebungsdateien erstellen:** Die vorhandene `stargate.env` unverändert lassen. Die folgenden Befehle überschreiben keine vorhandenen Zieldateien und entfernen die veralteten Warden-OTP-Einstellungen nur aus der neuen v1-Datei.
 
 ```bash
-chmod 600 stargate.env
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
 ```
 
-2. **Vorherigen Container für den Rollback behalten:**
+Herald-basiertes TOTP erfordert, dass Stargate authentifizierte Benutzer über Warden auflöst. Daher auch `WARDEN_ENABLED=true` und `WARDEN_URL` setzen.
+
+v1 lehnt `WARDEN_OTP_ENABLED` und `WARDEN_OTP_SECRET_KEY` bereits bei bloßer Anwesenheit ab, auch bei leeren oder `false` Werten. Nicht wieder hinzufügen. Für TOTP in `stargate-v1.env` `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL` und eine unterstützte Herald-Serviceauthentifizierung konfigurieren. Zusätzlich den TOTP-Proxy in Herald und einen unabhängigen `HERALD_TOTP_ENCRYPTION_KEY` in herald-totp konfigurieren; das alte Warden-Secret nicht automatisch wiederverwenden. Siehe [Konfiguration](CONFIG.md).
+
+2. **Vorherigen Container und seine ursprüngliche Umgebung für den Rollback behalten:**
 
 ```bash
 docker stop stargate
@@ -686,7 +706,7 @@ docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```bash
 docker run -d \
   --name stargate \
-  --env-file ./stargate.env \
+  --env-file ./stargate-v1.env \
   -p 8080:8080 \
   --restart unless-stopped \
   ghcr.io/soulteary/stargate:v1.0.0
@@ -704,7 +724,8 @@ curl --fail http://127.0.0.1:8080/readyz
 Wenn nach der Aktualisierung Probleme auftreten:
 
 ```bash
-# Neuen Container entfernen und den unveränderten alten Container wiederherstellen
+# Neuen Container entfernen und den unveränderten alten Container wiederherstellen.
+# stargate-v0.12.0.env als Rollback-Konfigurationsnachweis behalten.
 docker rm -f stargate
 docker rename stargate-previous stargate
 docker start stargate

--- a/docs/deDE/DEPLOYMENT.md
+++ b/docs/deDE/DEPLOYMENT.md
@@ -681,7 +681,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald-basiertes TOTP erfordert, dass Stargate authentifizierte Benutzer über Warden auflöst. Daher auch `WARDEN_ENABLED=true` und `WARDEN_URL` setzen.

--- a/docs/deDE/MIGRATION_V1.md
+++ b/docs/deDE/MIGRATION_V1.md
@@ -7,7 +7,32 @@ Stargate v1.0.0 definiert stabile Bereitstellungs- und HTTP-Verträge. Die Umste
 1. Image, Umgebungsvariablen, Proxy-Routen, Callback-Hosts und Probes dokumentieren.
 2. Das Image `v0.12.0` und den unveränderten Container für einen Rollback behalten.
 3. Alle Aufrufer von `/_logout`, `/totp/enroll` und `/_session_exchange` erfassen.
-4. Bei mehreren Replikaten Redis-Sitzungsspeicher vorbereiten.
+4. Redis vorbereiten, wenn mehrere Prozesse Traffic bedienen, alte und neue Prozesse während des Rollouts überlappen oder Sitzungen und verbrauchte Tickets einen Neustart überdauern müssen. Ein einzelner laufender Prozess darf auch bei Cross-Domain-Callbacks In-Memory-Speicher verwenden; der Zustand ist jedoch prozesslokal und geht beim Neustart verloren.
+
+## Rollback-Konfiguration erhalten und v1-Umgebung erstellen
+
+v1 nicht mit der alten Umgebungsdatei starten. `stargate.env` unverändert lassen und den v0.12.0-Container behalten. Diese Befehle erstellen eine geschützte Rollback-Kopie und eine getrennte v1-Datei, überschreiben keine vorhandene Ausgabe und entfernen die veralteten Einstellungen nur aus der v1-Datei:
+
+```bash
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+```
+
+Herald-basiertes TOTP erfordert, dass Stargate authentifizierte Benutzer über Warden auflöst. Daher auch `WARDEN_ENABLED=true` und `WARDEN_URL` setzen.
+
+v1 lehnt `WARDEN_OTP_ENABLED` und `WARDEN_OTP_SECRET_KEY` ab, sobald eine Variable vorhanden ist, auch leer oder `false`. Nicht zu `stargate-v1.env` hinzufügen. Für TOTP in Stargate `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL` und eine unterstützte Herald-Serviceauthentifizierung konfigurieren. Herald muss TOTP an herald-totp weiterleiten; herald-totp benötigt einen eigenen `HERALD_TOTP_ENCRYPTION_KEY`. Das alte Warden-Secret nicht automatisch wiederverwenden. Siehe [Konfiguration](CONFIG.md).
+
+v1 mit `--env-file ./stargate-v1.env` prüfen und starten. `stargate-v0.12.0.env`, die unveränderte Originaldatei und den alten Container bis zum Ende des Rollback-Fensters behalten.
 
 ## Erforderliche Änderungen
 

--- a/docs/deDE/MIGRATION_V1.md
+++ b/docs/deDE/MIGRATION_V1.md
@@ -25,7 +25,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald-basiertes TOTP erfordert, dass Stargate authentifizierte Benutzer über Warden auflöst. Daher auch `WARDEN_ENABLED=true` und `WARDEN_URL` setzen.

--- a/docs/deDE/MIGRATION_V1.md
+++ b/docs/deDE/MIGRATION_V1.md
@@ -18,14 +18,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# Falls die Datei fehlt, die Umgebung des vorhandenen Containers geschützt exportieren.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald-basiertes TOTP erfordert, dass Stargate authentifizierte Benutzer über Warden auflöst. Daher auch `WARDEN_ENABLED=true` und `WARDEN_URL` setzen.

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -674,14 +674,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# If the file is missing, export the existing container environment securely.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald-backed TOTP requires Stargate to resolve authenticated users through Warden, so also set `WARDEN_ENABLED=true` and `WARDEN_URL`.

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -681,7 +681,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald-backed TOTP requires Stargate to resolve authenticated users through Warden, so also set `WARDEN_ENABLED=true` and `WARDEN_URL`.

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -437,7 +437,12 @@ services:
       replicas: 3
 ```
 
-**Required:** Multi-instance, rolling-upgrade, and cross-domain deployments must enable Redis session storage (`SESSION_STORAGE_ENABLED=true` and configure `SESSION_STORAGE_REDIS_*`). Redis shares both sessions and single-use ticket replay state across replicas. Load-balancer sticky sessions alone are not supported; they may be used only as an additional routing optimization.
+**Session storage scope:**
+
+- **One process / one replica, including cross-domain callbacks:** in-memory storage (`SESSION_STORAGE_ENABLED=false`) is supported when ticket issuance, ticket redemption, and subsequent session use all reach the same live Stargate process. Session records and consumed-ticket hashes exist only in that process. A restart loses both stores, invalidates active sessions, and means single-use ticket state is not retained across the restart.
+- **Multiple processes or replicas:** Redis is required whenever a session or exchange ticket may be handled by different processes. Set `SESSION_STORAGE_ENABLED=true`, configure the same `SESSION_STORAGE_REDIS_*` namespace, and use the same `SESSION_EXCHANGE_SECRET` on every replica. Sticky sessions are only a routing optimization; they do not provide shared state or cross-process replay protection.
+- **Rolling upgrade:** Redis is required for an uninterrupted rolling replacement because old and new processes overlap. Without Redis, use a stop-then-start upgrade and accept session invalidation and fresh login. Never mix v0.12.0 and v1.0.0 in one serving pool.
+- **State across a process restart:** Redis is required whenever sessions or consumed-ticket replay state must survive a process replacement or restart.
 
 #### 2. Load Balancing
 
@@ -662,13 +667,28 @@ If you encounter problems:
 
 ### Upgrade Steps
 
-1. **Prepare a reusable environment file:** Copy the current container settings into `stargate.env`, keep secrets out of shell history, and restrict the file permissions.
+1. **Create separate rollback and v1 environment files:** Keep the existing `stargate.env` unchanged. The commands below refuse to overwrite either output file and remove the retired Warden OTP settings only from the new v1 file.
 
 ```bash
-chmod 600 stargate.env
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
 ```
 
-2. **Keep the previous container for rollback:**
+Herald-backed TOTP requires Stargate to resolve authenticated users through Warden, so also set `WARDEN_ENABLED=true` and `WARDEN_URL`.
+
+v1 rejects `WARDEN_OTP_ENABLED` and `WARDEN_OTP_SECRET_KEY` whenever either name is present, including empty or `false` values. Do not copy them back. If TOTP is needed, configure Stargate in `stargate-v1.env` with `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL`, and one supported Herald service-auth method. Configure Herald's TOTP proxy and herald-totp's independent `HERALD_TOTP_ENCRYPTION_KEY`; do not automatically reuse the retired Warden secret. See [Configuration](CONFIG.md).
+
+2. **Keep the previous container and its original environment for rollback:**
 
 ```bash
 docker stop stargate
@@ -686,7 +706,7 @@ docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```bash
 docker run -d \
   --name stargate \
-  --env-file ./stargate.env \
+  --env-file ./stargate-v1.env \
   -p 8080:8080 \
   --restart unless-stopped \
   ghcr.io/soulteary/stargate:v1.0.0
@@ -704,7 +724,8 @@ curl --fail http://127.0.0.1:8080/readyz
 If problems occur after upgrade:
 
 ```bash
-# Remove the new container and restore the unchanged previous container
+# Remove the new container and restore the unchanged previous container.
+# Keep stargate-v0.12.0.env as the rollback configuration record.
 docker rm -f stargate
 docker rename stargate-previous stargate
 docker start stargate

--- a/docs/enUS/MIGRATION_V1.md
+++ b/docs/enUS/MIGRATION_V1.md
@@ -18,14 +18,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# If the file is missing, export the existing container environment securely.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald-backed TOTP requires Stargate to resolve authenticated users through Warden, so also set `WARDEN_ENABLED=true` and `WARDEN_URL`.

--- a/docs/enUS/MIGRATION_V1.md
+++ b/docs/enUS/MIGRATION_V1.md
@@ -25,7 +25,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald-backed TOTP requires Stargate to resolve authenticated users through Warden, so also set `WARDEN_ENABLED=true` and `WARDEN_URL`.

--- a/docs/enUS/MIGRATION_V1.md
+++ b/docs/enUS/MIGRATION_V1.md
@@ -7,7 +7,32 @@ Stargate v1.0.0 establishes the first stable deployment and HTTP contracts. It a
 1. Record the current image, environment variables, proxy routes, callback hosts, and health probes.
 2. Back up the deployment configuration and keep the v0.12.0 image available for rollback.
 3. Identify every caller of `/_logout`, `/totp/enroll`, and the cross-domain session exchange route.
-4. If more than one Stargate replica is running, prepare Redis-backed session storage before upgrading.
+4. Prepare Redis before upgrading if multiple processes will serve traffic, the rollout overlaps old and new processes, or session and consumed-ticket state must survive a restart. A single live process may use in-memory storage even for cross-domain callbacks, but all state is process-local and is lost on restart.
+
+## Preserve rollback configuration and build the v1 environment
+
+Do not start v1 with the old environment file. Keep `stargate.env` unchanged and keep the v0.12.0 container. The following commands create a protected rollback copy and a separate v1 file, refuse to overwrite either output, and remove the retired settings only from the v1 file:
+
+```bash
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+```
+
+Herald-backed TOTP requires Stargate to resolve authenticated users through Warden, so also set `WARDEN_ENABLED=true` and `WARDEN_URL`.
+
+v1 rejects `WARDEN_OTP_ENABLED` and `WARDEN_OTP_SECRET_KEY` whenever either variable is present, including empty or `false` values. Do not add them to `stargate-v1.env`. For TOTP, configure Stargate with `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL`, and one supported Herald service-auth method. Configure Herald to proxy TOTP to herald-totp, and configure herald-totp with its own `HERALD_TOTP_ENCRYPTION_KEY`; do not automatically reuse the retired Warden secret. See [Configuration](CONFIG.md).
+
+Validate and deploy v1 with `--env-file ./stargate-v1.env`. Keep `stargate-v0.12.0.env`, the unchanged original file, and the old container until the rollback window closes.
 
 ## Required deployment changes
 

--- a/docs/frFR/DEPLOYMENT.md
+++ b/docs/frFR/DEPLOYMENT.md
@@ -681,7 +681,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Le TOTP via Herald exige que Stargate résolve les utilisateurs authentifiés par Warden ; configurez donc aussi `WARDEN_ENABLED=true` et `WARDEN_URL`.

--- a/docs/frFR/DEPLOYMENT.md
+++ b/docs/frFR/DEPLOYMENT.md
@@ -437,7 +437,12 @@ services:
       replicas: 3
 ```
 
-**Obligatoire :** Les déploiements multi-instances, les mises à niveau progressives et les scénarios inter-domaines doivent activer le stockage Redis (`SESSION_STORAGE_ENABLED=true` et `SESSION_STORAGE_REDIS_*`). Redis partage les sessions et l'état anti-rejeu des tickets à usage unique entre les réplicas. Les Sticky Sessions seules ne sont pas prises en charge et ne peuvent servir que d'optimisation de routage supplémentaire.
+**Périmètre du stockage de session :**
+
+- **Un processus / une réplique, y compris avec des callbacks inter-domaines :** le stockage en mémoire (`SESSION_STORAGE_ENABLED=false`) est pris en charge si l'émission, l'échange du ticket et l'utilisation ultérieure de la session atteignent le même processus Stargate actif. Les sessions et les empreintes de tickets consommés n'existent que dans ce processus. Un redémarrage perd les deux états, invalide les sessions actives et ne conserve pas l'usage unique des tickets.
+- **Plusieurs processus ou répliques :** Redis est obligatoire dès qu'une session ou un ticket peut être traité par des processus différents. Utilisez `SESSION_STORAGE_ENABLED=true`, le même espace `SESSION_STORAGE_REDIS_*` et le même `SESSION_EXCHANGE_SECRET` sur toutes les répliques. Les Sticky Sessions ne sont qu'une optimisation de routage et ne remplacent ni l'état partagé ni la protection anti-rejeu inter-processus.
+- **Mise à niveau progressive :** Redis est obligatoire pour un remplacement sans interruption, car anciens et nouveaux processus se chevauchent. Sans Redis, arrêtez puis démarrez le service et acceptez l'invalidation des sessions et une nouvelle connexion. Ne mélangez jamais v0.12.0 et v1.0.0 dans le même pool.
+- **État persistant après redémarrage :** Redis est obligatoire si les sessions ou l'état anti-rejeu des tickets consommés doivent survivre au remplacement ou au redémarrage d'un processus.
 
 #### 2. Répartition de Charge
 
@@ -662,13 +667,28 @@ Si vous rencontrez des problèmes :
 
 ### Étapes de Mise à Jour
 
-1. **Préparer un fichier d'environnement réutilisable** : enregistrer la configuration dans `stargate.env` et protéger ce fichier.
+1. **Créer des fichiers d'environnement distincts pour le retour arrière et v1** : conserver `stargate.env` sans modification. Les commandes suivantes refusent d'écraser les fichiers cibles et retirent les anciens paramètres Warden OTP uniquement du nouveau fichier v1.
 
 ```bash
-chmod 600 stargate.env
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
 ```
 
-2. **Conserver l'ancien conteneur pour le retour en arrière :**
+Le TOTP via Herald exige que Stargate résolve les utilisateurs authentifiés par Warden ; configurez donc aussi `WARDEN_ENABLED=true` et `WARDEN_URL`.
+
+v1 refuse `WARDEN_OTP_ENABLED` et `WARDEN_OTP_SECRET_KEY` dès que l'un de ces noms est présent, même vide ou à `false`. Ne les réintroduisez pas. Pour TOTP, configurez dans `stargate-v1.env` `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL` et une méthode d'authentification de service Herald prise en charge. Configurez aussi le proxy TOTP de Herald et un `HERALD_TOTP_ENCRYPTION_KEY` indépendant dans herald-totp ; ne réutilisez pas automatiquement l'ancien secret Warden. Voir la [configuration](CONFIG.md).
+
+2. **Conserver l'ancien conteneur et son environnement d'origine pour le retour en arrière :**
 
 ```bash
 docker stop stargate
@@ -686,7 +706,7 @@ docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```bash
 docker run -d \
   --name stargate \
-  --env-file ./stargate.env \
+  --env-file ./stargate-v1.env \
   -p 8080:8080 \
   --restart unless-stopped \
   ghcr.io/soulteary/stargate:v1.0.0
@@ -704,7 +724,8 @@ curl --fail http://127.0.0.1:8080/readyz
 Si des problèmes surviennent après la mise à jour :
 
 ```bash
-# Supprimer le nouveau conteneur et restaurer l'ancien conteneur intact
+# Supprimer le nouveau conteneur et restaurer l'ancien conteneur intact.
+# Conserver stargate-v0.12.0.env comme référence de configuration de retour arrière.
 docker rm -f stargate
 docker rename stargate-previous stargate
 docker start stargate

--- a/docs/frFR/DEPLOYMENT.md
+++ b/docs/frFR/DEPLOYMENT.md
@@ -674,14 +674,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# Si le fichier manque, exporter de manière protégée l'environnement du conteneur existant.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Le TOTP via Herald exige que Stargate résolve les utilisateurs authentifiés par Warden ; configurez donc aussi `WARDEN_ENABLED=true` et `WARDEN_URL`.

--- a/docs/frFR/MIGRATION_V1.md
+++ b/docs/frFR/MIGRATION_V1.md
@@ -25,7 +25,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Le TOTP via Herald exige que Stargate résolve les utilisateurs authentifiés par Warden ; configurez donc aussi `WARDEN_ENABLED=true` et `WARDEN_URL`.

--- a/docs/frFR/MIGRATION_V1.md
+++ b/docs/frFR/MIGRATION_V1.md
@@ -18,14 +18,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# Si le fichier manque, exporter de manière protégée l'environnement du conteneur existant.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Le TOTP via Herald exige que Stargate résolve les utilisateurs authentifiés par Warden ; configurez donc aussi `WARDEN_ENABLED=true` et `WARDEN_URL`.

--- a/docs/frFR/MIGRATION_V1.md
+++ b/docs/frFR/MIGRATION_V1.md
@@ -7,7 +7,32 @@ Stargate v1.0.0 fixe les premiers contrats stables de déploiement et d'API HTTP
 1. Relever l'image, les variables d'environnement, les routes proxy, les hôtes de callback et les sondes.
 2. Conserver l'image `v0.12.0` et le conteneur précédent pour le retour en arrière.
 3. Identifier les clients de `/_logout`, `/totp/enroll` et `/_session_exchange`.
-4. Préparer le stockage de session Redis lorsqu'il existe plusieurs répliques.
+4. Préparer Redis si plusieurs processus servent le trafic, si anciens et nouveaux processus se chevauchent pendant le déploiement, ou si les sessions et tickets consommés doivent survivre à un redémarrage. Un seul processus actif peut utiliser la mémoire même avec des callbacks inter-domaines, mais tout état est local au processus et perdu au redémarrage.
+
+## Conserver la configuration de retour arrière et créer l'environnement v1
+
+Ne démarrez pas v1 avec l'ancien fichier d'environnement. Conservez `stargate.env` inchangé ainsi que le conteneur v0.12.0. Ces commandes créent une copie de retour arrière protégée et un fichier v1 distinct, refusent d'écraser toute sortie existante et retirent les anciens paramètres uniquement du fichier v1 :
+
+```bash
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+```
+
+Le TOTP via Herald exige que Stargate résolve les utilisateurs authentifiés par Warden ; configurez donc aussi `WARDEN_ENABLED=true` et `WARDEN_URL`.
+
+v1 refuse `WARDEN_OTP_ENABLED` et `WARDEN_OTP_SECRET_KEY` dès qu'une variable est présente, même vide ou à `false`. Ne les ajoutez pas à `stargate-v1.env`. Pour TOTP, configurez Stargate avec `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL` et une authentification de service Herald prise en charge. Configurez Herald pour relayer TOTP vers herald-totp et fournissez à herald-totp son propre `HERALD_TOTP_ENCRYPTION_KEY` ; ne réutilisez pas automatiquement l'ancien secret Warden. Voir la [configuration](CONFIG.md).
+
+Validez et déployez v1 avec `--env-file ./stargate-v1.env`. Conservez `stargate-v0.12.0.env`, le fichier original inchangé et l'ancien conteneur jusqu'à la fin de la fenêtre de retour arrière.
 
 ## Modifications obligatoires
 

--- a/docs/itIT/DEPLOYMENT.md
+++ b/docs/itIT/DEPLOYMENT.md
@@ -674,14 +674,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# Se il file manca, esportare in modo protetto l'ambiente del container esistente.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Il TOTP tramite Herald richiede che Stargate risolva gli utenti autenticati tramite Warden; impostare quindi anche `WARDEN_ENABLED=true` e `WARDEN_URL`.

--- a/docs/itIT/DEPLOYMENT.md
+++ b/docs/itIT/DEPLOYMENT.md
@@ -437,7 +437,12 @@ services:
       replicas: 3
 ```
 
-**Obbligatorio:** I deployment multi-istanza, gli aggiornamenti progressivi e gli scenari cross-domain devono abilitare Redis (`SESSION_STORAGE_ENABLED=true` e `SESSION_STORAGE_REDIS_*`). Redis condivide tra le repliche sia le sessioni sia lo stato anti-replay dei ticket monouso. Le Sticky Session da sole non sono supportate e possono essere usate solo come ottimizzazione aggiuntiva del routing.
+**Ambito dello storage delle sessioni:**
+
+- **Un processo / una replica, inclusi callback cross-domain:** lo storage in memoria (`SESSION_STORAGE_ENABLED=false`) è supportato quando emissione e riscatto del ticket e il successivo uso della sessione raggiungono lo stesso processo Stargate attivo. Sessioni e hash dei ticket consumati esistono solo in quel processo. Un riavvio perde entrambi gli stati, invalida le sessioni attive e non conserva lo stato monouso dei ticket.
+- **Più processi o repliche:** Redis è obbligatorio quando una sessione o un ticket può essere gestito da processi diversi. Usare `SESSION_STORAGE_ENABLED=true`, lo stesso namespace `SESSION_STORAGE_REDIS_*` e lo stesso `SESSION_EXCHANGE_SECRET` su tutte le repliche. Le Sticky Session sono solo un'ottimizzazione del routing e non sostituiscono lo stato condiviso o la protezione anti-replay tra processi.
+- **Aggiornamento progressivo:** Redis è obbligatorio per la sostituzione senza interruzioni perché vecchi e nuovi processi si sovrappongono. Senza Redis, arrestare e poi avviare il servizio, accettando invalidazione delle sessioni e nuovo login. Non mescolare v0.12.0 e v1.0.0 nello stesso pool.
+- **Stato oltre il riavvio:** Redis è obbligatorio se sessioni o stato anti-replay dei ticket consumati devono sopravvivere alla sostituzione o al riavvio del processo.
 
 #### 2. Bilanciamento Carico
 
@@ -662,13 +667,28 @@ Se si incontrano problemi:
 
 ### Passi di Aggiornamento
 
-1. **Preparare un file di ambiente riutilizzabile**: salvare la configurazione in `stargate.env` e proteggere il file.
+1. **Creare file di ambiente separati per rollback e v1**: lasciare invariato `stargate.env`. I comandi seguenti rifiutano di sovrascrivere i file di destinazione e rimuovono le impostazioni Warden OTP ritirate solo dal nuovo file v1.
 
 ```bash
-chmod 600 stargate.env
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
 ```
 
-2. **Conservare il container precedente per il rollback:**
+Il TOTP tramite Herald richiede che Stargate risolva gli utenti autenticati tramite Warden; impostare quindi anche `WARDEN_ENABLED=true` e `WARDEN_URL`.
+
+v1 rifiuta `WARDEN_OTP_ENABLED` e `WARDEN_OTP_SECRET_KEY` se uno dei nomi è presente, anche vuoto o `false`. Non reinserirli. Per TOTP configurare in `stargate-v1.env` `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL` e un metodo di autenticazione del servizio Herald supportato. Configurare anche il proxy TOTP di Herald e un `HERALD_TOTP_ENCRYPTION_KEY` indipendente in herald-totp; non riutilizzare automaticamente il vecchio secret Warden. Vedere [Configurazione](CONFIG.md).
+
+2. **Conservare il container precedente e il suo ambiente originale per il rollback:**
 
 ```bash
 docker stop stargate
@@ -686,7 +706,7 @@ docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```bash
 docker run -d \
   --name stargate \
-  --env-file ./stargate.env \
+  --env-file ./stargate-v1.env \
   -p 8080:8080 \
   --restart unless-stopped \
   ghcr.io/soulteary/stargate:v1.0.0
@@ -704,7 +724,8 @@ curl --fail http://127.0.0.1:8080/readyz
 Se si verificano problemi dopo l'aggiornamento:
 
 ```bash
-# Rimuovere il nuovo container e ripristinare quello precedente invariato
+# Rimuovere il nuovo container e ripristinare quello precedente invariato.
+# Conservare stargate-v0.12.0.env come riferimento di configurazione per il rollback.
 docker rm -f stargate
 docker rename stargate-previous stargate
 docker start stargate

--- a/docs/itIT/DEPLOYMENT.md
+++ b/docs/itIT/DEPLOYMENT.md
@@ -681,7 +681,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Il TOTP tramite Herald richiede che Stargate risolva gli utenti autenticati tramite Warden; impostare quindi anche `WARDEN_ENABLED=true` e `WARDEN_URL`.

--- a/docs/itIT/MIGRATION_V1.md
+++ b/docs/itIT/MIGRATION_V1.md
@@ -7,7 +7,32 @@ Stargate v1.0.0 stabilisce i contratti di deployment e HTTP. Verificare prima l'
 1. Registrare immagine, variabili d'ambiente, route proxy, host di callback e probe.
 2. Conservare l'immagine `v0.12.0` e il container precedente per il rollback.
 3. Individuare tutti i client di `/_logout`, `/totp/enroll` e `/_session_exchange`.
-4. Preparare lo storage Redis delle sessioni per deployment con più repliche.
+4. Preparare Redis se più processi servono traffico, se processi vecchi e nuovi si sovrappongono durante il rollout o se sessioni e ticket consumati devono sopravvivere a un riavvio. Un singolo processo attivo può usare lo storage in memoria anche con callback cross-domain, ma tutto lo stato è locale al processo e si perde al riavvio.
+
+## Conservare la configurazione di rollback e creare l'ambiente v1
+
+Non avviare v1 con il vecchio file di ambiente. Lasciare invariato `stargate.env` e conservare il container v0.12.0. I comandi seguenti creano una copia protetta per il rollback e un file v1 separato, rifiutano di sovrascrivere output esistenti e rimuovono le impostazioni ritirate solo dal file v1:
+
+```bash
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+```
+
+Il TOTP tramite Herald richiede che Stargate risolva gli utenti autenticati tramite Warden; impostare quindi anche `WARDEN_ENABLED=true` e `WARDEN_URL`.
+
+v1 rifiuta `WARDEN_OTP_ENABLED` e `WARDEN_OTP_SECRET_KEY` quando una variabile è presente, anche vuota o `false`. Non aggiungerle a `stargate-v1.env`. Per TOTP configurare Stargate con `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL` e un'autenticazione del servizio Herald supportata. Configurare Herald per inoltrare TOTP a herald-totp e assegnare a herald-totp un proprio `HERALD_TOTP_ENCRYPTION_KEY`; non riutilizzare automaticamente il vecchio secret Warden. Vedere [Configurazione](CONFIG.md).
+
+Verificare e distribuire v1 con `--env-file ./stargate-v1.env`. Conservare `stargate-v0.12.0.env`, il file originale invariato e il vecchio container fino alla chiusura della finestra di rollback.
 
 ## Modifiche obbligatorie
 

--- a/docs/itIT/MIGRATION_V1.md
+++ b/docs/itIT/MIGRATION_V1.md
@@ -18,14 +18,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# Se il file manca, esportare in modo protetto l'ambiente del container esistente.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Il TOTP tramite Herald richiede che Stargate risolva gli utenti autenticati tramite Warden; impostare quindi anche `WARDEN_ENABLED=true` e `WARDEN_URL`.

--- a/docs/itIT/MIGRATION_V1.md
+++ b/docs/itIT/MIGRATION_V1.md
@@ -25,7 +25,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Il TOTP tramite Herald richiede che Stargate risolva gli utenti autenticati tramite Warden; impostare quindi anche `WARDEN_ENABLED=true` e `WARDEN_URL`.

--- a/docs/jaJP/DEPLOYMENT.md
+++ b/docs/jaJP/DEPLOYMENT.md
@@ -674,14 +674,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# ファイルがない場合は、既存 Container の環境を保護された状態で出力します。
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald ベースの TOTP では、Stargate が Warden 経由で認証済みユーザーを解決する必要があるため、`WARDEN_ENABLED=true` と `WARDEN_URL` も設定してください。

--- a/docs/jaJP/DEPLOYMENT.md
+++ b/docs/jaJP/DEPLOYMENT.md
@@ -437,7 +437,12 @@ services:
       replicas: 3
 ```
 
-**必須:** マルチインスタンス、ローリングアップグレード、クロスドメイン構成では Redis セッションストレージ（`SESSION_STORAGE_ENABLED=true` と `SESSION_STORAGE_REDIS_*`）を有効にしてください。Redis はセッションと使い捨てチケットのリプレイ防止状態を全レプリカで共有します。Sticky Session だけの構成はサポートされず、追加のルーティング最適化としてのみ利用できます。
+**セッションストレージの適用範囲:**
+
+- **1 プロセス / 1 レプリカ（クロスドメイン Callback を含む）:** Ticket の発行、交換、その後の Session 利用が同じ稼働中の Stargate プロセスに到達する場合、インメモリストレージ（`SESSION_STORAGE_ENABLED=false`）を利用できます。Session と消費済み Ticket のハッシュはそのプロセス内だけに存在します。再起動すると両方が失われ、稼働中の Session は無効になり、Ticket の一回限りの状態も引き継がれません。
+- **複数プロセスまたはレプリカ:** Session や交換 Ticket が異なるプロセスで処理される可能性がある場合は Redis が必須です。全レプリカで `SESSION_STORAGE_ENABLED=true`、同じ `SESSION_STORAGE_REDIS_*` 名前空間、同じ `SESSION_EXCHANGE_SECRET` を使用します。Sticky Session はルーティング最適化にすぎず、共有状態やプロセス間リプレイ防止の代替にはなりません。
+- **ローリングアップグレード:** 新旧プロセスが重なるため、無停止の入れ替えには Redis が必須です。Redis を使わない場合は停止後に起動し、Session の無効化と再ログインを受け入れてください。v0.12.0 と v1.0.0 を同じ Serving Pool に混在させないでください。
+- **再起動をまたぐ状態保持:** Session または消費済み Ticket のリプレイ状態をプロセス交換・再起動後も保持する必要がある場合は Redis が必須です。
 
 #### 2. ロードバランシング
 
@@ -662,13 +667,28 @@ curl -H "Cookie: stargate_session_id=<session_id>" http://auth.example.com/_auth
 
 ### 更新手順
 
-1. **再利用できる環境ファイルを準備**：現在の設定を `stargate.env` に保存し、ファイルを保護します。
+1. **Rollback 用と v1 用の環境ファイルを別々に作成**：既存の `stargate.env` は変更しません。次のコマンドは既存の出力ファイルを上書きせず、廃止された Warden OTP 設定を新しい v1 ファイルからだけ除去します。
 
 ```bash
-chmod 600 stargate.env
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
 ```
 
-2. **ロールバック用に以前のコンテナを保持:**
+Herald ベースの TOTP では、Stargate が Warden 経由で認証済みユーザーを解決する必要があるため、`WARDEN_ENABLED=true` と `WARDEN_URL` も設定してください。
+
+v1 は `WARDEN_OTP_ENABLED` または `WARDEN_OTP_SECRET_KEY` が存在するだけで、空や `false` でも起動を拒否します。追加し直さないでください。TOTP が必要な場合は `stargate-v1.env` に `HERALD_ENABLED=true`、`HERALD_TOTP_ENABLED=true`、`HERALD_URL` と対応する Herald Service Auth を設定します。さらに Herald の TOTP Proxy と herald-totp 独自の `HERALD_TOTP_ENCRYPTION_KEY` を設定し、旧 Warden Secret を自動的に再利用しないでください。[設定](CONFIG.md)を参照してください。
+
+2. **以前のコンテナと元の環境をロールバック用に保持:**
 
 ```bash
 docker stop stargate
@@ -686,7 +706,7 @@ docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```bash
 docker run -d \
   --name stargate \
-  --env-file ./stargate.env \
+  --env-file ./stargate-v1.env \
   -p 8080:8080 \
   --restart unless-stopped \
   ghcr.io/soulteary/stargate:v1.0.0
@@ -704,7 +724,8 @@ curl --fail http://127.0.0.1:8080/readyz
 更新後に問題が発生した場合：
 
 ```bash
-# 新しいコンテナを削除し、変更していない以前のコンテナを復元
+# 新しいコンテナを削除し、変更していない以前のコンテナを復元。
+# stargate-v0.12.0.env をロールバック設定の記録として保持する。
 docker rm -f stargate
 docker rename stargate-previous stargate
 docker start stargate

--- a/docs/jaJP/DEPLOYMENT.md
+++ b/docs/jaJP/DEPLOYMENT.md
@@ -681,7 +681,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald ベースの TOTP では、Stargate が Warden 経由で認証済みユーザーを解決する必要があるため、`WARDEN_ENABLED=true` と `WARDEN_URL` も設定してください。

--- a/docs/jaJP/MIGRATION_V1.md
+++ b/docs/jaJP/MIGRATION_V1.md
@@ -18,14 +18,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# ファイルがない場合は、既存 Container の環境を保護された状態で出力します。
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald ベースの TOTP では、Stargate が Warden 経由で認証済みユーザーを解決する必要があるため、`WARDEN_ENABLED=true` と `WARDEN_URL` も設定してください。

--- a/docs/jaJP/MIGRATION_V1.md
+++ b/docs/jaJP/MIGRATION_V1.md
@@ -25,7 +25,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald ベースの TOTP では、Stargate が Warden 経由で認証済みユーザーを解決する必要があるため、`WARDEN_ENABLED=true` と `WARDEN_URL` も設定してください。

--- a/docs/jaJP/MIGRATION_V1.md
+++ b/docs/jaJP/MIGRATION_V1.md
@@ -7,7 +7,32 @@ Stargate v1.0.0 はデプロイと HTTP の安定した契約を定義します�
 1. 現在のイメージ、環境変数、Proxy ルート、Callback ホスト、Probe を記録します。
 2. ロールバック用に `v0.12.0` イメージと以前のコンテナを保持します。
 3. `/_logout`、`/totp/enroll`、`/_session_exchange` の呼び出し元を確認します。
-4. 複数レプリカでは Redis セッションストレージを準備します。
+4. 複数プロセスが Traffic を処理する場合、Rollout 中に新旧プロセスが重なる場合、または Session と消費済み Ticket の状態を再起動後も保持する場合は Redis を準備します。1 つの稼働中プロセスなら Cross-Domain Callback があってもインメモリストレージを使えますが、すべての状態はプロセスローカルで再起動時に失われます。
+
+## ロールバック設定を保持して v1 環境を作成
+
+古い環境ファイルで v1 を起動しないでください。`stargate.env` を変更せず、v0.12.0 Container も保持します。次のコマンドは保護されたロールバックコピーと独立した v1 ファイルを作成し、既存の出力を上書きせず、廃止設定を v1 ファイルからだけ除去します。
+
+```bash
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+```
+
+Herald ベースの TOTP では、Stargate が Warden 経由で認証済みユーザーを解決する必要があるため、`WARDEN_ENABLED=true` と `WARDEN_URL` も設定してください。
+
+v1 は `WARDEN_OTP_ENABLED` または `WARDEN_OTP_SECRET_KEY` が存在するだけで、空や `false` でも拒否します。`stargate-v1.env` に追加しないでください。TOTP には Stargate の `HERALD_ENABLED=true`、`HERALD_TOTP_ENABLED=true`、`HERALD_URL` と対応する Herald Service Auth を設定します。Herald から herald-totp への TOTP Proxy と、herald-totp 独自の `HERALD_TOTP_ENCRYPTION_KEY` も設定し、旧 Warden Secret を自動再利用しないでください。[設定](CONFIG.md)を参照してください。
+
+`--env-file ./stargate-v1.env` で v1 を検証・起動します。ロールバック期間が終わるまで `stargate-v0.12.0.env`、未変更の元ファイル、旧 Container を保持してください。
 
 ## 必須の変更
 

--- a/docs/koKR/DEPLOYMENT.md
+++ b/docs/koKR/DEPLOYMENT.md
@@ -437,7 +437,12 @@ services:
       replicas: 3
 ```
 
-**필수:** 다중 인스턴스, 롤링 업그레이드 및 교차 도메인 배포에서는 Redis 세션 저장소(`SESSION_STORAGE_ENABLED=true` 및 `SESSION_STORAGE_REDIS_*`)를 활성화해야 합니다. Redis는 세션과 일회용 티켓의 재사용 방지 상태를 모든 복제본에서 공유합니다. Sticky Session만 사용하는 구성은 지원되지 않으며 추가 라우팅 최적화로만 사용할 수 있습니다.
+**세션 스토리지 적용 범위:**
+
+- **단일 프로세스 / 단일 복제본(교차 도메인 Callback 포함):** Ticket 발급, 교환 및 이후 Session 사용이 모두 같은 실행 중인 Stargate 프로세스에 도달하면 인메모리 스토리지(`SESSION_STORAGE_ENABLED=false`)를 사용할 수 있습니다. Session과 소비된 Ticket 해시는 해당 프로세스에만 존재합니다. 재시작하면 두 상태가 사라지고 활성 Session이 무효화되며 Ticket의 일회성 상태도 유지되지 않습니다.
+- **여러 프로세스 또는 복제본:** Session이나 교환 Ticket이 서로 다른 프로세스에서 처리될 수 있으면 Redis가 필수입니다. 모든 복제본에서 `SESSION_STORAGE_ENABLED=true`, 동일한 `SESSION_STORAGE_REDIS_*` 네임스페이스와 동일한 `SESSION_EXCHANGE_SECRET`을 사용합니다. Sticky Session은 라우팅 최적화일 뿐 공유 상태나 프로세스 간 재사용 방지를 대신하지 않습니다.
+- **롤링 업그레이드:** 이전 프로세스와 새 프로세스가 겹치므로 무중단 교체에는 Redis가 필수입니다. Redis가 없으면 중지 후 시작하고 Session 무효화와 재로그인을 허용해야 합니다. v0.12.0과 v1.0.0을 같은 Serving Pool에 혼합하지 마십시오.
+- **재시작 후 상태 유지:** Session 또는 소비된 Ticket의 재사용 방지 상태가 프로세스 교체나 재시작 후에도 유지되어야 하면 Redis가 필수입니다.
 
 #### 2. 로드 밸런싱
 
@@ -662,13 +667,28 @@ curl -H "Cookie: stargate_session_id=<session_id>" http://auth.example.com/_auth
 
 ### 업데이트 절차
 
-1. **재사용 가능한 환경 파일 준비**: 현재 구성을 `stargate.env`에 저장하고 파일 권한을 제한합니다.
+1. **롤백용과 v1용 환경 파일을 별도로 생성**: 기존 `stargate.env`는 변경하지 않습니다. 다음 명령은 기존 대상 파일을 덮어쓰지 않으며 폐기된 Warden OTP 설정을 새 v1 파일에서만 제거합니다.
 
 ```bash
-chmod 600 stargate.env
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
 ```
 
-2. **롤백을 위해 이전 컨테이너 보존:**
+Herald 기반 TOTP에서는 Stargate가 Warden을 통해 인증된 사용자를 확인해야 하므로 `WARDEN_ENABLED=true`와 `WARDEN_URL`도 설정하십시오.
+
+v1은 `WARDEN_OTP_ENABLED` 또는 `WARDEN_OTP_SECRET_KEY`가 존재하기만 해도 빈 값이나 `false` 여부와 관계없이 시작을 거부합니다. 다시 추가하지 마십시오. TOTP가 필요하면 `stargate-v1.env`에 `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL`과 지원되는 Herald Service Auth 방식 하나를 설정합니다. Herald의 TOTP Proxy와 herald-totp의 독립적인 `HERALD_TOTP_ENCRYPTION_KEY`도 설정하고 이전 Warden Secret을 자동 재사용하지 마십시오. [설정](CONFIG.md)을 참조하십시오.
+
+2. **이전 컨테이너와 원래 환경을 롤백용으로 보존:**
 
 ```bash
 docker stop stargate
@@ -686,7 +706,7 @@ docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```bash
 docker run -d \
   --name stargate \
-  --env-file ./stargate.env \
+  --env-file ./stargate-v1.env \
   -p 8080:8080 \
   --restart unless-stopped \
   ghcr.io/soulteary/stargate:v1.0.0
@@ -704,7 +724,8 @@ curl --fail http://127.0.0.1:8080/readyz
 업데이트 후 문제가 발생한 경우:
 
 ```bash
-# 새 컨테이너를 제거하고 변경되지 않은 이전 컨테이너 복원
+# 새 컨테이너를 제거하고 변경되지 않은 이전 컨테이너 복원.
+# stargate-v0.12.0.env를 롤백 설정 기록으로 보존.
 docker rm -f stargate
 docker rename stargate-previous stargate
 docker start stargate

--- a/docs/koKR/DEPLOYMENT.md
+++ b/docs/koKR/DEPLOYMENT.md
@@ -681,7 +681,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald 기반 TOTP에서는 Stargate가 Warden을 통해 인증된 사용자를 확인해야 하므로 `WARDEN_ENABLED=true`와 `WARDEN_URL`도 설정하십시오.

--- a/docs/koKR/DEPLOYMENT.md
+++ b/docs/koKR/DEPLOYMENT.md
@@ -674,14 +674,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# 파일이 없으면 기존 Container 환경을 보호된 상태로 내보냅니다.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald 기반 TOTP에서는 Stargate가 Warden을 통해 인증된 사용자를 확인해야 하므로 `WARDEN_ENABLED=true`와 `WARDEN_URL`도 설정하십시오.

--- a/docs/koKR/MIGRATION_V1.md
+++ b/docs/koKR/MIGRATION_V1.md
@@ -25,7 +25,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald 기반 TOTP에서는 Stargate가 Warden을 통해 인증된 사용자를 확인해야 하므로 `WARDEN_ENABLED=true`와 `WARDEN_URL`도 설정하십시오.

--- a/docs/koKR/MIGRATION_V1.md
+++ b/docs/koKR/MIGRATION_V1.md
@@ -18,14 +18,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# 파일이 없으면 기존 Container 환경을 보호된 상태로 내보냅니다.
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald 기반 TOTP에서는 Stargate가 Warden을 통해 인증된 사용자를 확인해야 하므로 `WARDEN_ENABLED=true`와 `WARDEN_URL`도 설정하십시오.

--- a/docs/koKR/MIGRATION_V1.md
+++ b/docs/koKR/MIGRATION_V1.md
@@ -7,7 +7,32 @@ Stargate v1.0.0은 안정적인 배포 및 HTTP 계약을 정의합니다. 프�
 1. 현재 이미지, 환경 변수, 프록시 경로, 콜백 호스트와 Probe를 기록합니다.
 2. 롤백을 위해 `v0.12.0` 이미지와 이전 컨테이너를 보존합니다.
 3. `/_logout`, `/totp/enroll`, `/_session_exchange` 호출자를 확인합니다.
-4. 여러 복제본에서는 Redis 세션 스토리지를 준비합니다.
+4. 여러 프로세스가 트래픽을 처리하거나 Rollout 중 이전 프로세스와 새 프로세스가 겹치거나 Session과 소비된 Ticket 상태가 재시작 후에도 유지되어야 하면 Redis를 준비합니다. 하나의 실행 중인 프로세스는 교차 도메인 Callback이 있어도 인메모리 스토리지를 사용할 수 있지만 모든 상태는 프로세스 로컬이며 재시작 시 사라집니다.
+
+## 롤백 설정 보존 및 v1 환경 생성
+
+이전 환경 파일로 v1을 시작하지 마십시오. `stargate.env`를 변경하지 않고 v0.12.0 컨테이너도 보존합니다. 다음 명령은 보호된 롤백 사본과 별도의 v1 파일을 생성하고 기존 출력을 덮어쓰지 않으며 폐기 설정을 v1 파일에서만 제거합니다.
+
+```bash
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+```
+
+Herald 기반 TOTP에서는 Stargate가 Warden을 통해 인증된 사용자를 확인해야 하므로 `WARDEN_ENABLED=true`와 `WARDEN_URL`도 설정하십시오.
+
+v1은 `WARDEN_OTP_ENABLED` 또는 `WARDEN_OTP_SECRET_KEY`가 존재하면 빈 값이나 `false`여도 거부합니다. `stargate-v1.env`에 추가하지 마십시오. TOTP에는 Stargate의 `HERALD_ENABLED=true`, `HERALD_TOTP_ENABLED=true`, `HERALD_URL`과 지원되는 Herald Service Auth를 설정합니다. Herald가 TOTP를 herald-totp로 전달하도록 하고 herald-totp에는 별도의 `HERALD_TOTP_ENCRYPTION_KEY`를 설정하며 이전 Warden Secret을 자동 재사용하지 마십시오. [설정](CONFIG.md)을 참조하십시오.
+
+`--env-file ./stargate-v1.env`로 v1을 검증하고 배포합니다. 롤백 기간이 끝날 때까지 `stargate-v0.12.0.env`, 변경하지 않은 원본 파일 및 이전 컨테이너를 보존하십시오.
 
 ## 필수 변경
 

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -868,7 +868,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald TOTP 要求 Stargate 通过 Warden 解析已认证用户，因此还必须配置 `WARDEN_ENABLED=true` 和 `WARDEN_URL`。

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -549,7 +549,12 @@ services:
       replicas: 3
 ```
 
-**必须配置：** 多实例、滚动升级和跨域部署必须启用 Redis 会话存储（`SESSION_STORAGE_ENABLED=true` 并配置 `SESSION_STORAGE_REDIS_*`）。Redis 会在副本间同时共享 Session 与单次 Ticket 的重放状态。仅使用负载均衡器会话保持（Sticky Session）不受支持；它只能作为额外的路由优化。
+**会话存储适用范围：**
+
+- **单进程、单副本（包括跨域回调）：** 只要 Ticket 签发、兑换及后续 Session 使用始终由同一个存活的 Stargate 进程处理，就可以使用进程内存储（`SESSION_STORAGE_ENABLED=false`）。Session 记录与已消费 Ticket 哈希只存在于该进程；进程重启后两者都会丢失，活动 Session 失效，也无法跨重启保留 Ticket 单次消费状态。
+- **多进程或多副本：** 只要 Session 或交换 Ticket 可能由不同进程处理，就必须使用 Redis。设置 `SESSION_STORAGE_ENABLED=true`，所有副本使用相同的 `SESSION_STORAGE_REDIS_*` 命名空间和 `SESSION_EXCHANGE_SECRET`。Sticky Session 只能优化路由，不能替代共享状态或跨进程重放防护。
+- **滚动升级：** 新旧进程会重叠运行；要无中断滚动替换，必须使用 Redis。未使用 Redis 时，应停旧再启新，并接受 Session 失效和用户重新登录。不要在同一服务实例池中混用 v0.12.0 与 v1.0.0。
+- **跨进程重启保留状态：** 只要要求 Session 或已消费 Ticket 的重放状态在进程替换或重启后继续有效，就必须使用 Redis。
 
 #### 2. 负载均衡
 
@@ -849,13 +854,28 @@ curl -H "Cookie: stargate_session_id=<session_id>" http://auth.example.com/_auth
 
 ### 升级步骤
 
-1. **准备可复用的环境变量文件**：将当前容器配置整理到 `stargate.env`，不要把密钥写入命令历史，并限制文件权限。
+1. **分别生成回滚与 v1 环境文件**：保持现有 `stargate.env` 不变。下面的命令在任一目标文件已存在时会拒绝覆盖，并且只从新的 v1 文件中删除废弃的 Warden OTP 配置。
 
 ```bash
-chmod 600 stargate.env
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
 ```
 
-2. **保留旧容器用于回滚**：
+Herald TOTP 要求 Stargate 通过 Warden 解析已认证用户，因此还必须配置 `WARDEN_ENABLED=true` 和 `WARDEN_URL`。
+
+只要环境中存在 `WARDEN_OTP_ENABLED` 或 `WARDEN_OTP_SECRET_KEY`（即使为空或为 `false`），v1 都会拒绝启动，请勿把它们加回新文件。需要 TOTP 时，在 `stargate-v1.env` 中为 Stargate 配置 `HERALD_ENABLED=true`、`HERALD_TOTP_ENABLED=true`、`HERALD_URL` 及一种受支持的 Herald 服务鉴权方式；同时在 Herald 配置 TOTP 代理，并为 herald-totp 单独配置 `HERALD_TOTP_ENCRYPTION_KEY`，不要自动复用旧 Warden 密钥。参见[配置说明](CONFIG.md)。
+
+2. **保留旧容器及其原始环境用于回滚**：
 
 ```bash
 docker stop stargate
@@ -873,7 +893,7 @@ docker pull ghcr.io/soulteary/stargate:v1.0.0
 ```bash
 docker run -d \
   --name stargate \
-  --env-file ./stargate.env \
+  --env-file ./stargate-v1.env \
   -p 8080:8080 \
   --restart unless-stopped \
   ghcr.io/soulteary/stargate:v1.0.0
@@ -891,7 +911,8 @@ curl --fail http://127.0.0.1:8080/readyz
 如果升级后出现问题：
 
 ```bash
-# 删除新容器并恢复未修改的旧容器
+# 删除新容器并恢复未修改的旧容器。
+# 保留 stargate-v0.12.0.env 作为回滚配置记录。
 docker rm -f stargate
 docker rename stargate-previous stargate
 docker start stargate

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -861,14 +861,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# 文件不存在时，安全导出现有容器的环境。
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald TOTP 要求 Stargate 通过 Warden 解析已认证用户，因此还必须配置 `WARDEN_ENABLED=true` 和 `WARDEN_URL`。

--- a/docs/zhCN/MIGRATION_V1.md
+++ b/docs/zhCN/MIGRATION_V1.md
@@ -18,14 +18,30 @@ set -eu
 old_env=./stargate.env
 rollback_env=./stargate-v0.12.0.env
 v1_env=./stargate-v1.env
+old_container=${STARGATE_OLD_CONTAINER:-stargate}
 
-test -f "$old_env"
 test ! -e "$rollback_env"
 test ! -e "$v1_env"
-chmod 600 "$old_env"
 umask 077
+
+# 文件不存在时，安全导出现有容器的环境。
+if [ ! -e "$old_env" ]; then
+  export_tmp=$(mktemp "${old_env}.tmp.XXXXXX")
+  trap 'rm -f "$export_tmp"' 0 1 2 15
+  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$old_container" > "$export_tmp"
+  ln "$export_tmp" "$old_env"
+  rm -f "$export_tmp"
+  trap - 0 1 2 15
+fi
+
+test -f "$old_env"
+chmod 600 "$old_env"
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
+(set -C; awk '
+  /^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/ { next }
+  /^[[:space:]]*PORT[[:space:]]*(=|$)/ { print "PORT=8080"; next }
+  { print }
+' "$old_env" > "$v1_env")
 ```
 
 Herald TOTP 要求 Stargate 通过 Warden 解析已认证用户，因此还必须配置 `WARDEN_ENABLED=true` 和 `WARDEN_URL`。

--- a/docs/zhCN/MIGRATION_V1.md
+++ b/docs/zhCN/MIGRATION_V1.md
@@ -7,7 +7,32 @@ Stargate v1.0.0 确立了首个稳定的部署与 HTTP 契约，同时调整了�
 1. 记录当前镜像、环境变量、反向代理路由、回调域名和健康检查配置。
 2. 备份部署配置，并保留 v0.12.0 镜像以便回滚。
 3. 找出所有调用 `/_logout`、`/totp/enroll` 和跨域会话交换路由的客户端。
-4. 如果运行多个 Stargate 副本，请在升级前准备 Redis 会话存储。
+4. 如果将由多个进程提供流量、发布期间新旧进程会重叠，或 Session 与已消费 Ticket 状态必须跨重启保留，请在升级前准备 Redis。即使存在跨域回调，单个存活进程也可以使用进程内存储，但所有状态仅属于该进程，并会在重启后丢失。
+
+## 保留回滚配置并生成 v1 环境文件
+
+不要让 v1 直接复用旧环境文件。保持 `stargate.env` 不变并保留 v0.12.0 容器。下面的命令会生成受保护的回滚副本和独立的 v1 文件，在目标文件已存在时拒绝覆盖，并且只从 v1 文件中删除废弃配置：
+
+```bash
+set -eu
+old_env=./stargate.env
+rollback_env=./stargate-v0.12.0.env
+v1_env=./stargate-v1.env
+
+test -f "$old_env"
+test ! -e "$rollback_env"
+test ! -e "$v1_env"
+chmod 600 "$old_env"
+umask 077
+(set -C; cat "$old_env" > "$rollback_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+```
+
+Herald TOTP 要求 Stargate 通过 Warden 解析已认证用户，因此还必须配置 `WARDEN_ENABLED=true` 和 `WARDEN_URL`。
+
+只要 `WARDEN_OTP_ENABLED` 或 `WARDEN_OTP_SECRET_KEY` 存在（即使为空或为 `false`），v1 就会拒绝启动。不要把它们加入 `stargate-v1.env`。需要 TOTP 时，为 Stargate 配置 `HERALD_ENABLED=true`、`HERALD_TOTP_ENABLED=true`、`HERALD_URL` 及一种受支持的 Herald 服务鉴权方式；同时让 Herald 将 TOTP 代理到 herald-totp，并为 herald-totp 单独配置 `HERALD_TOTP_ENCRYPTION_KEY`，不要自动复用旧 Warden 密钥。参见[配置说明](CONFIG.md)。
+
+使用 `--env-file ./stargate-v1.env` 验证和部署 v1。在回滚窗口关闭前，保留 `stargate-v0.12.0.env`、未修改的原文件和旧容器。
 
 ## 必须调整的部署配置
 

--- a/docs/zhCN/MIGRATION_V1.md
+++ b/docs/zhCN/MIGRATION_V1.md
@@ -25,7 +25,7 @@ test ! -e "$v1_env"
 chmod 600 "$old_env"
 umask 077
 (set -C; cat "$old_env" > "$rollback_env")
-(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*=/' "$old_env" > "$v1_env")
+(set -C; awk '!/^[[:space:]]*WARDEN_OTP_(ENABLED|SECRET_KEY)[[:space:]]*(=|$)/' "$old_env" > "$v1_env")
 ```
 
 Herald TOTP 要求 Stargate 通过 Warden 解析已认证用户，因此还必须配置 `WARDEN_ENABLED=true` 和 `WARDEN_URL`。


### PR DESCRIPTION
## Summary

- distinguish supported single-process cross-domain deployments from multi-process, multi-replica, rolling-upgrade, and restart-persistent deployments
- document the exact guarantees and limits of the in-memory session and exchange-ticket replay stores, and require Redis only when state must cross a process boundary or restart
- replace direct reuse of the v0.12.0 environment file with a no-clobber migration that preserves rollback material and removes `WARDEN_OTP_ENABLED` and `WARDEN_OTP_SECRET_KEY` from a separate v1 file
- protect the original environment plus both generated files with mode 0600 while preserving original contents and both no-clobber guarantees
- direct TOTP deployments to Stargate's Herald settings, Herald's TOTP proxy, herald-totp's independent encryption key, and the required Warden user-resolution prerequisites
- synchronize all seven languages and add documentation contracts plus executable migration-command self-tests
- allow retired names only as exact explanatory references; reject every executable/configuration occurrence, including assignments, mappings, expansions, command arguments, and valueless exports

## Validation

- `bash .github/scripts/check-doc-contracts.sh`
- `bash .github/scripts/check-doc-contracts.sh origin/main`
- `bash .github/scripts/test-doc-contracts.sh`
- `bash .github/scripts/test-go-version-contract.sh`
- `bash .github/scripts/test-release-notes.sh`
- `bash .github/scripts/test-release-workflow.sh`
- `bash .github/scripts/test-start-local.sh`
- `git diff --check`
- GitHub Actions `PR checks` run 393: passed, including documentation contracts, Compose validation, formatting, golangci-lint, and unit tests

## Scope and conflict resolution

Rebased onto current `main` after PRs #148 and #150 merged. PR #148's Compose network name, subnet, Traefik labels, `TRUSTED_PROXIES`, executable external-network examples, and related contracts are preserved. PR #150's API request-body and media-type documentation contracts and self-tests are also preserved.

This PR does not modify `docker-compose.yml`, Traefik network settings, or `.github/workflows/ci.yml` relative to current `main`.

Addresses the findings in:
- https://github.com/soulteary/stargate/pull/122#discussion_r3869274603
- https://github.com/soulteary/stargate/pull/135#discussion_r3870001268
- https://github.com/soulteary/stargate/pull/151#discussion_r3912837103
- https://github.com/soulteary/stargate/pull/151#discussion_r3912964350
- https://github.com/soulteary/stargate/pull/151#discussion_r3913054231
- https://github.com/soulteary/stargate/pull/151#discussion_r3913104722
- https://github.com/soulteary/stargate/pull/151#discussion_r3913165201
- https://github.com/soulteary/stargate/pull/151#discussion_r3913236957
- https://github.com/soulteary/stargate/pull/151#discussion_r3913324881
- https://github.com/soulteary/stargate/pull/151#discussion_r3913324891
