### PR TITLE
ci: pin final htpasswd contract fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 env:
-  CI_RECIPES_VERSION: 95ac30ff06ae04950b2fa0412504a4cf73ab7b7a
+  CI_RECIPES_VERSION: 39e30dfe38566a87ff1b3e92e24743c2aac81df6
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  CI_RECIPES_VERSION: 95ac30ff06ae04950b2fa0412504a4cf73ab7b7a
+  CI_RECIPES_VERSION: 39e30dfe38566a87ff1b3e92e24743c2aac81df6
 
 jobs:
   compatibility:


### PR DESCRIPTION
## Summary

- advance both PR and release workflows from `ci-recipes@95ac30f` to merged commit `39e30df`
- activate the complete reviewed sudo/env/ionice `htpasswd -b` contract handling from ci-recipes #5 and #10
- include GNU env assignment phases, `-S` escape semantics, and shell-double-quoted `\\_` separators
- keep both workflow pins identical and immutable

## Why

#157 was merged while the final ci-recipes review fixes were still landing, so Stargate currently pins an earlier commit that lacks those cases.

## Validation

- installed the exact pin with `go install github.com/soulteary/ci-recipes/cmd/ci-recipes@39e30dfe38566a87ff1b3e92e24743c2aac81df6`
- `ci-recipes stargate check-doc-contracts`
- `ci-recipes stargate check-go-version-contract`
- `ci-recipes stargate check-release-workflow`
- `git diff --check`
- ci-recipes #5 and #10 CI passed