### PR TITLE
docs: replace the protected whoami demo with soulteary/hello

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ services:
 docker-compose up -d
 ```
 
-The bundled stack starts Traefik, Stargate, and the protected `whoami` demo on
+The bundled stack starts Traefik, Stargate, and the protected `soulteary/hello` demo on
 a Compose-managed network whose CIDR matches `TRUSTED_PROXIES`. Open
-`http://whoami.test.localhost` to exercise the complete login flow.
+`http://hello.test.localhost` to exercise the complete login flow.
 
 ### Local Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost # Replace with your auth host (e.g.: auth.example.com).
       - PASSWORDS=plaintext:test1234|test1337 # Replace with your passwords. See the docs for more info.
-      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - CALLBACK_ALLOWED_HOSTS=hello.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
       - TRUSTED_PROXIES=172.30.0.0/24 # Matches the Compose-managed Traefik network below.
       - COOKIE_SECURE=false # Local HTTP only. Keep the default true in HTTPS deployments.
@@ -51,16 +51,18 @@ services:
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
-  whoami: # A demo whoami service that is protected with Stargate
-    image: traefik/whoami:v1.11.0
+  hello: # A soulteary/hello demo service protected with Stargate
+    image: ghcr.io/soulteary/hello:2.3.0
+    command: ["-listen", ":8080"]
     networks:
       - traefik
     labels:
       - traefik.enable=true
       - traefik.docker.network=stargate-traefik
-      - traefik.http.routers.whoami.entrypoints=http
-      - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
-      - "traefik.http.routers.whoami.middlewares=stargate"
+      - traefik.http.routers.hello.entrypoints=http
+      - traefik.http.routers.hello.rule=Host(`hello.test.localhost`)
+      - "traefik.http.routers.hello.middlewares=stargate"
+      - traefik.http.services.hello.loadbalancer.server.port=8080
        # Add this to services that you want to guard
 
 networks:

--- a/docs/deDE/ARCHITECTURE.md
+++ b/docs/deDE/ARCHITECTURE.md
@@ -329,7 +329,7 @@ Template-Datei `internal/web/templates/login.html` ändern.
 ### Docker-Bereitstellung
 
 - Multi-Stage-Build zur Reduzierung der Image-Größe
-- Build-Stufe: `golang:1.27.0-alpine3.24`; Ausführungsstufe: `alpine:3.24` (Health-Checks verwenden BusyBox wget)
+- Build-Stufe: `golang:1.27.1-alpine3.24`; Ausführungsstufe: `alpine:3.24` (Health-Checks verwenden BusyBox wget)
 - Template-Dateien von `src/internal/web/templates` nach `/app/web/templates` im Image kopiert
 - Verwendet `-ldflags "-s -w"` beim Kompilieren, um die Binärgröße zu reduzieren
 - Die Anwendung findet automatisch Template-Pfade (unterstützt `./internal/web/templates` für lokale Entwicklung und `./web/templates` für Produktion)

--- a/docs/deDE/DEPLOYMENT.md
+++ b/docs/deDE/DEPLOYMENT.md
@@ -94,7 +94,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 
 #### Build-Parameter
 
-- **Basis-Image**: `golang:1.27.0-alpine3.24` (Build-Stufe)
+- **Basis-Image**: `golang:1.27.1-alpine3.24` (Build-Stufe)
 - **Ausführungs-Image**: `alpine:3.24` (mit CA-Zertifikaten und BusyBox `wget` für HTTPS und Health-Checks)
 - **Arbeitsverzeichnis**: `/app`
 - **Exponierter Port**: `8080`
@@ -180,7 +180,7 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
-      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - CALLBACK_ALLOWED_HOSTS=hello.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
       - TRUSTED_PROXIES=${TRAEFIK_NETWORK_CIDR:?set TRAEFIK_NETWORK_CIDR from docker network inspect}
       - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
@@ -194,16 +194,18 @@ services:
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
-  whoami:
-    image: traefik/whoami
+  hello:
+    image: ghcr.io/soulteary/hello:2.3.0
+    command: ["-listen", ":8080"]
     networks:
       - traefik
     labels:
       - traefik.enable=true
       - traefik.docker.network=${TRAEFIK_NETWORK_NAME:-traefik}
