### PR TITLE
ci: validate CommonMark fenced blocks

### DIFF
--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -123,7 +123,7 @@ check_markdown_structure() {
     sub valid_reference_label {
       my ($label) = @_;
       return 0 if length($label) > 999;
-      return $label =~ /[^ \t]/;
+      return $label =~ /[^ \t\r\n]/;
     }
 
     sub reference_destination_prefix {
@@ -269,6 +269,74 @@ check_markdown_structure() {
       my $following = following_reference_title_lines(
         $containers, $line_index + 1, $lines);
       return defined $following ? 1 + $following : 1;
+    }
+
+    sub multiline_reference_label_lines {
+      my ($content, $containers, $line_index, $lines) = @_;
+      return 0 unless $content =~ /^ {0,3}\[(.*)$/;
+
+      my $label = "";
+      my $fragment = $1;
+      my $current_index = $line_index;
+      while (1) {
+        my $offset = 0;
+        while ($offset < length($fragment)) {
+          my $char = substr($fragment, $offset, 1);
+          if ($char eq "\\") {
+            return 0 if $offset + 1 >= length($fragment);
+            my $escaped = substr($fragment, $offset + 1, 1);
+            return 0 unless $escaped =~
+              /[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]/;
+            $label .= "\\$escaped";
+            $offset += 2;
+            next;
+          }
+          return 0 if $char eq "[";
+          if ($char eq "]") {
+            return 0 unless substr($fragment, $offset + 1, 1) eq ":";
+            return 0 unless valid_reference_label($label);
+
+            my $definition_tail = substr($fragment, $offset + 2);
+            my $label_lines = $current_index - $line_index;
+            if ($definition_tail =~ /^[ \t]*$/) {
+              my $destination_lines = multiline_reference_lines(
+                "[reference]:", $containers, $current_index, $lines);
+              return $destination_lines > 0
+                ? $label_lines + $destination_lines
+                : 0;
+            }
+
+            my @reference = link_reference_definition(
+              "[reference]:$definition_tail");
+            return 0 unless @reference;
+            my (undef, $title) = @reference;
+            if (defined $title) {
+              my $continued = reference_title_continuation_lines(
+                $title, $containers, $current_index, $lines);
+              return defined $continued
+                ? $label_lines + $continued
+                : 0;
+            }
+            my $following = following_reference_title_lines(
+              $containers, $current_index, $lines);
+            return $label_lines + (defined $following ? $following : 0);
+          }
+          $label .= $char;
+          $offset++;
+        }
+
+        return 0 if $current_index + 1 >= @$lines;
+        my $next_line = $lines->[$current_index + 1];
+        $next_line =~ s/\r$//;
+        $next_line = expand_tabs($next_line);
+        my ($container_offset, $matched) =
+          continue_containers($next_line, $containers);
+        return 0 if $matched < @$containers;
+        $fragment = substr($next_line, $container_offset);
+        return 0 if $fragment =~ /^ *$/;
+        $label .= "\n";
+        $current_index++;
+      }
     }
 
     sub interrupts_paragraph {
@@ -530,6 +598,15 @@ check_markdown_structure() {
             }
             if (!$paragraph_here) {
               my $continuation_lines = multiline_reference_lines(
+                $content, \@containers, $line_index, \@lines);
+              if ($continuation_lines > 0) {
+                $reference_lines_to_skip = $continuation_lines;
+                $paragraph_active = 0;
+                next LINE;
+              }
+            }
+            if (!$paragraph_here) {
+              my $continuation_lines = multiline_reference_label_lines(
                 $content, \@containers, $line_index, \@lines);
               if ($continuation_lines > 0) {
                 $reference_lines_to_skip = $continuation_lines;

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -19,6 +19,79 @@ check_markdown_structure() {
   if ! perl -MFile::Find -MFile::Basename -e '
     my $root = shift;
     my $failed = 0;
+
+    sub expand_leading_indent {
+      my ($line) = @_;
+      my $expanded = "";
+      my $column = 0;
+      my $offset = 0;
+      while ($offset < length($line)) {
+        my $char = substr($line, $offset, 1);
+        if ($char eq " ") {
+          $expanded .= " ";
+          $column++;
+        } elsif ($char eq "\t") {
+          my $width = 4 - ($column % 4);
+          $expanded .= " " x $width;
+          $column += $width;
+        } else {
+          last;
+        }
+        $offset++;
+      }
+      return $expanded . substr($line, $offset);
+    }
+
+    sub strip_block_quote_prefixes {
+      my ($line) = @_;
+      my $depth = 0;
+      while ($line =~ s/^ {0,3}>[ \t]?//) {
+        $depth++;
+      }
+      return ($line, $depth);
+    }
+
+    sub markdown_container_content {
+      my ($line, $list_indents) = @_;
+      $line = expand_leading_indent($line);
+      my ($leading) = $line =~ /^( *)/;
+      my $indent = length($leading);
+
+      # Blank lines do not end a list container. Keep the current content
+      # column so a fenced block after a blank line is still interpreted in
+      # the surrounding list item.
+      if ($line =~ /^ *$/) {
+        my $blank_base = @$list_indents ? $list_indents->[-1] : 0;
+        return ("", $blank_base);
+      }
+
+      # Continuation content is measured from the active list item content
+      # column. Pop containers when the line returns to an outer indentation.
+      while (@$list_indents && $indent < $list_indents->[-1]) {
+        pop @$list_indents;
+      }
+      my $base_indent = @$list_indents ? $list_indents->[-1] : 0;
+      my $content = substr($line, $base_indent);
+
+      # A child list marker may itself introduce a fence (for example
+      # "- ```"). CommonMark permits up to three spaces before the marker and
+      # uses one to four following spaces to determine its content column.
+      if ($content =~ /^( {0,3})([-+*]|\d{1,9}[.)])(?:([ ]+)|$)/) {
+        my ($before, $marker, $spacing) = ($1, $2, $3);
+        my $space_count = defined $spacing ? length($spacing) : 1;
+        my $padding = $space_count <= 4 ? $space_count : 1;
+        my $content_indent =
+          $base_indent + length($before) + length($marker) + $padding;
+        push @$list_indents, $content_indent;
+        my $nested = length($line) >= $content_indent
+          ? substr($line, $content_indent)
+          : "";
+        return ($nested, $content_indent);
+      }
+
+      return ($content, $base_indent);
+    }
+
     find({
       no_chdir => 1,
       wanted => sub {
@@ -29,20 +102,40 @@ check_markdown_structure() {
         my $text = <$fh>;
 
         my ($fence_char, $fence_length, $fence_line);
+        my ($fence_quote_depth, $fence_base_indent);
+        my $active_quote_depth = 0;
+        my @list_indents;
         my $line_number = 0;
         for my $line (split /\n/, $text, -1) {
           $line_number++;
           $line =~ s/\r$//;
           if (defined $fence_char) {
-            if ($line =~ /^ {0,3}(\Q$fence_char\E+)[ \t]*$/ && length($1) >= $fence_length) {
+            my ($container_line, $quote_depth) = strip_block_quote_prefixes($line);
+            $container_line = expand_leading_indent($container_line);
+            my ($leading) = $container_line =~ /^( *)/;
+            my $indent = length($leading);
+            my $candidate = $quote_depth == $fence_quote_depth
+              && $indent >= $fence_base_indent
+              ? substr($container_line, $fence_base_indent)
+              : "";
+            if ($candidate =~ /^ {0,3}(\Q$fence_char\E+)[ \t]*$/ && length($1) >= $fence_length) {
               undef $fence_char;
               undef $fence_length;
               undef $fence_line;
+              undef $fence_quote_depth;
+              undef $fence_base_indent;
             }
             next;
           }
 
-          next unless $line =~ /^ {0,3}(`{3,}|~{3,})(.*)$/;
+          my ($container_line, $quote_depth) = strip_block_quote_prefixes($line);
+          if ($quote_depth != $active_quote_depth) {
+            @list_indents = ();
+            $active_quote_depth = $quote_depth;
+          }
+          my ($content, $base_indent) =
+            markdown_container_content($container_line, \@list_indents);
+          next unless $content =~ /^ {0,3}(`{3,}|~{3,})(.*)$/;
           my ($marker, $info) = ($1, $2);
           my $char = substr($marker, 0, 1);
           # CommonMark does not treat a backtick sequence as an opening fence
@@ -51,6 +144,8 @@ check_markdown_structure() {
           $fence_char = $char;
           $fence_length = length($marker);
           $fence_line = $line_number;
+          $fence_quote_depth = $quote_depth;
+          $fence_base_indent = $base_indent;
         }
         if (defined $fence_char) {
           (my $relative = $file) =~ s{^\Q$root\E/?}{};

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -119,6 +119,52 @@ check_markdown_structure() {
       }x;
     }
 
+    sub reference_destination_details {
+      my ($content) = @_;
+      return unless $content =~ m{^ {0,3}
+        (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)
+        (?:([ \t]+(?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\))))?
+        [ \t]*$
+      }x;
+      return (1, defined($1));
+    }
+
+    sub reference_title_line {
+      my ($content) = @_;
+      return $content =~ m{^ {0,3}
+        (?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\))
+        [ \t]*$
+      }x;
+    }
+
+    sub multiline_reference_lines {
+      my ($content, $containers, $line_index, $lines) = @_;
+      return 0 unless $content =~ m{^ {0,3}
+        \[(?:\\.|[^\]\\])+\]:[ \t]*$
+      }x;
+      return 0 if $line_index + 1 >= @$lines;
+
+      my $destination_line = $lines->[$line_index + 1];
+      $destination_line =~ s/\r$//;
+      $destination_line = expand_tabs($destination_line);
+      my ($offset, $matched) =
+        continue_containers($destination_line, $containers);
+      return 0 if $matched < @$containers;
+      my @destination =
+        reference_destination_details(substr($destination_line, $offset));
+      return 0 unless @destination;
+
+      my (undef, $has_title) = @destination;
+      return 1 if $has_title || $line_index + 2 >= @$lines;
+
+      my $title_line = $lines->[$line_index + 2];
+      $title_line =~ s/\r$//;
+      $title_line = expand_tabs($title_line);
+      ($offset, $matched) = continue_containers($title_line, $containers);
+      return 1 if $matched < @$containers;
+      return reference_title_line(substr($title_line, $offset)) ? 2 : 1;
+    }
+
     sub interrupts_paragraph {
       my ($remaining) = @_;
       return 1 if $remaining =~ /^ *$/;
@@ -243,10 +289,19 @@ check_markdown_structure() {
         my $paragraph_active = 0;
         my $paragraph_depth = 0;
         my $line_number = 0;
-        LINE: for my $line (split /\n/, $text, -1) {
-          $line_number++;
+        my $reference_lines_to_skip = 0;
+        my @lines = split /\n/, $text, -1;
+        LINE: for (my $line_index = 0;
+                   $line_index < @lines;
+                   $line_index++) {
+          my $line = $lines[$line_index];
+          $line_number = $line_index + 1;
           $line =~ s/\r$//;
           $line = expand_tabs($line);
+          if ($reference_lines_to_skip > 0) {
+            $reference_lines_to_skip--;
+            next LINE;
+          }
 
           # A container can end before its fenced block is explicitly closed.
           # Report that opening fence immediately, then parse the current line
@@ -348,6 +403,15 @@ check_markdown_structure() {
             if (!$paragraph_here && link_reference_definition($content)) {
               $paragraph_active = 0;
               next LINE;
+            }
+            if (!$paragraph_here) {
+              my $continuation_lines = multiline_reference_lines(
+                $content, \@containers, $line_index, \@lines);
+              if ($continuation_lines > 0) {
+                $reference_lines_to_skip = $continuation_lines;
+                $paragraph_active = 0;
+                next LINE;
+              }
             }
 
             my ($starts_html, $html_end, $until_blank, $html_interrupts) =

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -222,6 +222,7 @@ check_markdown_structure() {
         return if $matched < @$containers;
         my $content = substr($line, $offset);
         return if $content =~ /^ *$/;
+        return if interrupts_paragraph($content);
         $title .= "\n$content";
         $continuation_lines++;
         return $continuation_lines if reference_title($title);
@@ -295,7 +296,13 @@ check_markdown_structure() {
         while ($offset < length($fragment)) {
           my $char = substr($fragment, $offset, 1);
           if ($char eq "\\") {
-            return 0 if $offset + 1 >= length($fragment);
+            if ($offset + 1 >= length($fragment)) {
+              # A terminal backslash does not escape through a physical line
+              # ending; both it and the newline remain label characters.
+              $label .= "\\";
+              $offset++;
+              next;
+            }
             my $escaped = substr($fragment, $offset + 1, 1);
             $label .= "\\$escaped";
             $offset += 2;
@@ -344,6 +351,7 @@ check_markdown_structure() {
         return 0 if $matched < @$containers;
         $fragment = substr($next_line, $container_offset);
         return 0 if $fragment =~ /^ *$/;
+        return 0 if interrupts_paragraph($fragment);
         $label .= "\n";
         $current_index++;
       }

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -261,8 +261,13 @@ check_markdown_structure() {
       my ($offset, $matched) =
         continue_containers($destination_line, $containers);
       return 0 if $matched < @$containers;
+      my $destination_content = substr($destination_line, $offset);
+      # A next-line destination remains part of the interrupted paragraph.
+      # Block constructs which can interrupt that paragraph take precedence
+      # over interpreting their marker text as a bare destination.
+      return 0 if interrupts_paragraph($destination_content);
       my @destination =
-        reference_destination_details(substr($destination_line, $offset));
+        reference_destination_details($destination_content);
       return 0 unless @destination;
 
       my (undef, $title) = @destination;

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -311,8 +311,20 @@ check_markdown_structure() {
             my $opened;
             ($offset, $opened) =
               open_containers($line, $offset, \@containers, $paragraph_here);
-            $paragraph_active = 0 if $opened;
+            if ($opened) {
+              $paragraph_active = 0;
+              $paragraph_here = 0;
+            }
             my $content = substr($line, $offset);
+
+            # Four spaces at the current container content column start an
+            # indented code leaf when there is no paragraph to continue. It
+            # must not create paragraph state that prevents a later non-one
+            # ordered list from opening.
+            if (!$paragraph_here && $content =~ /^ {4}/) {
+              $paragraph_active = 0;
+              next LINE;
+            }
 
             my ($starts_html, $html_end, $until_blank, $html_interrupts) =
               html_block_start($content);

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -82,14 +82,16 @@ check_markdown_structure() {
         $remaining =~ /^( {0,3})([-+*]|\d{1,9}[.)])(?:([ ]+)|$)/;
       my ($before, $marker, $spacing) = ($1, $2, $3);
       my $space_count = defined $spacing ? length($spacing) : 1;
-      my $padding = $space_count <= 4 ? $space_count : 1;
+      my $after_marker = substr(
+        $remaining, length($before) + length($marker));
+      my $has_content = $after_marker =~ /[^ ]/;
+      my $padding = $has_content && $space_count <= 4 ? $space_count : 1;
       my $width = length($before) + length($marker) + $padding;
       my $content = length($remaining) >= $width
         ? substr($remaining, $width)
         : "";
       my $ordered = $marker =~ /^(\d{1,9})[.)]$/;
       my $start = $ordered ? 0 + $1 : 0;
-      my $has_content = $content =~ /[^ ]/;
       return ($width, $ordered, $start, $has_content);
     }
 
@@ -112,11 +114,12 @@ check_markdown_structure() {
     sub reference_title {
       my ($content) = @_;
       # CommonMark backslash escapes may protect ASCII punctuation, including
-      # the delimiter used by any of the three reference-title forms.
+      # the delimiter used by any title form. Before other characters, a
+      # backslash remains literal rather than making the title invalid.
       return $content =~ m{^(?:
-        "(?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^"\\])*" |
-        \x27(?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^\x27\\])*\x27 |
-        \((?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^()\\])*\)
+        "(?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|\\(?=[^\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])|[^"\\])*" |
+        \x27(?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|\\(?=[^\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])|[^\x27\\])*\x27 |
+        \((?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|\\(?=[^\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])|[^()\\])*\)
       )[ \t]*$}x;
     }
 
@@ -174,7 +177,7 @@ check_markdown_structure() {
     sub link_reference_definition {
       my ($content) = @_;
       return unless $content =~ m{^[ ]{0,3}
-        \[((?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^\[\]\\])+)
+        \[((?:\\[^\r\n]|[^\[\]\\])+)
         \]:[ \t]*(.*)$
       }x;
       my ($label, $destination_text) = ($1, $2);
@@ -242,7 +245,7 @@ check_markdown_structure() {
     sub multiline_reference_lines {
       my ($content, $containers, $line_index, $lines) = @_;
       return 0 unless $content =~ m{^[ ]{0,3}
-        \[((?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^\[\]\\])+)
+        \[((?:\\[^\r\n]|[^\[\]\\])+)
         \]:[ \t]*$
       }x;
       return 0 unless valid_reference_label($1);
@@ -285,8 +288,6 @@ check_markdown_structure() {
           if ($char eq "\\") {
             return 0 if $offset + 1 >= length($fragment);
             my $escaped = substr($fragment, $offset + 1, 1);
-            return 0 unless $escaped =~
-              /[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]/;
             $label .= "\\$escaped";
             $offset += 2;
             next;

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -130,7 +130,7 @@ check_markdown_structure() {
     sub valid_reference_label {
       my ($label) = @_;
       return 0 if length($label) > 999;
-      return $label =~ /[^ \t\r\n]/;
+      return $label =~ /\S/;
     }
 
     sub reference_destination_prefix {

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -100,6 +100,9 @@ check_markdown_structure() {
       return 1 if $remaining =~ /^ {0,3}(?:`{3,}|~{3,})/;
       return 1 if $remaining =~ /^ {0,3}#{1,6}(?:[ ]|$)/;
       return 1 if thematic_break($remaining);
+      my ($starts_html, undef, undef, $html_interrupts) =
+        html_block_start($remaining);
+      return 1 if $starts_html && $html_interrupts;
 
       my @marker = list_marker_details($remaining);
       if (@marker) {
@@ -115,6 +118,43 @@ check_markdown_structure() {
       return 0 if $remaining =~ /^ {0,3}#{1,6}(?:[ ]|$)/;
       return 0 if thematic_break($remaining);
       return 1;
+    }
+
+    sub html_block_start {
+      my ($content) = @_;
+      return (1, qr/-->/, 0, 1) if $content =~ /^ {0,3}<!--/;
+      return (1, qr/\?>/, 0, 1) if $content =~ /^ {0,3}<\?/;
+      return (1, qr/\]\]>/, 0, 1) if $content =~ /^ {0,3}<!\[CDATA\[/;
+      return (1, qr/>/, 0, 1) if $content =~ /^ {0,3}<![A-Z]/;
+
+      if ($content =~ /^ {0,3}<(script|pre|style|textarea)(?:[ \t]|>|$)/i) {
+        my $tag = $1;
+        return (1, qr{</\Q$tag\E[ \t]*>}i, 0, 1);
+      }
+
+      if ($content =~ m{^ {0,3}</?(?:
+          address|article|aside|base|basefont|blockquote|body|caption|center|col|
+          colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|
+          footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|
+          li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|
+          search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul
+        )(?:[ \t]|/?>|$)}ix) {
+        return (1, undef, 1, 1);
+      }
+
+      # A complete open or closing tag for any other element starts a type-7
+      # HTML block only where it does not interrupt an existing paragraph.
+      if ($content =~ m{^ {0,3}</[A-Za-z][A-Za-z0-9-]*[ \t]*>[ \t]*$} ||
+          $content =~ m{^ {0,3}<[A-Za-z][A-Za-z0-9-]*(?:[ \t]+[A-Za-z_:][A-Za-z0-9_.:-]*(?:[ \t]*=[ \t]*(?:[^\x00-\x20"\x27=<>`]+|"[^"]*"|\x27[^\x27]*\x27))?)*[ \t]*/?>[ \t]*$}) {
+        return (1, undef, 1, 0);
+      }
+      return (0, undef, 0, 0);
+    }
+
+    sub html_block_finished {
+      my ($content, $end_pattern, $until_blank) = @_;
+      return $content =~ /^ *$/ if $until_blank;
+      return $content =~ /$end_pattern/;
     }
 
     sub open_containers {
@@ -169,6 +209,10 @@ check_markdown_structure() {
         my ($fence_char, $fence_length, $fence_line);
         my @containers;
         my @fence_containers;
+        my $html_active = 0;
+        my $html_end_pattern;
+        my $html_until_blank = 0;
+        my @html_containers;
         my $paragraph_active = 0;
         my $paragraph_depth = 0;
         my $line_number = 0;
@@ -209,6 +253,33 @@ check_markdown_structure() {
               next LINE;
             }
 
+            if ($html_active) {
+              my ($offset, $matched) =
+                continue_containers($line, \@html_containers);
+              if ($matched < @html_containers) {
+                # Unlike a fenced block, a raw HTML block simply ends when
+                # its list or block-quote container ends. Reprocess the line
+                # at the surviving outer container level.
+                splice @containers, $matched;
+                $html_active = 0;
+                undef $html_end_pattern;
+                $html_until_blank = 0;
+                @html_containers = ();
+                $paragraph_active = 0;
+                next REPROCESS;
+              }
+
+              my $html_content = substr($line, $offset);
+              if (html_block_finished(
+                  $html_content, $html_end_pattern, $html_until_blank)) {
+                $html_active = 0;
+                undef $html_end_pattern;
+                $html_until_blank = 0;
+                @html_containers = ();
+              }
+              next LINE;
+            }
+
             my ($offset, $matched) = continue_containers($line, \@containers);
             if ($matched < @containers) {
               my $remaining = substr($line, $offset);
@@ -230,6 +301,20 @@ check_markdown_structure() {
               open_containers($line, $offset, \@containers, $paragraph_here);
             $paragraph_active = 0 if $opened;
             my $content = substr($line, $offset);
+
+            my ($starts_html, $html_end, $until_blank, $html_interrupts) =
+              html_block_start($content);
+            if ($starts_html && (!$paragraph_here || $html_interrupts)) {
+              $paragraph_active = 0;
+              unless (html_block_finished($content, $html_end, $until_blank)) {
+                $html_active = 1;
+                $html_end_pattern = $html_end;
+                $html_until_blank = $until_blank;
+                @html_containers = map { { %$_ } } @containers;
+              }
+              next LINE;
+            }
+
             if ($content =~ /^ {0,3}(`{3,}|~{3,})(.*)$/) {
               my ($marker, $info) = ($1, $2);
               my $char = substr($marker, 0, 1);

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -104,6 +104,21 @@ check_markdown_structure() {
       return ($char, length($marker));
     }
 
+    sub setext_underline {
+      my ($content) = @_;
+      return $content =~ /^ {0,3}(?:=+|-+)[ \t]*$/;
+    }
+
+    sub link_reference_definition {
+      my ($content) = @_;
+      return $content =~ m{^ {0,3}
+        \[(?:\\.|[^\]\\])+\]:[ \t]*
+        (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)
+        (?:[ \t]+(?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\)))?
+        [ \t]*$
+      }x;
+    }
+
     sub interrupts_paragraph {
       my ($remaining) = @_;
       return 1 if $remaining =~ /^ *$/;
@@ -322,6 +337,15 @@ check_markdown_structure() {
             # must not create paragraph state that prevents a later non-one
             # ordered list from opening.
             if (!$paragraph_here && $content =~ /^ {4}/) {
+              $paragraph_active = 0;
+              next LINE;
+            }
+
+            if ($paragraph_here && setext_underline($content)) {
+              $paragraph_active = 0;
+              next LINE;
+            }
+            if (!$paragraph_here && link_reference_definition($content)) {
               $paragraph_active = 0;
               next LINE;
             }

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -111,12 +111,13 @@ check_markdown_structure() {
 
     sub link_reference_definition {
       my ($content) = @_;
-      return $content =~ m{^ {0,3}
+      return unless $content =~ m{^ {0,3}
         \[(?:\\.|[^\]\\])+\]:[ \t]*
         (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)
-        (?:[ \t]+(?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\)))?
+        (?:[ \t]+("[^"]*"|\x27[^\x27]*\x27|\([^()]*\)))?
         [ \t]*$
       }x;
+      return (1, defined($1));
     }
 
     sub reference_destination_details {
@@ -135,6 +136,18 @@ check_markdown_structure() {
         (?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\))
         [ \t]*$
       }x;
+    }
+
+    sub following_reference_title_line {
+      my ($containers, $line_index, $lines) = @_;
+      return 0 if $line_index + 1 >= @$lines;
+
+      my $title_line = $lines->[$line_index + 1];
+      $title_line =~ s/\r$//;
+      $title_line = expand_tabs($title_line);
+      my ($offset, $matched) = continue_containers($title_line, $containers);
+      return 0 if $matched < @$containers;
+      return reference_title_line(substr($title_line, $offset));
     }
 
     sub multiline_reference_lines {
@@ -400,9 +413,17 @@ check_markdown_structure() {
               $paragraph_active = 0;
               next LINE;
             }
-            if (!$paragraph_here && link_reference_definition($content)) {
-              $paragraph_active = 0;
-              next LINE;
+            if (!$paragraph_here) {
+              my @reference = link_reference_definition($content);
+              if (@reference) {
+                my (undef, $has_title) = @reference;
+                if (!$has_title && following_reference_title_line(
+                    \@containers, $line_index, \@lines)) {
+                  $reference_lines_to_skip = 1;
+                }
+                $paragraph_active = 0;
+                next LINE;
+              }
             }
             if (!$paragraph_here) {
               my $continuation_lines = multiline_reference_lines(

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -120,13 +120,21 @@ check_markdown_structure() {
       )[ \t]*$}x;
     }
 
+    sub valid_reference_label {
+      my ($label) = @_;
+      return 0 if length($label) > 999;
+      return $label =~ /[^ \t]/;
+    }
+
     sub link_reference_definition {
       my ($content) = @_;
-      return unless $content =~ m{^ {0,3}
-        \[(?:\\.|[^\]\\])+\]:[ \t]*
+      return unless $content =~ m{^[ ]{0,3}
+        \[((?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^\[\]\\])+)
+        \]:[ \t]*
         (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)(.*)$
       }x;
-      my $remainder = $1;
+      my ($label, $remainder) = ($1, $2);
+      return unless valid_reference_label($label);
       return (1, 0) if $remainder =~ /^[ \t]*$/;
       return unless $remainder =~ s/^[ \t]+//;
       return unless reference_title($remainder);
@@ -135,7 +143,7 @@ check_markdown_structure() {
 
     sub reference_destination_details {
       my ($content) = @_;
-      return unless $content =~ m{^ {0,3}
+      return unless $content =~ m{^[ ]{0,3}
         (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)(.*)$
       }x;
       my $remainder = $1;
@@ -165,9 +173,11 @@ check_markdown_structure() {
 
     sub multiline_reference_lines {
       my ($content, $containers, $line_index, $lines) = @_;
-      return 0 unless $content =~ m{^ {0,3}
-        \[(?:\\.|[^\]\\])+\]:[ \t]*$
+      return 0 unless $content =~ m{^[ ]{0,3}
+        \[((?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^\[\]\\])+)
+        \]:[ \t]*$
       }x;
+      return 0 unless valid_reference_label($1);
       return 0 if $line_index + 1 >= @$lines;
 
       my $destination_line = $lines->[$line_index + 1];
@@ -224,14 +234,14 @@ check_markdown_structure() {
       return (1, qr/-->/, 0, 1) if $content =~ /^ {0,3}<!--/;
       return (1, qr/\?>/, 0, 1) if $content =~ /^ {0,3}<\?/;
       return (1, qr/\]\]>/, 0, 1) if $content =~ /^ {0,3}<!\[CDATA\[/;
-      return (1, qr/>/, 0, 1) if $content =~ /^ {0,3}<![A-Z]/;
+      return (1, qr/>/, 0, 1) if $content =~ /^ {0,3}<![A-Za-z]/;
 
       if ($content =~ /^ {0,3}<(script|pre|style|textarea)(?:[ \t]|>|$)/i) {
         my $tag = $1;
         return (1, qr{</\Q$tag\E>}i, 0, 1);
       }
 
-      if ($content =~ m{^ {0,3}</?(?:
+      if ($content =~ m{^[ ]{0,3}</?(?:
           address|article|aside|base|basefont|blockquote|body|caption|center|col|
           colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|
           footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -115,6 +115,11 @@ check_markdown_structure() {
       return $content =~ /^ {0,3}(?:=+|-+)[ \t]*$/;
     }
 
+    sub reference_continuation_boundary {
+      my ($content) = @_;
+      return setext_underline($content) || interrupts_paragraph($content);
+    }
+
     sub reference_title {
       my ($content) = @_;
       # CommonMark backslash escapes may protect ASCII punctuation, including
@@ -158,7 +163,7 @@ check_markdown_structure() {
       my $parentheses = 0;
       while ($offset < length($content)) {
         my $char = substr($content, $offset, 1);
-        last if $char eq " " || $char eq "\t";
+        last if $char =~ /\s/;
         return if ord($char) < 0x20 || ord($char) == 0x7f;
         if ($char eq "\\" && $offset + 1 < length($content) &&
             substr($content, $offset + 1, 1) =~
@@ -222,7 +227,7 @@ check_markdown_structure() {
         return if $matched < @$containers;
         my $content = substr($line, $offset);
         return if $content =~ /^ *$/;
-        return if interrupts_paragraph($content);
+        return if reference_continuation_boundary($content);
         $title .= "\n$content";
         $continuation_lines++;
         return $continuation_lines if reference_title($title);
@@ -266,7 +271,7 @@ check_markdown_structure() {
       # A next-line destination remains part of the interrupted paragraph.
       # Block constructs which can interrupt that paragraph take precedence
       # over interpreting their marker text as a bare destination.
-      return 0 if interrupts_paragraph($destination_content);
+      return 0 if reference_continuation_boundary($destination_content);
       my @destination =
         reference_destination_details($destination_content);
       return 0 unless @destination;
@@ -351,7 +356,7 @@ check_markdown_structure() {
         return 0 if $matched < @$containers;
         $fragment = substr($next_line, $container_offset);
         return 0 if $fragment =~ /^ *$/;
-        return 0 if interrupts_paragraph($fragment);
+        return 0 if reference_continuation_boundary($fragment);
         $label .= "\n";
         $current_index++;
       }

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -93,11 +93,23 @@ check_markdown_structure() {
       return ($width, $ordered, $start, $has_content);
     }
 
+    sub fence_opener_details {
+      my ($content) = @_;
+      return unless $content =~ /^ {0,3}(`{3,}|~{3,})(.*)$/;
+      my ($marker, $info) = ($1, $2);
+      my $char = substr($marker, 0, 1);
+      # A backtick sequence whose info string contains a backtick is paragraph
+      # text, not a fenced-code opener. Tilde info strings have no such rule.
+      return if $char eq "`" && index($info, "`") >= 0;
+      return ($char, length($marker));
+    }
+
     sub interrupts_paragraph {
       my ($remaining) = @_;
       return 1 if $remaining =~ /^ *$/;
       return 1 if $remaining =~ /^ {0,3}>/;
-      return 1 if $remaining =~ /^ {0,3}(?:`{3,}|~{3,})/;
+      my @fence = fence_opener_details($remaining);
+      return 1 if @fence;
       return 1 if $remaining =~ /^ {0,3}#{1,6}(?:[ ]|$)/;
       return 1 if thematic_break($remaining);
       my ($starts_html, undef, undef, $html_interrupts) =
@@ -315,19 +327,15 @@ check_markdown_structure() {
               next LINE;
             }
 
-            if ($content =~ /^ {0,3}(`{3,}|~{3,})(.*)$/) {
-              my ($marker, $info) = ($1, $2);
-              my $char = substr($marker, 0, 1);
-              # CommonMark does not treat a backtick sequence as an opening
-              # fence when its info string itself contains a backtick.
-              if ($char ne "`" || index($info, "`") < 0) {
-                $fence_char = $char;
-                $fence_length = length($marker);
-                $fence_line = $line_number;
-                @fence_containers = map { { %$_ } } @containers;
-                $paragraph_active = 0;
-                next LINE;
-              }
+            my ($opening_char, $opening_length) =
+              fence_opener_details($content);
+            if (defined $opening_char) {
+              $fence_char = $opening_char;
+              $fence_length = $opening_length;
+              $fence_line = $line_number;
+              @fence_containers = map { { %$_ } } @containers;
+              $paragraph_active = 0;
+              next LINE;
             }
 
             if (paragraph_content($content)) {

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -16,15 +16,6 @@ check_markdown_structure() {
   local root=$1
   local failed=false
 
-  while IFS= read -r -d '' file; do
-    local fences
-    fences=$(grep -c '^```' "$file" || true)
-    if (( fences % 2 != 0 )); then
-      echo "Unclosed fenced code block: ${file#"$root"/}" >&2
-      failed=true
-    fi
-  done < <(find "$root" -type f -name '*.md' -not -path '*/.git/*' -print0)
-
   if ! perl -MFile::Find -MFile::Basename -e '
     my $root = shift;
     my $failed = 0;
@@ -36,6 +27,37 @@ check_markdown_structure() {
         open my $fh, "<", $file or die "open $file: $!";
         local $/;
         my $text = <$fh>;
+
+        my ($fence_char, $fence_length, $fence_line);
+        my $line_number = 0;
+        for my $line (split /\n/, $text, -1) {
+          $line_number++;
+          $line =~ s/\r$//;
+          if (defined $fence_char) {
+            if ($line =~ /^ {0,3}(\Q$fence_char\E+)[ \t]*$/ && length($1) >= $fence_length) {
+              undef $fence_char;
+              undef $fence_length;
+              undef $fence_line;
+            }
+            next;
+          }
+
+          next unless $line =~ /^ {0,3}(`{3,}|~{3,})(.*)$/;
+          my ($marker, $info) = ($1, $2);
+          my $char = substr($marker, 0, 1);
+          # CommonMark does not treat a backtick sequence as an opening fence
+          # when its info string itself contains a backtick.
+          next if $char eq "`" && index($info, "`") >= 0;
+          $fence_char = $char;
+          $fence_length = length($marker);
+          $fence_line = $line_number;
+        }
+        if (defined $fence_char) {
+          (my $relative = $file) =~ s{^\Q$root\E/?}{};
+          warn "Unclosed fenced code block in $relative:$fence_line\n";
+          $failed = 1;
+        }
+
         while ($text =~ /\[[^\]]*\]\(([^)]+)\)/g) {
           my $target = $1;
           $target =~ s/^<|>$//g;

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -92,7 +92,11 @@ check_markdown_structure() {
         : "";
       my $ordered = $marker =~ /^(\d{1,9})[.)]$/;
       my $start = $ordered ? 0 + $1 : 0;
-      return ($width, $ordered, $start, $has_content);
+      my $starts_with_indented_code = $content =~ /^ {4}/;
+      return (
+        $width, $ordered, $start, $has_content,
+        $starts_with_indented_code,
+      );
     }
 
     sub fence_opener_details {
@@ -354,8 +358,10 @@ check_markdown_structure() {
 
       my @marker = list_marker_details($remaining);
       if (@marker) {
-        my (undef, $ordered, $start, $has_content) = @marker;
-        return 1 if $has_content && (!$ordered || $start == 1);
+        my (undef, $ordered, $start, $has_content,
+            $starts_with_indented_code) = @marker;
+        return 1 if $has_content && !$starts_with_indented_code &&
+          (!$ordered || $start == 1);
       }
       return 0;
     }
@@ -427,11 +433,14 @@ check_markdown_structure() {
 
         my @marker = list_marker_details($remaining);
         if (@marker) {
-          my ($width, $ordered, $start, $has_content) = @marker;
+          my ($width, $ordered, $start, $has_content,
+              $starts_with_indented_code) = @marker;
           # An ordered list can interrupt a paragraph only when it starts at
-          # one, and an empty item cannot interrupt a paragraph at all.
+          # one. Empty items and items whose first block is indented code also
+          # cannot interrupt a paragraph.
           last if $paragraph_active &&
-            (!$has_content || ($ordered && $start != 1));
+            (!$has_content || $starts_with_indented_code ||
+             ($ordered && $start != 1));
           push @$containers, { type => "list", width => $width };
           $offset += $width;
           $offset = length($line) if $offset > length($line);

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -109,33 +109,46 @@ check_markdown_structure() {
       return $content =~ /^ {0,3}(?:=+|-+)[ \t]*$/;
     }
 
+    sub reference_title {
+      my ($content) = @_;
+      # CommonMark backslash escapes may protect ASCII punctuation, including
+      # the delimiter used by any of the three reference-title forms.
+      return $content =~ m{^(?:
+        "(?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^"\\])*" |
+        \x27(?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^\x27\\])*\x27 |
+        \((?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^()\\])*\)
+      )[ \t]*$}x;
+    }
+
     sub link_reference_definition {
       my ($content) = @_;
       return unless $content =~ m{^ {0,3}
         \[(?:\\.|[^\]\\])+\]:[ \t]*
-        (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)
-        (?:[ \t]+("[^"]*"|\x27[^\x27]*\x27|\([^()]*\)))?
-        [ \t]*$
+        (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)(.*)$
       }x;
-      return (1, defined($1));
+      my $remainder = $1;
+      return (1, 0) if $remainder =~ /^[ \t]*$/;
+      return unless $remainder =~ s/^[ \t]+//;
+      return unless reference_title($remainder);
+      return (1, 1);
     }
 
     sub reference_destination_details {
       my ($content) = @_;
       return unless $content =~ m{^ {0,3}
-        (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)
-        (?:([ \t]+(?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\))))?
-        [ \t]*$
+        (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)(.*)$
       }x;
-      return (1, defined($1));
+      my $remainder = $1;
+      return (1, 0) if $remainder =~ /^[ \t]*$/;
+      return unless $remainder =~ s/^[ \t]+//;
+      return unless reference_title($remainder);
+      return (1, 1);
     }
 
     sub reference_title_line {
       my ($content) = @_;
-      return $content =~ m{^ {0,3}
-        (?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\))
-        [ \t]*$
-      }x;
+      return 0 unless $content =~ /^ {0,3}(.*)$/;
+      return reference_title($1);
     }
 
     sub following_reference_title_line {
@@ -215,7 +228,7 @@ check_markdown_structure() {
 
       if ($content =~ /^ {0,3}<(script|pre|style|textarea)(?:[ \t]|>|$)/i) {
         my $tag = $1;
-        return (1, qr{</\Q$tag\E[ \t]*>}i, 0, 1);
+        return (1, qr{</\Q$tag\E>}i, 0, 1);
       }
 
       if ($content =~ m{^ {0,3}</?(?:

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -20,76 +20,84 @@ check_markdown_structure() {
     my $root = shift;
     my $failed = 0;
 
-    sub expand_leading_indent {
+    sub expand_tabs {
       my ($line) = @_;
       my $expanded = "";
       my $column = 0;
-      my $offset = 0;
-      while ($offset < length($line)) {
+      for my $offset (0 .. length($line) - 1) {
         my $char = substr($line, $offset, 1);
-        if ($char eq " ") {
-          $expanded .= " ";
-          $column++;
-        } elsif ($char eq "\t") {
+        if ($char eq "\t") {
           my $width = 4 - ($column % 4);
           $expanded .= " " x $width;
           $column += $width;
         } else {
-          last;
+          $expanded .= $char;
+          $column++;
         }
-        $offset++;
       }
-      return $expanded . substr($line, $offset);
+      return $expanded;
     }
 
-    sub strip_block_quote_prefixes {
-      my ($line) = @_;
-      my $depth = 0;
-      while ($line =~ s/^ {0,3}>[ \t]?//) {
-        $depth++;
+    sub consume_container {
+      my ($line, $offset, $container) = @_;
+      my $remaining = substr($line, $offset);
+
+      if ($container->{type} eq "quote") {
+        return -1 unless $remaining =~ /^( {0,3})>/;
+        my $consumed = length($1) + 1;
+        $consumed++ if substr($remaining, $consumed, 1) eq " ";
+        return $offset + $consumed;
       }
-      return ($line, $depth);
+
+      # Blank lines may remain in a list item without repeating its content
+      # indentation. A non-blank continuation must provide the full width.
+      return length($line) if $remaining =~ /^ *$/;
+      my $width = $container->{width};
+      return -1 if length($remaining) < $width;
+      return -1 unless substr($remaining, 0, $width) eq " " x $width;
+      return $offset + $width;
     }
 
-    sub markdown_container_content {
-      my ($line, $list_indents) = @_;
-      $line = expand_leading_indent($line);
-      my ($leading) = $line =~ /^( *)/;
-      my $indent = length($leading);
-
-      # Blank lines do not end a list container. Keep the current content
-      # column so a fenced block after a blank line is still interpreted in
-      # the surrounding list item.
-      if ($line =~ /^ *$/) {
-        my $blank_base = @$list_indents ? $list_indents->[-1] : 0;
-        return ("", $blank_base);
+    sub continue_containers {
+      my ($line, $containers) = @_;
+      my $offset = 0;
+      my $matched = 0;
+      for my $container (@$containers) {
+        my $next = consume_container($line, $offset, $container);
+        last if $next < 0;
+        $offset = $next;
+        $matched++;
       }
+      return ($offset, $matched);
+    }
 
-      # Continuation content is measured from the active list item content
-      # column. Pop containers when the line returns to an outer indentation.
-      while (@$list_indents && $indent < $list_indents->[-1]) {
-        pop @$list_indents;
+    sub open_containers {
+      my ($line, $offset, $containers) = @_;
+      while ($offset <= length($line)) {
+        my $remaining = substr($line, $offset);
+
+        if ($remaining =~ /^( {0,3})>/) {
+          my $consumed = length($1) + 1;
+          $consumed++ if substr($remaining, $consumed, 1) eq " ";
+          push @$containers, { type => "quote" };
+          $offset += $consumed;
+          next;
+        }
+
+        if ($remaining =~ /^( {0,3})([-+*]|\d{1,9}[.)])(?:([ ]+)|$)/) {
+          my ($before, $marker, $spacing) = ($1, $2, $3);
+          my $space_count = defined $spacing ? length($spacing) : 1;
+          my $padding = $space_count <= 4 ? $space_count : 1;
+          my $width = length($before) + length($marker) + $padding;
+          push @$containers, { type => "list", width => $width };
+          $offset += $width;
+          $offset = length($line) if $offset > length($line);
+          next;
+        }
+
+        last;
       }
-      my $base_indent = @$list_indents ? $list_indents->[-1] : 0;
-      my $content = substr($line, $base_indent);
-
-      # A child list marker may itself introduce a fence (for example
-      # "- ```"). CommonMark permits up to three spaces before the marker and
-      # uses one to four following spaces to determine its content column.
-      if ($content =~ /^( {0,3})([-+*]|\d{1,9}[.)])(?:([ ]+)|$)/) {
-        my ($before, $marker, $spacing) = ($1, $2, $3);
-        my $space_count = defined $spacing ? length($spacing) : 1;
-        my $padding = $space_count <= 4 ? $space_count : 1;
-        my $content_indent =
-          $base_indent + length($before) + length($marker) + $padding;
-        push @$list_indents, $content_indent;
-        my $nested = length($line) >= $content_indent
-          ? substr($line, $content_indent)
-          : "";
-        return ($nested, $content_indent);
-      }
-
-      return ($content, $base_indent);
+      return $offset;
     }
 
     find({
@@ -102,50 +110,60 @@ check_markdown_structure() {
         my $text = <$fh>;
 
         my ($fence_char, $fence_length, $fence_line);
-        my ($fence_quote_depth, $fence_base_indent);
-        my $active_quote_depth = 0;
-        my @list_indents;
+        my @containers;
+        my @fence_containers;
         my $line_number = 0;
-        for my $line (split /\n/, $text, -1) {
+        LINE: for my $line (split /\n/, $text, -1) {
           $line_number++;
           $line =~ s/\r$//;
-          if (defined $fence_char) {
-            my ($container_line, $quote_depth) = strip_block_quote_prefixes($line);
-            $container_line = expand_leading_indent($container_line);
-            my ($leading) = $container_line =~ /^( *)/;
-            my $indent = length($leading);
-            my $candidate = $quote_depth == $fence_quote_depth
-              && $indent >= $fence_base_indent
-              ? substr($container_line, $fence_base_indent)
-              : "";
-            if ($candidate =~ /^ {0,3}(\Q$fence_char\E+)[ \t]*$/ && length($1) >= $fence_length) {
-              undef $fence_char;
-              undef $fence_length;
-              undef $fence_line;
-              undef $fence_quote_depth;
-              undef $fence_base_indent;
-            }
-            next;
-          }
+          $line = expand_tabs($line);
 
-          my ($container_line, $quote_depth) = strip_block_quote_prefixes($line);
-          if ($quote_depth != $active_quote_depth) {
-            @list_indents = ();
-            $active_quote_depth = $quote_depth;
+          # A container can end before its fenced block is explicitly closed.
+          # Report that opening fence immediately, then parse the current line
+          # again at the surviving outer container level.
+          REPROCESS: while (1) {
+            if (defined $fence_char) {
+              my ($offset, $matched) =
+                continue_containers($line, \@fence_containers);
+              if ($matched < @fence_containers) {
+                (my $relative = $file) =~ s{^\Q$root\E/?}{};
+                warn "Unclosed fenced code block in $relative:$fence_line " .
+                  "before container ended at line $line_number\n";
+                $failed = 1;
+                splice @containers, $matched;
+                undef $fence_char;
+                undef $fence_length;
+                undef $fence_line;
+                @fence_containers = ();
+                next REPROCESS;
+              }
+
+              my $candidate = substr($line, $offset);
+              if ($candidate =~ /^ {0,3}(\Q$fence_char\E+)[ ]*$/ && length($1) >= $fence_length) {
+                undef $fence_char;
+                undef $fence_length;
+                undef $fence_line;
+                @fence_containers = ();
+              }
+              next LINE;
+            }
+
+            my ($offset, $matched) = continue_containers($line, \@containers);
+            splice @containers, $matched if $matched < @containers;
+            $offset = open_containers($line, $offset, \@containers);
+            my $content = substr($line, $offset);
+            next LINE unless $content =~ /^ {0,3}(`{3,}|~{3,})(.*)$/;
+            my ($marker, $info) = ($1, $2);
+            my $char = substr($marker, 0, 1);
+            # CommonMark does not treat a backtick sequence as an opening fence
+            # when its info string itself contains a backtick.
+            next LINE if $char eq "`" && index($info, "`") >= 0;
+            $fence_char = $char;
+            $fence_length = length($marker);
+            $fence_line = $line_number;
+            @fence_containers = map { { %$_ } } @containers;
+            next LINE;
           }
-          my ($content, $base_indent) =
-            markdown_container_content($container_line, \@list_indents);
-          next unless $content =~ /^ {0,3}(`{3,}|~{3,})(.*)$/;
-          my ($marker, $info) = ($1, $2);
-          my $char = substr($marker, 0, 1);
-          # CommonMark does not treat a backtick sequence as an opening fence
-          # when its info string itself contains a backtick.
-          next if $char eq "`" && index($info, "`") >= 0;
-          $fence_char = $char;
-          $fence_length = length($marker);
-          $fence_line = $line_number;
-          $fence_quote_depth = $quote_depth;
-          $fence_base_indent = $base_indent;
         }
         if (defined $fence_char) {
           (my $relative = $file) =~ s{^\Q$root\E/?}{};

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -126,15 +126,62 @@ check_markdown_structure() {
       return $label =~ /[^ \t]/;
     }
 
+    sub reference_destination_prefix {
+      my ($content) = @_;
+      return unless length($content);
+
+      if (substr($content, 0, 1) eq "<") {
+        my $offset = 1;
+        while ($offset < length($content)) {
+          my $char = substr($content, $offset, 1);
+          if ($char eq "\\" && $offset + 1 < length($content) &&
+              substr($content, $offset + 1, 1) =~
+                /[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]/) {
+            $offset += 2;
+            next;
+          }
+          return (1, substr($content, $offset + 1)) if $char eq ">";
+          return if $char eq "<" || $char eq "\r" || $char eq "\n";
+          $offset++;
+        }
+        return;
+      }
+
+      my $offset = 0;
+      my $parentheses = 0;
+      while ($offset < length($content)) {
+        my $char = substr($content, $offset, 1);
+        last if $char eq " " || $char eq "\t";
+        return if ord($char) < 0x20 || ord($char) == 0x7f;
+        if ($char eq "\\" && $offset + 1 < length($content) &&
+            substr($content, $offset + 1, 1) =~
+              /[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]/) {
+          $offset += 2;
+          next;
+        }
+        if ($char eq "(") {
+          $parentheses++;
+        } elsif ($char eq ")") {
+          return if $parentheses == 0;
+          $parentheses--;
+        }
+        $offset++;
+      }
+      return if $offset == 0 || $parentheses != 0;
+      return (1, substr($content, $offset));
+    }
+
     sub link_reference_definition {
       my ($content) = @_;
       return unless $content =~ m{^[ ]{0,3}
         \[((?:\\[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]|[^\[\]\\])+)
-        \]:[ \t]*
-        (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)(.*)$
+        \]:[ \t]*(.*)$
       }x;
-      my ($label, $remainder) = ($1, $2);
+      my ($label, $destination_text) = ($1, $2);
       return unless valid_reference_label($label);
+      my @destination = reference_destination_prefix($destination_text);
+      return unless @destination;
+      my (undef, $remainder) = @destination;
       return (1, 0) if $remainder =~ /^[ \t]*$/;
       return unless $remainder =~ s/^[ \t]+//;
       return unless reference_title($remainder);
@@ -143,10 +190,10 @@ check_markdown_structure() {
 
     sub reference_destination_details {
       my ($content) = @_;
-      return unless $content =~ m{^[ ]{0,3}
-        (?:<[^<>\r\n]*>|[^ \t<>\r\n]+)(.*)$
-      }x;
-      my $remainder = $1;
+      return unless $content =~ /^ {0,3}(.*)$/;
+      my @destination = reference_destination_prefix($1);
+      return unless @destination;
+      my (undef, $remainder) = @destination;
       return (1, 0) if $remainder =~ /^[ \t]*$/;
       return unless $remainder =~ s/^[ \t]+//;
       return unless reference_title($remainder);

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -182,10 +182,10 @@ check_markdown_structure() {
       my @destination = reference_destination_prefix($destination_text);
       return unless @destination;
       my (undef, $remainder) = @destination;
-      return (1, 0) if $remainder =~ /^[ \t]*$/;
+      return (1, undef) if $remainder =~ /^[ \t]*$/;
       return unless $remainder =~ s/^[ \t]+//;
-      return unless reference_title($remainder);
-      return (1, 1);
+      return unless $remainder =~ /^(?:"|\x27|\()/;
+      return (1, $remainder);
     }
 
     sub reference_destination_details {
@@ -194,28 +194,49 @@ check_markdown_structure() {
       my @destination = reference_destination_prefix($1);
       return unless @destination;
       my (undef, $remainder) = @destination;
-      return (1, 0) if $remainder =~ /^[ \t]*$/;
+      return (1, undef) if $remainder =~ /^[ \t]*$/;
       return unless $remainder =~ s/^[ \t]+//;
-      return unless reference_title($remainder);
-      return (1, 1);
+      return unless $remainder =~ /^(?:"|\x27|\()/;
+      return (1, $remainder);
     }
 
-    sub reference_title_line {
-      my ($content) = @_;
-      return 0 unless $content =~ /^ {0,3}(.*)$/;
-      return reference_title($1);
+    sub reference_title_continuation_lines {
+      my ($title, $containers, $line_index, $lines) = @_;
+      return 0 if reference_title($title);
+
+      my $continuation_lines = 0;
+      for (my $next_index = $line_index + 1;
+           $next_index < @$lines;
+           $next_index++) {
+        my $line = $lines->[$next_index];
+        $line =~ s/\r$//;
+        $line = expand_tabs($line);
+        my ($offset, $matched) = continue_containers($line, $containers);
+        return if $matched < @$containers;
+        my $content = substr($line, $offset);
+        return if $content =~ /^ *$/;
+        $title .= "\n$content";
+        $continuation_lines++;
+        return $continuation_lines if reference_title($title);
+      }
+      return;
     }
 
-    sub following_reference_title_line {
+    sub following_reference_title_lines {
       my ($containers, $line_index, $lines) = @_;
-      return 0 if $line_index + 1 >= @$lines;
+      return if $line_index + 1 >= @$lines;
 
       my $title_line = $lines->[$line_index + 1];
       $title_line =~ s/\r$//;
       $title_line = expand_tabs($title_line);
       my ($offset, $matched) = continue_containers($title_line, $containers);
-      return 0 if $matched < @$containers;
-      return reference_title_line(substr($title_line, $offset));
+      return if $matched < @$containers;
+      my $content = substr($title_line, $offset);
+      return unless $content =~ /^ {0,3}((?:"|\x27|\().*)$/;
+      my $continued = reference_title_continuation_lines(
+        $1, $containers, $line_index + 1, $lines);
+      return unless defined $continued;
+      return 1 + $continued;
     }
 
     sub multiline_reference_lines {
@@ -237,15 +258,17 @@ check_markdown_structure() {
         reference_destination_details(substr($destination_line, $offset));
       return 0 unless @destination;
 
-      my (undef, $has_title) = @destination;
-      return 1 if $has_title || $line_index + 2 >= @$lines;
+      my (undef, $title) = @destination;
+      if (defined $title) {
+        my $continued = reference_title_continuation_lines(
+          $title, $containers, $line_index + 1, $lines);
+        return 0 unless defined $continued;
+        return 1 + $continued;
+      }
 
-      my $title_line = $lines->[$line_index + 2];
-      $title_line =~ s/\r$//;
-      $title_line = expand_tabs($title_line);
-      ($offset, $matched) = continue_containers($title_line, $containers);
-      return 1 if $matched < @$containers;
-      return reference_title_line(substr($title_line, $offset)) ? 2 : 1;
+      my $following = following_reference_title_lines(
+        $containers, $line_index + 1, $lines);
+      return defined $following ? 1 + $following : 1;
     }
 
     sub interrupts_paragraph {
@@ -358,7 +381,7 @@ check_markdown_structure() {
       wanted => sub {
         return unless /\.md$/;
         my $file = $File::Find::name;
-        open my $fh, "<", $file or die "open $file: $!";
+        open my $fh, "<:encoding(UTF-8)", $file or die "open $file: $!";
         local $/;
         my $text = <$fh>;
 
@@ -486,13 +509,23 @@ check_markdown_structure() {
             if (!$paragraph_here) {
               my @reference = link_reference_definition($content);
               if (@reference) {
-                my (undef, $has_title) = @reference;
-                if (!$has_title && following_reference_title_line(
-                    \@containers, $line_index, \@lines)) {
-                  $reference_lines_to_skip = 1;
+                my (undef, $title) = @reference;
+                if (defined $title) {
+                  my $continued = reference_title_continuation_lines(
+                    $title, \@containers, $line_index, \@lines);
+                  if (defined $continued) {
+                    $reference_lines_to_skip = $continued;
+                    $paragraph_active = 0;
+                    next LINE;
+                  }
+                } else {
+                  my $following = following_reference_title_lines(
+                    \@containers, $line_index, \@lines);
+                  $reference_lines_to_skip = $following
+                    if defined $following;
+                  $paragraph_active = 0;
+                  next LINE;
                 }
-                $paragraph_active = 0;
-                next LINE;
               }
             }
             if (!$paragraph_here) {

--- a/.github/scripts/check-doc-contracts.sh
+++ b/.github/scripts/check-doc-contracts.sh
@@ -71,33 +71,90 @@ check_markdown_structure() {
       return ($offset, $matched);
     }
 
+    sub thematic_break {
+      my ($line) = @_;
+      return $line =~ /^ {0,3}(?:(?:\*[ ]*){3,}|(?:-[ ]*){3,}|(?:_[ ]*){3,})$/;
+    }
+
+    sub list_marker_details {
+      my ($remaining) = @_;
+      return unless
+        $remaining =~ /^( {0,3})([-+*]|\d{1,9}[.)])(?:([ ]+)|$)/;
+      my ($before, $marker, $spacing) = ($1, $2, $3);
+      my $space_count = defined $spacing ? length($spacing) : 1;
+      my $padding = $space_count <= 4 ? $space_count : 1;
+      my $width = length($before) + length($marker) + $padding;
+      my $content = length($remaining) >= $width
+        ? substr($remaining, $width)
+        : "";
+      my $ordered = $marker =~ /^(\d{1,9})[.)]$/;
+      my $start = $ordered ? 0 + $1 : 0;
+      my $has_content = $content =~ /[^ ]/;
+      return ($width, $ordered, $start, $has_content);
+    }
+
+    sub interrupts_paragraph {
+      my ($remaining) = @_;
+      return 1 if $remaining =~ /^ *$/;
+      return 1 if $remaining =~ /^ {0,3}>/;
+      return 1 if $remaining =~ /^ {0,3}(?:`{3,}|~{3,})/;
+      return 1 if $remaining =~ /^ {0,3}#{1,6}(?:[ ]|$)/;
+      return 1 if thematic_break($remaining);
+
+      my @marker = list_marker_details($remaining);
+      if (@marker) {
+        my (undef, $ordered, $start, $has_content) = @marker;
+        return 1 if $has_content && (!$ordered || $start == 1);
+      }
+      return 0;
+    }
+
+    sub paragraph_content {
+      my ($remaining) = @_;
+      return 0 if $remaining =~ /^ *$/;
+      return 0 if $remaining =~ /^ {0,3}#{1,6}(?:[ ]|$)/;
+      return 0 if thematic_break($remaining);
+      return 1;
+    }
+
     sub open_containers {
-      my ($line, $offset, $containers) = @_;
+      my ($line, $offset, $containers, $paragraph_active) = @_;
+      my $opened = 0;
       while ($offset <= length($line)) {
         my $remaining = substr($line, $offset);
+
+        # Thematic breaks take precedence over interpreting their first marker
+        # as a list item.
+        last if thematic_break($remaining);
 
         if ($remaining =~ /^( {0,3})>/) {
           my $consumed = length($1) + 1;
           $consumed++ if substr($remaining, $consumed, 1) eq " ";
           push @$containers, { type => "quote" };
           $offset += $consumed;
+          $paragraph_active = 0;
+          $opened++;
           next;
         }
 
-        if ($remaining =~ /^( {0,3})([-+*]|\d{1,9}[.)])(?:([ ]+)|$)/) {
-          my ($before, $marker, $spacing) = ($1, $2, $3);
-          my $space_count = defined $spacing ? length($spacing) : 1;
-          my $padding = $space_count <= 4 ? $space_count : 1;
-          my $width = length($before) + length($marker) + $padding;
+        my @marker = list_marker_details($remaining);
+        if (@marker) {
+          my ($width, $ordered, $start, $has_content) = @marker;
+          # An ordered list can interrupt a paragraph only when it starts at
+          # one, and an empty item cannot interrupt a paragraph at all.
+          last if $paragraph_active &&
+            (!$has_content || ($ordered && $start != 1));
           push @$containers, { type => "list", width => $width };
           $offset += $width;
           $offset = length($line) if $offset > length($line);
+          $paragraph_active = 0;
+          $opened++;
           next;
         }
 
         last;
       }
-      return $offset;
+      return ($offset, $opened);
     }
 
     find({
@@ -112,6 +169,8 @@ check_markdown_structure() {
         my ($fence_char, $fence_length, $fence_line);
         my @containers;
         my @fence_containers;
+        my $paragraph_active = 0;
+        my $paragraph_depth = 0;
         my $line_number = 0;
         LINE: for my $line (split /\n/, $text, -1) {
           $line_number++;
@@ -135,6 +194,7 @@ check_markdown_structure() {
                 undef $fence_length;
                 undef $fence_line;
                 @fence_containers = ();
+                $paragraph_active = 0;
                 next REPROCESS;
               }
 
@@ -144,24 +204,53 @@ check_markdown_structure() {
                 undef $fence_length;
                 undef $fence_line;
                 @fence_containers = ();
+                $paragraph_active = 0;
               }
               next LINE;
             }
 
             my ($offset, $matched) = continue_containers($line, \@containers);
-            splice @containers, $matched if $matched < @containers;
-            $offset = open_containers($line, $offset, \@containers);
+            if ($matched < @containers) {
+              my $remaining = substr($line, $offset);
+              if ($paragraph_active && $paragraph_depth == @containers &&
+                  !interrupts_paragraph($remaining)) {
+                # CommonMark permits paragraph text to lazily continue without
+                # repeating one or more list container prefixes. Preserve the
+                # stack so a following indented fence remains in that item.
+                next LINE;
+              }
+              splice @containers, $matched;
+              $paragraph_active = 0 if $paragraph_depth > $matched;
+            }
+
+            my $paragraph_here =
+              $paragraph_active && $paragraph_depth == @containers;
+            my $opened;
+            ($offset, $opened) =
+              open_containers($line, $offset, \@containers, $paragraph_here);
+            $paragraph_active = 0 if $opened;
             my $content = substr($line, $offset);
-            next LINE unless $content =~ /^ {0,3}(`{3,}|~{3,})(.*)$/;
-            my ($marker, $info) = ($1, $2);
-            my $char = substr($marker, 0, 1);
-            # CommonMark does not treat a backtick sequence as an opening fence
-            # when its info string itself contains a backtick.
-            next LINE if $char eq "`" && index($info, "`") >= 0;
-            $fence_char = $char;
-            $fence_length = length($marker);
-            $fence_line = $line_number;
-            @fence_containers = map { { %$_ } } @containers;
+            if ($content =~ /^ {0,3}(`{3,}|~{3,})(.*)$/) {
+              my ($marker, $info) = ($1, $2);
+              my $char = substr($marker, 0, 1);
+              # CommonMark does not treat a backtick sequence as an opening
+              # fence when its info string itself contains a backtick.
+              if ($char ne "`" || index($info, "`") < 0) {
+                $fence_char = $char;
+                $fence_length = length($marker);
+                $fence_line = $line_number;
+                @fence_containers = map { { %$_ } } @containers;
+                $paragraph_active = 0;
+                next LINE;
+              }
+            }
+
+            if (paragraph_content($content)) {
+              $paragraph_active = 1;
+              $paragraph_depth = scalar @containers;
+            } else {
+              $paragraph_active = 0;
+            }
             next LINE;
           }
         }

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -728,6 +728,32 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 
+# Reference labels may contain internal line endings. The completed definition
+# remains a leaf before a non-one ordered list.
+printf '%s\n' \
+  '[foo' \
+  'bar]: /target' \
+  '22. list item after a multiline reference label' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a multiline reference label failure" >&2
+  exit 1
+fi
+
+# An unclosed multiline label remains ordinary paragraph text.
+printf '%s\n' \
+  '[incomplete' \
+  'label without a closing bracket' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an incomplete multiline reference label to remain paragraph text" >&2
+  exit 1
+fi
+
 # A bare destination must balance every unescaped parenthesis. An invalid
 # definition stays paragraph text, so a non-one list marker cannot interrupt.
 printf '%s\n' \

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -360,6 +360,12 @@ printf '%s\n' \
   '> ~~~text' \
   '> quoted content' \
   '> ~~~' \
+  '- > ```json' \
+  '  > {}' \
+  '  > ```' \
+  '> - ~~~text' \
+  '>   quoted list content' \
+  '>   ~~~' \
   > "$fence_fixture"
 if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected valid CommonMark fence forms to pass" >&2
@@ -393,6 +399,31 @@ printf '%s\n' \
   > "$fence_fixture"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an unclosed nested-list fence failure" >&2
+  exit 1
+fi
+
+# A later top-level delimiter must not close a fence whose list container has
+# already ended.
+printf '%s\n' \
+  '1. list item' \
+  '   ```text' \
+  '   missing close' \
+  'top-level paragraph ends the list' \
+  '   ```' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a fence container-exit failure" >&2
+  exit 1
+fi
+
+# Container markers can interleave. A quote opened after a list marker must be
+# part of the fence context rather than hiding an unclosed fence.
+printf '%s\n' \
+  '- > ```json' \
+  '  > {}' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed interleaved-container fence failure" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -701,6 +701,31 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 
+# A bare destination must balance every unescaped parenthesis. An invalid
+# definition stays paragraph text, so a non-one list marker cannot interrupt.
+printf '%s\n' \
+  '[reference]: /unbalanced(' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unbalanced reference destination to remain paragraph text" >&2
+  exit 1
+fi
+
+# Balanced and escaped parentheses are both valid bare destinations and retain
+# reference-definition leaf semantics for the following list.
+printf '%s\n' \
+  '[reference]: /balanced(one)/escaped\(two\)' \
+  '22. list item after a balanced destination' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a balanced reference destination failure" >&2
+  exit 1
+fi
+
 # An incomplete definition is paragraph text and still blocks a non-one list
 # from interrupting it.
 printf '%s\n' \

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -403,6 +403,15 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 
+# A tab immediately after a block-quote marker expands to three spaces at
+# that column. One space belongs to the quote delimiter, leaving a valid
+# two-space-indented fence opener (CommonMark 0.31.2, example 6).
+printf '%b\n' '>\t```' '> ordinary quoted text' > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed quoted fence after a tab failure" >&2
+  exit 1
+fi
+
 # Raw HTML blocks extend to their matching terminator (or EOF), so fence-like
 # text inside them must not create an unclosed fenced-code error.
 printf '%s\n' '<!--' '``` marker inside an unterminated HTML comment' \
@@ -553,6 +562,20 @@ printf '%s\n' \
   > "$fence_fixture"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an unclosed fence after a multiline reference failure" >&2
+  exit 1
+fi
+
+# The optional title may also move to the next line when the destination is
+# already present on the definition line. Both lines form the same leaf.
+printf '%s\n' \
+  '[reference]: /target' \
+  '  "optional title"' \
+  '22. list item after a continued title' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a continued reference title failure" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -421,6 +421,18 @@ if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" 
   exit 1
 fi
 
+# Type-1 raw HTML blocks end only at the exact closing-tag sequence. A tag
+# with whitespace before `>` remains literal HTML content through EOF.
+printf '%s\n' \
+  '<script>' \
+  '</script >' \
+  '``` literal marker in the still-open HTML block' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an inexact raw HTML closing tag to remain open" >&2
+  exit 1
+fi
+
 # Fence parsing must resume immediately after a raw HTML block terminates.
 printf '%s\n' \
   '<!--' \
@@ -576,6 +588,32 @@ printf '%s\n' \
   > "$fence_fixture"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an unclosed fence after a continued reference title failure" >&2
+  exit 1
+fi
+
+# Backslash-escaped ASCII punctuation is valid inside each reference-title
+# delimiter form. It must not turn the definition into paragraph text.
+printf '%s\n' \
+  '[reference]: /target "escaped \"title\""' \
+  '22. list item after an escaped reference title' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after an escaped reference title failure" >&2
+  exit 1
+fi
+
+# The same escape rule applies when a title follows a next-line destination.
+printf '%s\n' \
+  '[reference]:' \
+  '  /target (escaped \(title\))' \
+  '22. list item after an escaped multiline title' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after an escaped multiline title failure" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -528,6 +528,45 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 
+# A complete standalone link-reference definition is a leaf block. It must
+# not prevent a following non-one ordered list from opening.
+printf '%s\n' \
+  '[reference]: /target' \
+  '22. list item after a reference definition' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a link-reference definition failure" >&2
+  exit 1
+fi
+
+# A Setext underline closes its preceding paragraph as a heading, so a
+# non-one ordered list may likewise begin immediately afterward.
+printf '%s\n' \
+  'Setext heading' \
+  '==============' \
+  '22. list item after a heading' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a Setext heading failure" >&2
+  exit 1
+fi
+
+# A reference-shaped line cannot interrupt an existing paragraph.
+printf '%s\n' \
+  'paragraph before a reference-shaped line' \
+  '[reference]: /target' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a reference-shaped paragraph continuation to pass" >&2
+  exit 1
+fi
+
 # Exercise the same five-space list-container indentation used by the existing
 # localized API response examples, so those real blocks cannot silently regress.
 perl -0pi -e 's/^     ```\r?\n//m' "$temp_dir/docs/enUS/API.md"

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -338,8 +338,9 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
 fi
 git -C "$temp_dir" checkout -q -- docs/enUS/DEPLOYMENT.md
 
-# CommonMark fenced blocks allow up to three leading spaces, either marker
-# character, and a closing marker at least as long as the opening marker.
+# CommonMark fenced blocks allow up to three leading spaces after list or
+# block-quote container prefixes, either marker character, and a closing
+# marker at least as long as the opening marker.
 fence_fixture="$temp_dir/fence-structure-test.md"
 printf '%s\n' \
   '   ```bash' \
@@ -350,6 +351,15 @@ printf '%s\n' \
   '~~~~' \
   'inline ``` markers are not fences' \
   '    ```four-space-indented-code' \
+  '1. outer list' \
+  '   - nested item' \
+  '' \
+  '     ```json' \
+  '     {}' \
+  '     ```' \
+  '> ~~~text' \
+  '> quoted content' \
+  '> ~~~' \
   > "$fence_fixture"
 if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected valid CommonMark fence forms to pass" >&2
@@ -373,6 +383,27 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   echo "Expected a short closing-fence failure" >&2
   exit 1
 fi
+
+printf '%s\n' \
+  '1. outer list' \
+  '   - nested item' \
+  '' \
+  '     ```json' \
+  '     {}' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed nested-list fence failure" >&2
+  exit 1
+fi
+
+# Exercise the same five-space list-container indentation used by the existing
+# localized API response examples, so those real blocks cannot silently regress.
+perl -0pi -e 's/^     ```\r?\n//m' "$temp_dir/docs/enUS/API.md"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a localized nested-list fence failure" >&2
+  exit 1
+fi
+git -C "$temp_dir" checkout -q -- docs/enUS/API.md
 rm -f "$fence_fixture"
 
 echo "Documentation contract self-tests passed."

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -338,4 +338,41 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
 fi
 git -C "$temp_dir" checkout -q -- docs/enUS/DEPLOYMENT.md
 
+# CommonMark fenced blocks allow up to three leading spaces, either marker
+# character, and a closing marker at least as long as the opening marker.
+fence_fixture="$temp_dir/fence-structure-test.md"
+printf '%s\n' \
+  '   ```bash' \
+  'echo valid' \
+  '   ```' \
+  '~~~text' \
+  'valid' \
+  '~~~~' \
+  'inline ``` markers are not fences' \
+  '    ```four-space-indented-code' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected valid CommonMark fence forms to pass" >&2
+  exit 1
+fi
+
+printf '%s\n' '   ```bash' 'echo unclosed' > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an indented unclosed fence failure" >&2
+  exit 1
+fi
+
+printf '%s\n' '```text' 'wrong marker' '~~~' > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a mismatched fence-marker failure" >&2
+  exit 1
+fi
+
+printf '%s\n' '````text' 'short close' '```' > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a short closing-fence failure" >&2
+  exit 1
+fi
+rm -f "$fence_fixture"
+
 echo "Documentation contract self-tests passed."

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -840,6 +840,29 @@ if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" 
   exit 1
 fi
 
+# A fenced block can interrupt the paragraph started by an incomplete
+# reference definition. Its opener must not be consumed as a bare next-line
+# destination, or an unclosed fence would be hidden from the validator.
+printf '%s\n' \
+  '[ref]:' \
+  '```text' \
+  'unclosed root fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after an empty reference destination failure" >&2
+  exit 1
+fi
+
+printf '%s\n' \
+  '[ref]:' \
+  '~~~text' \
+  'unclosed root fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed tilde fence after an empty reference destination failure" >&2
+  exit 1
+fi
+
 # A list item whose first child would be indented code cannot interrupt a
 # paragraph. The later non-one marker and its indented fence therefore remain
 # literal paragraph text rather than opening nested block structure.

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -521,6 +521,18 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 
+# Trailing spaces on a marker-only line do not establish wide item padding.
+# A four-space-indented fence on the next line belongs to the blank item.
+printf '%s\n' \
+  '-    ' \
+  '    ```text' \
+  '    unclosed fence in a blank list item' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence inside a blank list item failure" >&2
+  exit 1
+fi
+
 # Container markers can interleave. A quote opened after a list marker must be
 # part of the fence context rather than hiding an unclosed fence.
 printf '%s\n' \
@@ -713,6 +725,31 @@ printf '%s\n' \
   > "$fence_fixture"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an unclosed fence after an escaped reference label failure" >&2
+  exit 1
+fi
+
+# A backslash before a non-punctuation character stays literal in a valid
+# label instead of acting as an invalid escape.
+printf '%s\n' \
+  '[foo\bar]: /target' \
+  '22. list item after a literal-backslash label' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a literal-backslash label failure" >&2
+  exit 1
+fi
+
+# Reference titles use the same literal-backslash rule.
+printf '%s\n' \
+  '[reference]: /target "foo\bar"' \
+  '22. list item after a literal-backslash title' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a literal-backslash title failure" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -421,6 +421,18 @@ if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" 
   exit 1
 fi
 
+# Type-4 declarations accept any ASCII letter after `<!`, not only uppercase
+# declarations. Fence-like lines remain literal until the first `>`.
+printf '%s\n' \
+  '<!doctype' \
+  '``` literal marker inside a lowercase declaration' \
+  '>' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a lowercase HTML declaration containing a fence to pass" >&2
+  exit 1
+fi
+
 # Type-1 raw HTML blocks end only at the exact closing-tag sequence. A tag
 # with whitespace before `>` remains literal HTML content through EOF.
 printf '%s\n' \
@@ -456,6 +468,18 @@ printf '%s\n' \
   > "$fence_fixture"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an unclosed fence after paragraph HTML to fail" >&2
+  exit 1
+fi
+
+# A block-level tag only starts a type-6 HTML block at the beginning of the
+# line (after up to three spaces), never when embedded later in paragraph text.
+printf '%s\n' \
+  'paragraph text before <div>' \
+  '```text' \
+  'unclosed after an embedded block tag' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after an embedded block tag failure" >&2
   exit 1
 fi
 
@@ -640,6 +664,40 @@ printf '%s\n' \
   > "$fence_fixture"
 if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected a reference-shaped paragraph continuation to pass" >&2
+  exit 1
+fi
+
+# Unescaped brackets and whitespace-only labels are not reference labels. Each
+# line therefore remains paragraph text and a later indented marker is literal.
+printf '%s\n' \
+  '[a[b]: /target' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unescaped nested reference bracket to remain paragraph text" >&2
+  exit 1
+fi
+
+printf '%s\n' \
+  '[   ]: /target' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a whitespace-only reference label to remain paragraph text" >&2
+  exit 1
+fi
+
+# An escaped opening bracket is valid and preserves leaf-block semantics.
+printf '%s\n' \
+  '[a\[b]: /target' \
+  '22. list item after an escaped reference label' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after an escaped reference label failure" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -376,6 +376,21 @@ printf '%s\n' \
   '   ```text' \
   'unindented root fence content' \
   '   ```' \
+  '<!--' \
+  '``` marker inside an HTML comment' \
+  '-->' \
+  '<script>' \
+  '~~~ marker inside a script block' \
+  '</script>' \
+  '- <!--' \
+  '  ``` marker inside a list HTML comment' \
+  '  -->' \
+  '<div>' \
+  '``` marker inside a type-6 HTML block' \
+  '' \
+  '<custom-element data-test="value">' \
+  '~~~ marker inside a type-7 HTML block' \
+  '' \
   > "$fence_fixture"
 if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected valid CommonMark fence forms to pass" >&2
@@ -385,6 +400,41 @@ fi
 printf '%s\n' '   ```bash' 'echo unclosed' > "$fence_fixture"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an indented unclosed fence failure" >&2
+  exit 1
+fi
+
+# Raw HTML blocks extend to their matching terminator (or EOF), so fence-like
+# text inside them must not create an unclosed fenced-code error.
+printf '%s\n' '<!--' '``` marker inside an unterminated HTML comment' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a raw HTML block ending at EOF to pass" >&2
+  exit 1
+fi
+
+# Fence parsing must resume immediately after a raw HTML block terminates.
+printf '%s\n' \
+  '<!--' \
+  '``` ignored inside HTML' \
+  '-->' \
+  '```text' \
+  'unclosed after HTML' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after raw HTML to fail" >&2
+  exit 1
+fi
+
+# A type-7 HTML tag cannot interrupt a paragraph; the following fence must
+# therefore be parsed normally rather than swallowed as HTML content.
+printf '%s\n' \
+  'paragraph before inline HTML' \
+  '<custom-element>' \
+  '```text' \
+  'unclosed after non-interrupting tag' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after paragraph HTML to fail" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -791,6 +791,33 @@ if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" 
   exit 1
 fi
 
+# A fence interrupts the paragraph containing an incomplete multiline label;
+# the opener cannot be accumulated as label text and skipped with a later
+# apparent definition suffix.
+printf '%s\n' \
+  '[foo' \
+  '```text' \
+  'bar]: /target' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence interrupting a multiline label failure" >&2
+  exit 1
+fi
+
+# A physical line ending after a backslash is not a bracket escape. Preserve
+# the literal backslash and continue parsing the valid multiline label.
+printf '%s\n' \
+  '[foo\' \
+  'bar]: /target' \
+  '22. list item after a backslash-ended reference label' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a backslash-ended label failure" >&2
+  exit 1
+fi
+
 # Unicode whitespace does not satisfy CommonMark's requirement that a link
 # reference label contain a non-whitespace character. NBSP therefore leaves
 # this reference-shaped line as paragraph text.
@@ -812,6 +839,18 @@ printf '%s\n' \
   > "$fence_fixture"
 if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an unbalanced reference destination to remain paragraph text" >&2
+  exit 1
+fi
+
+# A block opener likewise interrupts an unfinished reference title instead of
+# becoming title text which can hide the fence from structural validation.
+printf '%s\n' \
+  '[ref]: /target "foo' \
+  '```text' \
+  'bar"' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence interrupting a reference title failure" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -541,6 +541,21 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 
+# CommonMark permits the destination and optional title on following lines;
+# the entire completed definition remains a non-paragraph leaf.
+printf '%s\n' \
+  '[reference]:' \
+  '  /target' \
+  '  "optional title"' \
+  '22. list item after a multiline reference' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a multiline reference failure" >&2
+  exit 1
+fi
+
 # A Setext underline closes its preceding paragraph as a heading, so a
 # non-one ordered list may likewise begin immediately afterward.
 printf '%s\n' \
@@ -564,6 +579,18 @@ printf '%s\n' \
   > "$fence_fixture"
 if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected a reference-shaped paragraph continuation to pass" >&2
+  exit 1
+fi
+
+# An incomplete definition is paragraph text and still blocks a non-one list
+# from interrupting it.
+printf '%s\n' \
+  '[incomplete]:' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an incomplete reference definition to remain paragraph text" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -514,6 +514,20 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 
+# Indented code is a leaf block, not an active paragraph. A following ordered
+# list may therefore start at a number other than one, and its indented fence
+# must still be validated within the list container.
+printf '%s\n' \
+  '    indented code' \
+  '22. list item after code' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence in a non-one list after indented code failure" >&2
+  exit 1
+fi
+
 # Exercise the same five-space list-container indentation used by the existing
 # localized API response examples, so those real blocks cannot silently regress.
 perl -0pi -e 's/^     ```\r?\n//m' "$temp_dir/docs/enUS/API.md"

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -615,6 +615,21 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 
+# A reference title may itself contain line endings, provided no blank line
+# interrupts it and its delimiter eventually closes.
+printf '%s\n' \
+  '[reference]: /target "multi' \
+  'line' \
+  'title"' \
+  '22. list item after a multiline title' \
+  '    ```text' \
+  '    unclosed list fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a multiline reference title failure" >&2
+  exit 1
+fi
+
 # Backslash-escaped ASCII punctuation is valid inside each reference-title
 # delimiter form. It must not turn the definition into paragraph text.
 printf '%s\n' \
@@ -698,6 +713,18 @@ printf '%s\n' \
   > "$fence_fixture"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an unclosed fence after an escaped reference label failure" >&2
+  exit 1
+fi
+
+# CommonMark limits labels by Unicode characters, not encoded UTF-8 bytes.
+perl -e '
+  binmode STDOUT, ":encoding(UTF-8)";
+  print "[", "\x{754c}" x 400, "]: /target\n";
+  print "22. list item after a multibyte label\n";
+  print "    ```text\n    unclosed list fence\n";
+' > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a multibyte reference label failure" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -500,6 +500,20 @@ if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/
   exit 1
 fi
 
+# A backtick in a backtick-fence info string makes that line paragraph text.
+# It must not interrupt a lazy paragraph and discard the wide list container,
+# or the following indented real fence would be missed as root indented code.
+printf '%s\n' \
+  '-   paragraph in a wide list item' \
+  '```bad`info' \
+  '    ```text' \
+  '    unclosed real fence' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after invalid lazy opener text failure" >&2
+  exit 1
+fi
+
 # Exercise the same five-space list-container indentation used by the existing
 # localized API response examples, so those real blocks cannot silently regress.
 perl -0pi -e 's/^     ```\r?\n//m' "$temp_dir/docs/enUS/API.md"

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -828,6 +828,20 @@ if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" 
   exit 1
 fi
 
+# A list item whose first child would be indented code cannot interrupt a
+# paragraph. The later non-one marker and its indented fence therefore remain
+# literal paragraph text rather than opening nested block structure.
+printf '%s\n' \
+  'paragraph before an indented-code item' \
+  '-     code' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an indented-code item not to interrupt a paragraph" >&2
+  exit 1
+fi
+
 # Exercise the same five-space list-container indentation used by the existing
 # localized API response examples, so those real blocks cannot silently regress.
 perl -0pi -e 's/^     ```\r?\n//m' "$temp_dir/docs/enUS/API.md"

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -830,6 +830,17 @@ if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" 
   exit 1
 fi
 
+# Unicode whitespace also terminates a bare destination. It cannot appear
+# inside that destination and make an otherwise invalid definition into a leaf.
+printf '[reference]: /foo\302\240bar\n%s\n%s\n' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a bare destination containing Unicode whitespace to remain paragraph text" >&2
+  exit 1
+fi
+
 # A bare destination must balance every unescaped parenthesis. An invalid
 # definition stays paragraph text, so a non-one list marker cannot interrupt.
 printf '%s\n' \
@@ -851,6 +862,20 @@ printf '%s\n' \
   > "$fence_fixture"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an unclosed fence interrupting a reference title failure" >&2
+  exit 1
+fi
+
+# A Setext underline transforms the preceding incomplete-label paragraph into
+# a heading. It is therefore a boundary for reference continuation lookahead.
+printf '%s\n' \
+  '[foo' \
+  '===' \
+  'bar]: /target' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a Setext underline to stop reference label lookahead" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -366,6 +366,16 @@ printf '%s\n' \
   '> - ~~~text' \
   '>   quoted list content' \
   '>   ~~~' \
+  '-   paragraph in a wide list item' \
+  'lazy paragraph continuation' \
+  '    ```text' \
+  '    fenced content after lazy continuation' \
+  '    ```' \
+  'paragraph before a non-list marker' \
+  '2. this remains paragraph text' \
+  '   ```text' \
+  'unindented root fence content' \
+  '   ```' \
   > "$fence_fixture"
 if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected valid CommonMark fence forms to pass" >&2
@@ -424,6 +434,19 @@ printf '%s\n' \
   > "$fence_fixture"
 if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
   echo "Expected an unclosed interleaved-container fence failure" >&2
+  exit 1
+fi
+
+# A lazy paragraph continuation retains its list container, including the
+# wider content column established by marker padding.
+printf '%s\n' \
+  '-   paragraph in a wide list item' \
+  'lazy paragraph continuation' \
+  '    ```text' \
+  '    missing close' \
+  > "$fence_fixture"
+if (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected an unclosed fence after a lazy list continuation failure" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-doc-contracts.sh
+++ b/.github/scripts/test-doc-contracts.sh
@@ -791,6 +791,18 @@ if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" 
   exit 1
 fi
 
+# Unicode whitespace does not satisfy CommonMark's requirement that a link
+# reference label contain a non-whitespace character. NBSP therefore leaves
+# this reference-shaped line as paragraph text.
+printf '[\302\240]: /target\n%s\n%s\n' \
+  '22. still paragraph text' \
+  '    ``` literal paragraph text' \
+  > "$fence_fixture"
+if ! (cd "$temp_dir" && bash .github/scripts/check-doc-contracts.sh "$base_sha" >/dev/null 2>&1); then
+  echo "Expected a Unicode-whitespace reference label to remain paragraph text" >&2
+  exit 1
+fi
+
 # A bare destination must balance every unescaped parenthesis. An invalid
 # definition stays paragraph text, so a non-one list marker cannot interrupt.
 printf '%s\n' \


### PR DESCRIPTION
## Summary

- replace raw fence-line parity counting with a CommonMark-aware state machine
- support backtick and tilde fences, 0–3-space indentation, marker matching, minimum closing length, and backtick info-string rules
- track block quotes and ordered/unordered list containers, including interleaving, blank items, container exit, tabs, lazy paragraphs, and list interruption rules
- distinguish paragraphs from indented code, Setext headings, raw HTML blocks, and complete link-reference definitions
- parse single- and multi-line reference labels, destinations, and titles with escapes, balanced parentheses, and Unicode label limits
- report the Markdown path and opening line for every structurally unclosed fence
- add focused passing and failing fixtures for all reviewed fence, container, paragraph, reference, and HTML forms

## Why

Counting lines beginning with three backticks misses valid indented and tilde fences and cannot detect mismatched markers, short closers, or container-scoped blocks. It can also reject valid raw HTML containing literal fence markers and misclassify fence-like text in other CommonMark leaf blocks.

## Validation

- `bash .github/scripts/check-doc-contracts.sh`
- `bash .github/scripts/test-doc-contracts.sh`
- `bash .github/scripts/test-release-workflow.sh`
- `bash .github/scripts/test-release-notes.sh`
- `bash .github/scripts/test-go-version-contract.sh`
- `bash .github/scripts/test-start-local.sh`
- all repository shell scripts via `bash -n`
- `git diff --check`

Addresses https://github.com/soulteary/stargate/pull/97#discussion_r3866465795