### PR TITLE
fix(auth): preserve sessions on refresh timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Preserve authenticated Warden sessions when an authorization refresh is
+  canceled or reaches the request deadline; the current request still fails
+  closed without turning a transient provider timeout into a logout.
 - Added a 10-second, strictly validated request-context deadline before tracing
   so Warden and Herald calls receive a real `Done` signal and are canceled on
   timeout or handler completion. Fiber/fasthttp client-disconnect limitations

--- a/src/internal/handlers/auth_refresh.go
+++ b/src/internal/handlers/auth_refresh.go
@@ -46,6 +46,12 @@ func refreshAuthorizationIfNeeded(ctx context.Context, sess *session.Session) (b
 		return false, errors.New("session has no refresh identity")
 	}
 	user := lookupRefreshUser(ctx, phone, mail)
+	if user == nil && ctx.Err() != nil {
+		// A canceled or expired request does not prove that the Warden user was
+		// removed or disabled. Fail the current refresh closed, but preserve the
+		// authenticated session so a transient timeout does not log the user out.
+		return false, ctx.Err()
+	}
 	if user == nil || (user.Status != "" && !strings.EqualFold(user.Status, "active")) {
 		_ = auth.Unauthenticate(sess)
 		return false, errors.New("user is no longer active")

--- a/src/internal/handlers/auth_refresh_test.go
+++ b/src/internal/handlers/auth_refresh_test.go
@@ -53,6 +53,32 @@ func TestAuthRefreshRejectsMissingOrDisabledUser(t *testing.T) {
 	testza.AssertFalse(t, auth.IsAuthenticated(sess))
 }
 
+func TestAuthRefreshPreservesSessionWhenRequestDeadlineExpires(t *testing.T) {
+	setupRefreshTest(t)
+	store := setupTestStore()
+	ctx, app := createTestContext("GET", "/_auth", nil, "")
+	defer app.ReleaseCtx(ctx)
+	sess, err := store.Get(ctx)
+	testza.AssertNoError(t, err)
+	sess.Set("user_mail", "active@example.com")
+	sess.Set("auth_method", "warden")
+	sess.Set("auth_refreshed_at", time.Now().Add(-time.Minute).Unix())
+	testza.AssertNoError(t, auth.Authenticate(sess))
+
+	lookupRefreshUser = func(ctx context.Context, _, _ string) *warden.AllowListUser {
+		<-ctx.Done()
+		return nil
+	}
+	requestCtx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-requestCtx.Done()
+
+	refreshed, err := refreshAuthorizationIfNeeded(requestCtx, sess)
+	testza.AssertEqual(t, context.DeadlineExceeded, err)
+	testza.AssertFalse(t, refreshed)
+	testza.AssertTrue(t, auth.IsAuthenticated(sess))
+}
+
 func TestAuthRefreshReplacesRevokedAuthorization(t *testing.T) {
 	setupRefreshTest(t)
 	store := setupTestStore()


### PR DESCRIPTION
## Summary

- preserve an authenticated Warden session when authorization refresh returns no user because the request context was canceled or reached its deadline
- continue failing the current request closed while keeping the existing explicit missing/disabled-user revocation behavior
- add regression coverage proving a deadline error does not log the user out
- document the user-visible behavior in the Unreleased changelog

## Why

After request deadlines were propagated in #145, a canceled Warden lookup returns `nil`. The refresh path treated that value like an explicitly missing or disabled user and destroyed the valid session. A transient provider timeout must fail the current request without becoming a persistent logout.

## Validation

- `bash .github/scripts/check-doc-contracts.sh`
- `bash .github/scripts/test-doc-contracts.sh`
- `bash .github/scripts/test-release-workflow.sh`
- `bash .github/scripts/test-start-local.sh`
- `git diff --check`

The local environment does not provide a Go toolchain; GitHub PR checks will run the Go unit and lint suites.

Addresses https://github.com/soulteary/stargate/pull/145#discussion_r3911197331