-      - traefik.http.routers.whoami.entrypoints=http
-      - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
-      - "traefik.http.routers.whoami.middlewares=stargate"
+      - traefik.http.routers.hello.entrypoints=http
+      - traefik.http.routers.hello.rule=Host(`hello.test.localhost`)
+      - "traefik.http.routers.hello.middlewares=stargate"
+      - traefik.http.services.hello.loadbalancer.server.port=8080
 
 networks:
   traefik:

--- a/docs/enUS/ARCHITECTURE.md
+++ b/docs/enUS/ARCHITECTURE.md
@@ -374,7 +374,7 @@ Modify the `internal/web/templates/login.html` template file.
 ### Docker Deployment
 
 - Multi-stage build to reduce image size
-- Build stage: `golang:1.27.0-alpine3.24`; runtime stage: `alpine:3.24` (health checks use BusyBox wget)
+- Build stage: `golang:1.27.1-alpine3.24`; runtime stage: `alpine:3.24` (health checks use BusyBox wget)
 - Template files copied from `src/internal/web/templates` to `/app/web/templates` in image
 - Uses `-ldflags "-s -w"` during compilation to reduce binary size
 - Application automatically finds template paths (supports `./internal/web/templates` for local development and `./web/templates` for production)

--- a/docs/enUS/DEPLOYMENT.md
+++ b/docs/enUS/DEPLOYMENT.md
@@ -94,7 +94,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 
 #### Build Parameters
 
-- **Base Image**: `golang:1.27.0-alpine3.24` (build stage)
+- **Base Image**: `golang:1.27.1-alpine3.24` (build stage)
 - **Runtime Image**: `alpine:3.24` (runtime stage; includes CA certificates and BusyBox `wget` for HTTPS and health checks)
 - **Working Directory**: `/app`
 - **Exposed Port**: `8080`
@@ -180,7 +180,7 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
-      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - CALLBACK_ALLOWED_HOSTS=hello.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
       - TRUSTED_PROXIES=${TRAEFIK_NETWORK_CIDR:?set TRAEFIK_NETWORK_CIDR from docker network inspect}
       - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
@@ -194,16 +194,18 @@ services:
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
-  whoami:
-    image: traefik/whoami
+  hello:
+    image: ghcr.io/soulteary/hello:2.3.0
+    command: ["-listen", ":8080"]
     networks:
       - traefik
     labels:
       - traefik.enable=true
       - traefik.docker.network=${TRAEFIK_NETWORK_NAME:-traefik}
-      - traefik.http.routers.whoami.entrypoints=http
-      - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
-      - "traefik.http.routers.whoami.middlewares=stargate"
+      - traefik.http.routers.hello.entrypoints=http
+      - traefik.http.routers.hello.rule=Host(`hello.test.localhost`)
+      - "traefik.http.routers.hello.middlewares=stargate"
+      - traefik.http.services.hello.loadbalancer.server.port=8080
 
 networks:
   traefik:

--- a/docs/frFR/ARCHITECTURE.md
+++ b/docs/frFR/ARCHITECTURE.md
@@ -329,7 +329,7 @@ Modifier le fichier template `internal/web/templates/login.html`.
 ### Déploiement Docker
 
 - Build multi-étapes pour réduire la taille de l'image
-- Étape de build : `golang:1.27.0-alpine3.24` ; étape d'exécution : `alpine:3.24` (les health checks utilisent BusyBox wget)
+- Étape de build : `golang:1.27.1-alpine3.24` ; étape d’exécution : `alpine:3.24` (les health checks utilisent BusyBox wget)
 - Fichiers template copiés de `src/internal/web/templates` vers `/app/web/templates` dans l'image
 - Utilise `-ldflags "-s -w"` lors de la compilation pour réduire la taille du binaire
 - L'application trouve automatiquement les chemins de template (supporte `./internal/web/templates` pour le développement local et `./web/templates` pour la production)

--- a/docs/frFR/DEPLOYMENT.md
+++ b/docs/frFR/DEPLOYMENT.md
@@ -94,7 +94,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 
 #### Paramètres de Build
 
-- **Image de Base** : `golang:1.27.0-alpine3.24` (étape de build)
+- **Image de Base** : `golang:1.27.1-alpine3.24` (étape de build)
 - **Image d'Exécution** : `alpine:3.24` (certificats CA et BusyBox `wget` pour HTTPS et les health checks)
 - **Répertoire de Travail** : `/app`
 - **Port Exposé** : `8080`
