### PR TITLE
ci: pin reviewed htpasswd contract fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 env:
-  CI_RECIPES_VERSION: 804758e6c692b56d1543ef447b6b319b517ab985
+  CI_RECIPES_VERSION: 95ac30ff06ae04950b2fa0412504a4cf73ab7b7a
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  CI_RECIPES_VERSION: 804758e6c692b56d1543ef447b6b319b517ab985
+  CI_RECIPES_VERSION: 95ac30ff06ae04950b2fa0412504a4cf73ab7b7a
 
 jobs:
   compatibility:


### PR DESCRIPTION
## Summary

- advance both PR and release workflows from `ci-recipes@804758e` to reviewed commit `95ac30f`
- activate wrapper, root-prompt, shell-comment, and execution-form `ionice` coverage for the Stargate `htpasswd -b` documentation contract
- keep both workflow pins identical and immutable

## Validation

- installed the exact pinned commit with `go install github.com/soulteary/ci-recipes/cmd/ci-recipes@95ac30ff06ae04950b2fa0412504a4cf73ab7b7a`
- `ci-recipes stargate check-doc-contracts`
- `ci-recipes stargate check-go-version-contract`
- `ci-recipes stargate check-release-workflow`
- `git diff --check`
- ci-recipes #5 CI passed and Codex re-review completed with no remaining findings

Depends on soulteary/ci-recipes#5.