@@ -180,7 +180,7 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
-      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - CALLBACK_ALLOWED_HOSTS=hello.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
       - TRUSTED_PROXIES=${TRAEFIK_NETWORK_CIDR:?set TRAEFIK_NETWORK_CIDR from docker network inspect}
       - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
@@ -194,16 +194,18 @@ services:
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
-  whoami:
-    image: traefik/whoami
+  hello:
+    image: ghcr.io/soulteary/hello:2.3.0
+    command: ["-listen", ":8080"]
     networks:
       - traefik
     labels:
       - traefik.enable=true
       - traefik.docker.network=${TRAEFIK_NETWORK_NAME:-traefik}
-      - traefik.http.routers.whoami.entrypoints=http
-      - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
-      - "traefik.http.routers.whoami.middlewares=stargate"
+      - traefik.http.routers.hello.entrypoints=http
+      - traefik.http.routers.hello.rule=Host(`hello.test.localhost`)
+      - "traefik.http.routers.hello.middlewares=stargate"
+      - traefik.http.services.hello.loadbalancer.server.port=8080
 
 networks:
   traefik:

--- a/docs/itIT/ARCHITECTURE.md
+++ b/docs/itIT/ARCHITECTURE.md
@@ -328,7 +328,7 @@ Modificare il file template `internal/web/templates/login.html`.
 ### Deployment Docker
 
 - Build multi-stage per ridurre dimensione immagine
-- Stage di build: `golang:1.27.0-alpine3.24`; stage di esecuzione: `alpine:3.24` (gli health check usano BusyBox wget)
+- Stage di build: `golang:1.27.1-alpine3.24`; stage di esecuzione: `alpine:3.24` (gli health check usano BusyBox wget)
 - File template copiati da `src/internal/web/templates` a `/app/web/templates` nell'immagine
 - Utilizza `-ldflags "-s -w"` durante compilazione per ridurre dimensione binario
 - L'applicazione trova automaticamente i percorsi template (supporta `./internal/web/templates` per sviluppo locale e `./web/templates` per produzione)

--- a/docs/itIT/DEPLOYMENT.md
+++ b/docs/itIT/DEPLOYMENT.md
@@ -94,7 +94,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 
 #### Parametri di Build
 
-- **Immagine Base**: `golang:1.27.0-alpine3.24` (stage di build)
+- **Immagine Base**: `golang:1.27.1-alpine3.24` (stage di build)
 - **Immagine di Esecuzione**: `alpine:3.24` (certificati CA e BusyBox `wget` per HTTPS e health check)
 - **Directory di Lavoro**: `/app`
 - **Porta Esposta**: `8080`
@@ -180,7 +180,7 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
-      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - CALLBACK_ALLOWED_HOSTS=hello.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
       - TRUSTED_PROXIES=${TRAEFIK_NETWORK_CIDR:?set TRAEFIK_NETWORK_CIDR from docker network inspect}
       - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
@@ -194,16 +194,18 @@ services:
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
-  whoami:
-    image: traefik/whoami
+  hello:
+    image: ghcr.io/soulteary/hello:2.3.0
+    command: ["-listen", ":8080"]
     networks:
       - traefik
     labels:
       - traefik.enable=true
       - traefik.docker.network=${TRAEFIK_NETWORK_NAME:-traefik}
-      - traefik.http.routers.whoami.entrypoints=http
-      - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
-      - "traefik.http.routers.whoami.middlewares=stargate"
+      - traefik.http.routers.hello.entrypoints=http
+      - traefik.http.routers.hello.rule=Host(`hello.test.localhost`)
+      - "traefik.http.routers.hello.middlewares=stargate"
+      - traefik.http.services.hello.loadbalancer.server.port=8080
 
 networks:
   traefik:

--- a/docs/jaJP/ARCHITECTURE.md
+++ b/docs/jaJP/ARCHITECTURE.md
@@ -328,7 +328,7 @@ WardenおよびHerald統合が有効な場合、OTP認証を使用できます�
 ### Docker デプロイメント
 
 - イメージサイズを削減するためのマルチステージビルド
-- ビルドステージ: `golang:1.27.0-alpine3.24`；実行ステージ: `alpine:3.24`（ヘルスチェックには BusyBox wget を使用）
+- ビルドステージ: `golang:1.27.1-alpine3.24`；実行ステージ: `alpine:3.24`（ヘルスチェックには BusyBox wget を使用）
 - テンプレートファイルを `src/internal/web/templates` からイメージ内の `/app/web/templates` にコピー
 - バイナリサイズを削減するため、コンパイル時に `-ldflags "-s -w"` を使用
 - アプリケーションは自動的にテンプレートパスを見つける（ローカル開発用に `./internal/web/templates`、本番環境用に `./web/templates` をサポート）

--- a/docs/jaJP/DEPLOYMENT.md
+++ b/docs/jaJP/DEPLOYMENT.md
@@ -94,7 +94,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 
 #### ビルドパラメータ
 
-- **ベースイメージ**: `golang:1.27.0-alpine3.24`（ビルドステージ）
+- **ベースイメージ**: `golang:1.27.1-alpine3.24`（ビルドステージ）
 - **実行イメージ**: `alpine:3.24`（CA 証明書と HTTPS・ヘルスチェック用 BusyBox `wget` を含む）
 - **作業ディレクトリ**: `/app`
 - **公開ポート**: `8080`
@@ -180,7 +180,7 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
-      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - CALLBACK_ALLOWED_HOSTS=hello.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
       - TRUSTED_PROXIES=${TRAEFIK_NETWORK_CIDR:?set TRAEFIK_NETWORK_CIDR from docker network inspect}
       - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
@@ -194,16 +194,18 @@ services:
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
-  whoami:
-    image: traefik/whoami
+  hello:
+    image: ghcr.io/soulteary/hello:2.3.0
+    command: ["-listen", ":8080"]
     networks:
       - traefik
     labels:
       - traefik.enable=true
       - traefik.docker.network=${TRAEFIK_NETWORK_NAME:-traefik}
-      - traefik.http.routers.whoami.entrypoints=http
-      - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
-      - "traefik.http.routers.whoami.middlewares=stargate"
+      - traefik.http.routers.hello.entrypoints=http
+      - traefik.http.routers.hello.rule=Host(`hello.test.localhost`)
+      - "traefik.http.routers.hello.middlewares=stargate"
+      - traefik.http.services.hello.loadbalancer.server.port=8080
 
 networks:
   traefik:

--- a/docs/koKR/ARCHITECTURE.md
+++ b/docs/koKR/ARCHITECTURE.md
@@ -328,7 +328,7 @@ Warden 및 Herald 통합이 활성화된 경우 OTP 인증을 사용할 수 있�
 ### Docker 배포
 
 - 이미지 크기 감소를 위한 다단계 빌드
-- 빌드 단계: `golang:1.27.0-alpine3.24`; 실행 단계: `alpine:3.24`(헬스 체크는 BusyBox wget 사용)
+- 빌드 단계: `golang:1.27.1-alpine3.24`; 실행 단계: `alpine:3.24`(헬스 체크는 BusyBox wget 사용)
 - 템플릿 파일을 `src/internal/web/templates`에서 이미지 내 `/app/web/templates`로 복사
 - 바이너리 크기 감소를 위해 컴파일 시 `-ldflags "-s -w"` 사용
 - 애플리케이션은 자동으로 템플릿 경로를 찾습니다 (로컬 개발용 `./internal/web/templates`, 프로덕션용 `./web/templates` 지원)

--- a/docs/koKR/DEPLOYMENT.md
+++ b/docs/koKR/DEPLOYMENT.md
@@ -94,7 +94,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 
 #### 빌드 매개변수
 
-- **베이스 이미지**: `golang:1.27.0-alpine3.24` (빌드 단계)
+- **베이스 이미지**: `golang:1.27.1-alpine3.24` (빌드 단계)
 - **실행 이미지**: `alpine:3.24` (CA 인증서와 HTTPS·헬스 체크용 BusyBox `wget` 포함)
 - **작업 디렉토리**: `/app`
 - **공개 포트**: `8080`
@@ -180,7 +180,7 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
-      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - CALLBACK_ALLOWED_HOSTS=hello.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
       - TRUSTED_PROXIES=${TRAEFIK_NETWORK_CIDR:?set TRAEFIK_NETWORK_CIDR from docker network inspect}
       - COOKIE_SECURE=false # Local HTTP only; omit for HTTPS.
@@ -194,16 +194,18 @@ services:
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
-  whoami:
-    image: traefik/whoami
+  hello:
+    image: ghcr.io/soulteary/hello:2.3.0
+    command: ["-listen", ":8080"]
     networks:
       - traefik
     labels:
       - traefik.enable=true
       - traefik.docker.network=${TRAEFIK_NETWORK_NAME:-traefik}
-      - traefik.http.routers.whoami.entrypoints=http
-      - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
-      - "traefik.http.routers.whoami.middlewares=stargate"
+      - traefik.http.routers.hello.entrypoints=http
+      - traefik.http.routers.hello.rule=Host(`hello.test.localhost`)
+      - "traefik.http.routers.hello.middlewares=stargate"
+      - traefik.http.services.hello.loadbalancer.server.port=8080
 
 networks:
   traefik:

--- a/docs/zhCN/ARCHITECTURE.md
+++ b/docs/zhCN/ARCHITECTURE.md
@@ -374,7 +374,7 @@ Stargate 支持可选的服务集成，以扩展认证功能。这些集成都�
 ### Docker 部署
 
 - 多阶段构建，减小镜像体积
-- 构建阶段：`golang:1.27.0-alpine3.24`；运行阶段：`alpine:3.24`（健康检查使用 BusyBox wget）
+- 构建阶段：`golang:1.27.1-alpine3.24`；运行阶段：`alpine:3.24`（健康检查使用 BusyBox wget）
 - 模板文件从 `src/internal/web/templates` 复制到镜像中的 `/app/web/templates`
 - 编译时使用 `-ldflags "-s -w"` 减小二进制体积
 - 应用会自动查找模板路径（支持本地开发的 `./internal/web/templates` 和生产环境的 `./web/templates`）

--- a/docs/zhCN/DEPLOYMENT.md
+++ b/docs/zhCN/DEPLOYMENT.md
@@ -94,7 +94,7 @@ docker build -f docker/Dockerfile -t stargate:latest .
 
 #### 构建参数
 
-- **基础镜像**：`golang:1.27.0-alpine3.24`（构建阶段）
+- **基础镜像**：`golang:1.27.1-alpine3.24`（构建阶段）
 - **运行镜像**：`alpine:3.24`（运行阶段，包含 CA 证书和用于 HTTPS/健康检查的 BusyBox `wget`）
 - **工作目录**：`/app`
 - **暴露端口**：`8080`
@@ -180,7 +180,7 @@ services:
     environment:
       - AUTH_HOST=auth.test.localhost
       - PASSWORDS=plaintext:test1234|test1337
-      - CALLBACK_ALLOWED_HOSTS=whoami.test.localhost
+      - CALLBACK_ALLOWED_HOSTS=hello.test.localhost
       - SESSION_EXCHANGE_SECRET=local-development-session-secret-change-me
       - TRUSTED_PROXIES=${TRAEFIK_NETWORK_CIDR:?set TRAEFIK_NETWORK_CIDR from docker network inspect}
       - COOKIE_SECURE=false # 仅本地 HTTP；HTTPS 部署请省略。
@@ -194,16 +194,18 @@ services:
       - traefik.http.middlewares.stargate.forwardauth.address=http://stargate:8080/_auth
       - "traefik.http.middlewares.stargate.forwardauth.authResponseHeaders=X-Forwarded-User,X-Auth-User,X-Auth-Email,X-Auth-Name,X-Auth-Scopes,X-Auth-Role,X-Auth-AMR"
 
-  whoami:
-    image: traefik/whoami
+  hello:
+    image: ghcr.io/soulteary/hello:2.3.0
+    command: ["-listen", ":8080"]
     networks:
       - traefik
     labels:
       - traefik.enable=true
       - traefik.docker.network=${TRAEFIK_NETWORK_NAME:-traefik}
-      - traefik.http.routers.whoami.entrypoints=http
-      - traefik.http.routers.whoami.rule=Host(`whoami.test.localhost`)
-      - "traefik.http.routers.whoami.middlewares=stargate"
+      - traefik.http.routers.hello.entrypoints=http
+      - traefik.http.routers.hello.rule=Host(`hello.test.localhost`)
+      - "traefik.http.routers.hello.middlewares=stargate"
+      - traefik.http.services.hello.loadbalancer.server.port=8080
 
 networks:
   traefik:


### PR DESCRIPTION
## Summary

- replace the bundled `traefik/whoami` backend with `ghcr.io/soulteary/hello:2.3.0`
- run hello explicitly in HTTP mode on port 8080
- rename the example service, router, and callback host from `whoami` to `hello`
- update all localized deployment examples
- correct stale documentation to the current `golang:1.27.1-alpine3.24` builder baseline

## Validation

- `git diff --check`
- parsed `docker-compose.yml` and all GitHub Actions workflow YAML files